### PR TITLE
CPHD Consistency Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ message indicating the missing optional dependency.
   and/or writing a kmz image overlay requires the `pillow` package.
 
 - CPHD consistency checks, presented in the `sarpy.consistency` module, depend on 
-  `lxml>=4.1.1`, `shapely>=1.6.4`, and `pytest>=3.3.2`. Note that these are the 
-  versions tested for compliance.
+  `lxml>=4.1.1`, `networkx>=2.5`, `shapely>=1.6.4`, and `pytest>=3.3.2`. Note that these
+  are the versions tested for compliance.
 
 - Some less commonly used (in the sarpy realm) NITF functionality requires the use 
   and interpretation of UTM coordinates, and this requires the `pyproj` package. 

--- a/sarpy/consistency/parsers.py
+++ b/sarpy/consistency/parsers.py
@@ -158,3 +158,29 @@ def parse_ll(node):
     """
 
     return np.radians(float(node.findtext('Lon'))), np.radians(float(node.findtext('Lat')))
+
+
+def parse_poly2d(node):
+    """
+    Parse a node with ``'exponent1'`` and ``'exponent2'`` children.
+
+    Args
+    ----
+    node: `lxml.etree.ElementTree.Element`
+        Element containing a poly2d node.
+
+    Returns
+    -------
+    result: list of list, shape=(:, :)
+        A list of coefficient values.
+
+    """
+    coefs = node.findall('./Coef')
+    num_coefs1 = max([int(coef.get('exponent1')) for coef in coefs]) + 1
+    num_coefs2 = max([int(coef.get('exponent2')) for coef in coefs]) + 1
+    poly2d = np.zeros((num_coefs1, num_coefs2), np.float64)
+
+    for coef in coefs:
+        poly2d[int(coef.get('exponent1')), int(coef.get('exponent2'))] = float(coef.text)
+
+    return poly2d.tolist()


### PR DESCRIPTION
# Description
This PR attempts to add the following improvements to SarPy's `cphd_consistency` checker:
- Additional Antenna branch checks
- Check IDs in Channel for optional branches
- Reference Geometry checks
- Warn for unconnected nodes

## Changes
- update `README.md` with new `sarpy.consistency` dependency
- add tests for new behavior to `pytests/test_cphd_consistency.py`
- add new checks to `sarpy/consistency/cphd_consistency.py`
- add `parse_poly2d` to `sarpy/consistency/parsers.py` for use in Reference Geometry calculation

## Test Plan
Tested in python 2.7 and 3.8 using `pytest pytests/test_cphd_consistency.py`