### PR TITLE
Check that fileno() actually works before attempting a memmap.

### DIFF
--- a/sarpy/io/general/base.py
+++ b/sarpy/io/general/base.py
@@ -5,6 +5,7 @@ The general base elements for reading and writing image files.
 __classification__ = "UNCLASSIFIED"
 __author__ = "Thomas McCullough"
 
+import io
 import os
 import logging
 from typing import Union, Tuple, BinaryIO, Callable
@@ -1199,7 +1200,16 @@ class BIPChipper(BaseChipper):
             self._close_after = False
             self._file_name = data_input.name if hasattr(data_input, 'name') else None
 
+            try_memmap = False
             if hasattr(data_input, 'fileno'):
+                try:
+                    # check that fileno actually works, not just exists.
+                    data_input.fileno()
+                    try_memmap = True
+                except io.UnsupportedOperation:
+                    pass
+
+            if try_memmap:
                 # noinspection PyBroadException
                 try:
                     self._memory_map = numpy.memmap(data_input,


### PR DESCRIPTION
Previously when reading a SICD from S3, you'd get a scary warning.

Error setting up a BIP chipper - fileno
    This may actually be fatal.

A smart_open(ed) resource has a fileno attribute, but it doesn't
always work.  Check that we can actually call fileno() before
trying to memmap the resource.