### PR TITLE
Bug fixes for CPHD writing

### DIFF
--- a/sarpy/io/phase_history/cphd1_elements/utils.py
+++ b/sarpy/io/phase_history/cphd1_elements/utils.py
@@ -76,7 +76,7 @@ def binary_format_string_to_dtype(format_string):
         # special handling of XYZ types
         keys, types = list(zip(*comptypes))
         if keys == ('X', 'Y', 'Z') and len(set(types)) == 1:
-            dtype = numpy.dtype('3' + comptypes[0][1].name)
+            dtype = numpy.dtype((comptypes[0][1], 3))
         else:
             dtype = numpy.dtype(comptypes)
     else:


### PR DESCRIPTION
# Description
This PR comes from a review of ngageoint/sarpy#185 and fixes two minor bugs and proposes clarified terminology in some methods of CPHD writing.

## Changes
**Bugfix:** XYZ PVPs after being read and rewritten can be byte swapped
  - To fix: change XYZ handling in `cphd1_elements.utils.binary_format_string_to_dtype` so that the way the dtype is constructed maintains the big-endian specifier
 
**Bugfix:** The logic in `CPHDWriter1_0._check_fully_written` was incorrectly structured causing the check to fail before the comparison is performed when support arrays are present.
  - To fix: move the status assignment after comparison
  - While updating, I also modified the `logging.error` calls to use lazy formatting (see [pylint](https://vald-phoenix.github.io/pylint-errors/plerr/errors/logging/W1202.html) error)

Some of the write_ methods which write individual arrays in `CPHDWriter1_0` were incorrectly named `write_<>_block`
  - To address: Changed the names of existing methods to `write_<>_array` and introduced new `write_<>_block` methods for symmetry (which are then used in `write_file`)