### PR TITLE
Bugs fixes for minor issues

### DIFF
--- a/changelog/version_1_2
+++ b/changelog/version_1_2
@@ -1,4 +1,5 @@
 # This details the important differences introduced in sarpy 1.2
 
-* .1 - Bug fixes for complex NITF construction, the Poly2DType shift method, and BSQChipper
+* .1 - Bug fixes for complex NITF construction, the Poly2DType shift method,
+       the BSQChipper, and NITF writing for an extra long/wide image
 * .0 - Initialized with streamlining and simplification of reader structure

--- a/changelog/version_1_2
+++ b/changelog/version_1_2
@@ -1,3 +1,4 @@
 # This details the important differences introduced in sarpy 1.2
 
+* .1 - Bug fixes for complex NITF construction, the Poly2DType shift method, and BSQChipper
 * .0 - Initialized with streamlining and simplification of reader structure

--- a/sarpy/__about__.py
+++ b/sarpy/__about__.py
@@ -27,7 +27,7 @@ __all__ = ['__version__',
            '__license__', '__copyright__']
 
 
-__version__ = "1.2.0"
+__version__ = "1.2.1"
 
 
 __classification__ = "UNCLASSIFIED"  # This should be set appropriately in any high-side version

--- a/sarpy/io/complex/sicd_elements/blocks.py
+++ b/sarpy/io/complex/sicd_elements/blocks.py
@@ -1188,7 +1188,7 @@ class Poly2DType(Serializable, Arrayable):
             for i in range(siz):
                 index = siz-i-1
                 if i > 0:
-                    out[:, index:siz-1] -= t1_shift*out[:, index+1:siz]
+                    out[:, index:siz-1] -= t2_shift*out[:, index+1:siz]
         if t2_scale != 1 and out.shape[1] > 1:
             out *= numpy.power(t2_scale, numpy.arange(out.shape[1]))
 

--- a/sarpy/io/general/nitf.py
+++ b/sarpy/io/general/nitf.py
@@ -2550,7 +2550,7 @@ class NITFWriter(AbstractWriter):
         for img_index in self._img_groups[index]:
             details = self._img_details[img_index]
 
-            overall_inds, this_inds = details.get_overlap(index_range)
+            this_inds, overall_inds = details.get_overlap(index_range)
             if overall_inds is None:
                 # there is no overlap here, so skip
                 continue

--- a/sarpy/io/general/nitf.py
+++ b/sarpy/io/general/nitf.py
@@ -983,11 +983,12 @@ class NITFReader(BaseReader):
             if bpp not in [8, 16]:
                 raise ValueError(
                     'Got PVTYPE = C and NBPP = {} (not 64 or 128), which is unsupported.'.format(nbpp))
+            bands = len(img_header.Bands)
             return (
-                numpy.dtype('>f{}'.format(int(bpp/2))),
+                numpy.dtype('>c{}'.format(bpp)),
                 numpy.complex64,
-                2*len(img_header.Bands),
-                len(img_header.Bands),
+                bands,
+                bands,
                 'COMPLEX')
 
     @staticmethod


### PR DESCRIPTION
Addressed are bugs involving:
- the construction of reader for NITF with complex PVTYPE
- the Poly2DType shift method
- the BSQChipper reading
- NITF writing for an extra long/wide image