### PR TITLE
Bug fixes for AntGainPhase support array reading

### DIFF
--- a/sarpy/io/general/utils.py
+++ b/sarpy/io/general/utils.py
@@ -55,10 +55,10 @@ def validate_range(arg, siz):
         raise ValueError(
             'Range argument {} has extracted "stop" {}, which is required '
             'to be in the range [0, {}]'.format(arg, stop, siz))
-    if not ((0 < step < siz) or (-siz < step < 0)):
+    if not (0 < abs(step) <= siz):
         raise ValueError(
             'Range argument {} has extracted step {}, for an axis of length '
-            '{}'.format(arg, start, siz))
+            '{}'.format(arg, step, siz))
     if ((step < 0) and (stop > start)) or ((step > 0) and (start > stop)):
         raise ValueError(
             'Range argument {} has extracted start {}, stop {}, step {}, '

--- a/sarpy/io/phase_history/cphd1_elements/Antenna.py
+++ b/sarpy/io/phase_history/cphd1_elements/Antenna.py
@@ -107,7 +107,7 @@ class GainPhaseArrayType(Serializable):
     frequency value.
     """
 
-    _fields = ('Freq', 'ArrayId')
+    _fields = ('Freq', 'ArrayId', 'ElementId')
     _required = ('Freq', 'ArrayId')
     # descriptors
     Freq = _FloatDescriptor(

--- a/sarpy/io/phase_history/cphd1_elements/utils.py
+++ b/sarpy/io/phase_history/cphd1_elements/utils.py
@@ -84,9 +84,9 @@ def homogeneous_dtype(frm, return_length=False):
     numpy.dtype
     """
 
-    entries = ['>'+el.lower() for el in frm.strip().split(';') if len(el.strip()) > 0]
-    entry_set = set(entries)
-    if len(entry_set) == 1:
-        return numpy.dtype(entry_set.pop()), len(entries) if return_length else numpy.dtype(entry_set.pop())
+    format_str, num_elements = homogeneous_format(frm, return_length=True)
+    format_dtype = numpy.dtype('>' + format_str)
+    if return_length:
+        return format_dtype, num_elements
     else:
-        raise ValueError('Non-homogeneous format required {}'.format(entries))
+        return format_dtype


### PR DESCRIPTION
This PR contains bugfixes in order to use SarPy functions for reading antenna support arrays (including vector-shaped ones).
- `sarpy/io/phase_history/cphd1_elements/Antenna.py`: The CPHD spec is encoded incorrectly in SarPy such that `GainPhaseArray.ElementId` is not available even when present in the file
  - add `ElementId` to `_fields` in `GainPhaseArrayType`
- `sarpy/io/phase_history/cphd1_elements/utils.py`: the code for parsing the format strings is incorrect in `homogeneous_dtype` resulting in the ValueError being thrown when trying to use `CPHDReader.read_support_array`
  - the correct code is present in the `homogeneous_format` function in the same module, so incorporate that into `homogeneous_dtype`
- `sarpy/io/general/utils.py`: `validate_range` is too strict resulting in an error for vector-shaped inputs (in that case `step` = `siz` = 1)
  - change the condition to `<=` instead of `< `and fix variable reference in error message
 