### PR TITLE
Add cphd writing

### DIFF
--- a/sarpy/io/complex/sicd_elements/base.py
+++ b/sarpy/io/complex/sicd_elements/base.py
@@ -141,7 +141,8 @@ def _parse_str(value, name, instance):
     if isinstance(value, string_types):
         return value
     elif isinstance(value, ElementTree.Element):
-        return _get_node_value(value)
+        node_value = _get_node_value(value)
+        return "" if node_value is None else node_value
     else:
         raise TypeError(
             'field {} of class {} requires a string value.'.format(name, instance.__class__.__name__))
@@ -162,7 +163,7 @@ def _parse_bool(value, name, instance):
         return None
     if isinstance(value, bool):
         return value
-    elif isinstance(value, integer_types):
+    elif isinstance(value, (integer_types, numpy.bool_)):
         return bool(value)
     elif isinstance(value, ElementTree.Element):
         # from XML deserialization

--- a/sarpy/io/phase_history/cphd1_elements/CPHD.py
+++ b/sarpy/io/phase_history/cphd1_elements/CPHD.py
@@ -34,9 +34,10 @@ __author__ = "Thomas McCullough"
 
 #########
 # Module variables
-_CPHD_SPECIFICATION_VERSION = '1.0'
+_CPHD_SPECIFICATION_VERSION = '1.0.1'
 _CPHD_SPECIFICATION_DATE = '2018-05-21T00:00:00Z'
-_CPHD_SPECIFICATION_NAMESPACE = 'urn:CPHD:1.0.1'
+_CPHD_SPECIFICATION_NAMESPACE = 'http://api.nsgreg.nga.mil/schema/cphd/1.0.1'
+_CPHD_SECTION_TERMINATOR = b'\f\n'
 
 
 #########
@@ -55,9 +56,9 @@ def _parse_cphd_header_field(line):
     None|(str, str)
     """
 
-    if line.startswith(b'\f\n'):
+    if line.startswith(_CPHD_SECTION_TERMINATOR):
         return None
-    parts = line.strip().split(b':=')
+    parts = line.split(b' := ')
     if len(parts) != 2:
         raise ValueError('Cannot extract CPHD header value from line {}'.format(line))
     fld = parts[0].strip().decode('utf-8')
@@ -163,6 +164,12 @@ class CPHDHeader(CPHDHeaderBase):
         self.RELEASE_INFO = RELEASE_INFO
         super(CPHDHeader, self).__init__()
 
+    def to_string(self):
+        """
+        Forms a CPHD file header string (not including the section terminator) from populated attributes.
+        """
+        return ('CPHD/{}\n'.format(_CPHD_SPECIFICATION_VERSION)
+                + ''.join(["{} := {}\n".format(f, getattr(self,f)) for f in self._fields if getattr(self, f) is not None]))
 
 class CPHDType(Serializable):
     """
@@ -371,3 +378,50 @@ class CPHDType(Serializable):
 
     def to_xml_string(self, urn=None, tag='CPHD', check_validity=False, strict=DEFAULT_STRICT):
         return self.to_xml_bytes(urn=urn, tag=tag, check_validity=check_validity, strict=strict).decode('utf-8')
+
+    def make_file_header(self, xml_offset=1024):
+        """
+        Forms a CPHD file header consistent with the information in the Data and CollectionID nodes.
+
+        Parameters
+        ----------
+        xml_offset : int, optional
+            Offset in bytes to the first byte of the XML block. If the provided value is not large enough to account for
+            the length of the file header string, a larger value is chosen.
+
+        Returns
+        -------
+        header : sarpy.io.phase_history.cphd1_elements.CPHD.CPHDHeader
+        """
+
+        _kvps = OrderedDict()
+
+        def _align(val):
+            align_to = 64
+            return -(-val//align_to) * align_to
+
+        _kvps['XML_BLOCK_SIZE'] = len(self.to_xml_string())
+        _kvps['XML_BLOCK_BYTE_OFFSET'] = xml_offset
+        block_end = _kvps['XML_BLOCK_BYTE_OFFSET'] + _kvps['XML_BLOCK_SIZE'] + len(_CPHD_SECTION_TERMINATOR)
+
+        if self.Data.NumSupportArrays > 0:
+            _kvps['SUPPORT_BLOCK_SIZE'] = self.Data.calculate_support_block_size()
+            _kvps['SUPPORT_BLOCK_BYTE_OFFSET'] = _align(block_end)
+            block_end = _kvps['SUPPORT_BLOCK_BYTE_OFFSET'] + _kvps['SUPPORT_BLOCK_SIZE']
+
+        _kvps['PVP_BLOCK_SIZE'] = self.Data.calculate_pvp_block_size()
+        _kvps['PVP_BLOCK_BYTE_OFFSET'] = _align(block_end)
+        block_end = _kvps['PVP_BLOCK_BYTE_OFFSET'] + _kvps['PVP_BLOCK_SIZE']
+
+        _kvps['SIGNAL_BLOCK_SIZE'] = self.Data.calculate_signal_block_size()
+        _kvps['SIGNAL_BLOCK_BYTE_OFFSET'] = _align(block_end)
+        _kvps['CLASSIFICATION'] = self.CollectionID.Classification
+        _kvps['RELEASE_INFO'] = self.CollectionID.ReleaseInfo
+
+        header = CPHDHeader(**_kvps)
+        header_str = header.to_string()
+        min_xml_offset = len(header_str) + len(_CPHD_SECTION_TERMINATOR)
+        if _kvps['XML_BLOCK_BYTE_OFFSET'] < min_xml_offset:
+            header = make_file_header(xml_offset=_align(min_xml_offset + 32))
+
+        return header

--- a/sarpy/io/phase_history/cphd1_elements/blocks.py
+++ b/sarpy/io/phase_history/cphd1_elements/blocks.py
@@ -234,6 +234,7 @@ class XYVertexType(XYType):
 
     _fields = ('X', 'Y', 'index')
     _required = _fields
+    _set_as_attribute = ('index', )
     # descriptors
     index = _IntegerDescriptor(
         'index', _required, strict=DEFAULT_STRICT, bounds=(1, None),

--- a/sarpy/io/phase_history/cphd1_elements/utils.py
+++ b/sarpy/io/phase_history/cphd1_elements/utils.py
@@ -3,72 +3,78 @@
 Common utils for CPHD functionality.
 """
 
+import numpy as np
+
 __classification__ = "UNCLASSIFIED"
 __author__ = "Thomas McCullough"
 
 
-import numpy
+#########
+# Module variables
+_DTYPE_LOOKUP = {
+    "U1": np.dtype('>u1'),
+    "U2": np.dtype('>u2'),
+    "U4": np.dtype('>u4'),
+    "U8": np.dtype('>u8'),
+    "I1": np.dtype('>i1'),
+    "I2": np.dtype('>i2'),
+    "I4": np.dtype('>i4'),
+    "I8": np.dtype('>i8'),
+    "F4": np.dtype('>f4'),
+    "F8": np.dtype('>f8'),
+    "CI2": np.dtype([('real', '>i1'), ('imag', '>i1')]),
+    "CI4": np.dtype([('real', '>i2'), ('imag', '>i2')]),
+    "CI8": np.dtype([('real', '>i4'), ('imag', '>i4')]),
+    "CI16": np.dtype([('real', '>i8'), ('imag', '>i8')]),
+    "CF8": np.dtype('>c8'),
+    "CF16": np.dtype('>c16')}
 
-_format_mapping = {
-    'F8': 'd', 'F4': 'f', 'I8': 'q', 'I4': 'i', 'I2': 'h', 'I1': 'b'}
 
-
-def _map_part(part):
-    parts = part.split('=')
-    if len(parts) == 1:
-        res = _format_mapping.get(parts[0].strip(), None)
-    elif len(parts) == 2:
-        res = _format_mapping.get(parts[1].strip(), None)
+def _single_binary_format_string_to_dtype(form):
+    """Convert a CPHD datatype into a dtype"""
+    if form.startswith('S'):
+        dtype = np.dtype(form)
     else:
-        raise ValueError('Cannot parse format part {}'.format(part))
+        dtype = _DTYPE_LOOKUP[form]
 
-    if res is None:
-        raise ValueError('Cannot parse format part {}'.format(part))
-    return res
+    return dtype
 
-
-def parse_format(frm):
-    """
-    Determine a struct format from a CPHD format string.
+def binary_format_string_to_dtype(format_string):
+    """Return the numpy.dtype for CPHD Binary Format string (table 10-2).
 
     Parameters
-    ----------
-    frm : str
+    ----
+    format_string: str
+        PVP type designator (e.g., ``'I1'``, ``'I4'``, ``'CF8'``, etc.).
 
     Returns
     -------
-    Tuple[str, ...]
+    dtype: `numpy.dtype`
+        The equivalent `numpy.dtype` of the PVP format string
+        (e.g., numpy.int8, numpy.int32, numpy.complex64, etc.).
+
     """
+    components = format_string.split(';')
 
-    return tuple(_map_part(el) for el in frm.strip().split(';') if len(el.strip()) > 0)
+    if '=' in components[0]:
+        assert format_string.endswith(';'), 'Format strings describing multiple parameters must end with a semi-colon'
+        comptypes = []
+        for comp in components[:-1]:
+            kvp = comp.split('=')
+            comptypes.append((kvp[0], _single_binary_format_string_to_dtype(kvp[1])))
 
-def homogeneous_format(frm, return_length=False):
-    """
-    Determine a struct format from a CPHD format string, requiring that any multiple
-    parts are all identical.
-
-    Parameters
-    ----------
-    frm : str
-    return_length : bool
-        Return the number of elements?
-
-    Returns
-    -------
-    str
-    """
-
-    entries = parse_format(frm)
-    entry_set = set(entries)
-    if len(entry_set) == 1:
-        val = entry_set.pop()
-        if return_length:
-            return val, len(entries)
-        return val
+        # special handling of XYZ types
+        keys, types = list(zip(*comptypes))
+        if keys == ('X', 'Y', 'Z') and len(set(types)) == 1:
+            dtype = np.dtype('3' + comptypes[0][1].name)
+        else:
+            dtype = np.dtype(comptypes)
     else:
-        raise ValueError('Non-homogeneous format required {}'.format(entries))
+        dtype = _single_binary_format_string_to_dtype(components[0])
 
-def homogeneous_dtype(frm, return_length=False):
+    return dtype
+
+def homogeneous_dtype(format_string, return_length=False):
     """
     Determine a numpy.dtype (including endianness) from a CPHD format string, requiring
     that any multiple parts are all identical.
@@ -81,12 +87,26 @@ def homogeneous_dtype(frm, return_length=False):
 
     Returns
     -------
-    numpy.dtype
+    numpy.dtype|(numpy.dtype, int)
+        Tuple of (`numpy.dtype`, # of elements) if `return_length`, `numpy.dtype` otherwise
+
     """
 
-    format_str, num_elements = homogeneous_format(frm, return_length=True)
-    format_dtype = numpy.dtype('>' + format_str)
-    if return_length:
-        return format_dtype, num_elements
+    raw_dtype = binary_format_string_to_dtype(format_string)
+    if raw_dtype.names is None:
+        # Simple or subarray
+        dtype = raw_dtype.base
+        num_elements = max(1, sum(raw_dtype.shape))
     else:
-        return format_dtype
+        # Structured
+        dtype_set = {v[0] for v in raw_dtype.fields.values()}
+        if len(dtype_set) == 1:
+            dtype = dtype_set.pop()
+            num_elements = len(raw_dtype.names)
+        else:
+            raise ValueError("Format string {} was heterogeneous (dtype_set={})".format(format_string, dtype_set))
+
+    if return_length:
+        return dtype, num_elements
+    else:
+        return dtype

--- a/tests/io/phase_history/cphd1_elements/test_utils.py
+++ b/tests/io/phase_history/cphd1_elements/test_utils.py
@@ -1,0 +1,13 @@
+import numpy as np
+import sarpy.io.phase_history.cphd1_elements.utils
+
+from tests import unittest
+
+
+class TestCphd1Utils(unittest.TestCase):
+    def test_binary_format_to_dtype(self):
+        self.assertEqual(sarpy.io.phase_history.cphd1_elements.utils.binary_format_string_to_dtype('I1'), np.int8)
+        dt = np.dtype([('a', '>i8'),
+                       ('b', '>f8'),
+                       ('c', '>f8')])
+        self.assertEqual(sarpy.io.phase_history.cphd1_elements.utils.binary_format_string_to_dtype('a=I8;b=F8;c=F8;'),  dt)


### PR DESCRIPTION
# Description
This PR adds a simple CPHD writer to SarPy. A unit-test was added that runs the CPHD consistency check on the written CPHDs. To do so, minor bugs were fixed in the CPHD consistency checker.

## Changes
- `sarpy/io/phase_history/cphd1_elements/utils.py` and portions of `sarpy/io/phase_history/cphd.py` read functions refactored to be based on `numpy.dtypes` by refactoring code out of `consistency/cphd_consistency`; doing so:
  - resolves inconsistencies between [`struct`](https://docs.python.org/3/library/struct.html) and `numpy.dtype` (e.g. L = uint32 in struct but uint64 in numpy)
  - added support for all CPHD 1.0 binary format types
  - forms a foundation for PVP structured dtype
- add utility methods to various `cphd1_elements` for use in writing
  - `get_numpy_dtype` to `PVPType`
  - various `calculate_size` methods in `sarpy/io/phase_history/cphd1_elements/Data.py`
  - CPHD file header utilities in `CPHD.py`
- `sarpy/io/phase/history/cphd.py`
  - add `read_<>_block` functions to aid in round-tripping of IO as well as for general use
  - add `CPHDWriter1_0`
- Modify existing CPHD test (renamed) to include writing checks for CPHD1.0 files
- Bugfixes in `cphd_consistency` to work across python versions

Tested in python 2.7, 3.8, and 3.8 using `python setup.py test` and `pytest pytests/`