### PR TITLE
bugfix/csg-doppler-from-raw

### DIFF
--- a/sarpy/io/complex/csk.py
+++ b/sarpy/io/complex/csk.py
@@ -176,6 +176,10 @@ class CSKDetails(object):
                 band_dict[gp_name] = OrderedDict()
                 _extract_attrs(gp, out=band_dict[gp_name])
 
+                if 'B0001' in gp:
+                    beam_info = gp['B0001']
+                    _extract_attrs(beam_info, out=band_dict[gp_name])
+
                 if self._mission_id in ['CSK', 'KMPS']:
                     the_dataset = gp['SBI']
                 elif self._mission_id == 'CSG':
@@ -183,6 +187,7 @@ class CSKDetails(object):
                 else:
                     raise ValueError('Unhandled mission id {}'.format(self._mission_id))
                 _extract_attrs(the_dataset, out=band_dict[gp_name])
+
                 shape_dict[gp_name] = the_dataset.shape[:2]
                 if the_dataset.dtype.name == 'float32':
                     dtype_dict[gp_name] = 'RE32F_IM32F'
@@ -433,9 +438,20 @@ class CSKDetails(object):
             dop_poly_az = strip_poly(h5_dict['Centroid vs Azimuth Time Polynomial'])
             dop_poly_rg = strip_poly(h5_dict['Centroid vs Range Time Polynomial'])
         elif self._mission_id == 'CSG':
+            az_ref_time_nozd = band_dict[band_name]['Azimuth Polynomial Reference Time']
+            first_time = band_dict[band_name]['Azimuth First Time']
+            last_time = band_dict[band_name]['Azimuth Last Time']
+            az_fit_times = numpy.linspace(first_time, last_time, num=11)
+
+            geom_dop_cent_poly = band_dict[band_name]['Doppler Centroid vs Azimuth Time Polynomial - RAW']
+            dop_rate_poly = band_dict[band_name]['Doppler Rate vs Azimuth Time Polynomial']
+            centroid_values = polynomial.polyval(az_fit_times - az_ref_time_nozd, geom_dop_cent_poly)
+            rate_values = polynomial.polyval(az_fit_times - az_ref_time_nozd, dop_rate_poly)
+            zd_times = az_fit_times - centroid_values / rate_values
             az_ref_time = band_dict[band_name]['Azimuth Polynomial Reference Time - ZD']
+            dop_poly_az = strip_poly(polynomial.polyfit(zd_times - az_ref_time, centroid_values, 4))
+
             rg_ref_time = band_dict[band_name]['Range Polynomial Reference Time']
-            dop_poly_az = strip_poly(band_dict[band_name]['Doppler Centroid vs Azimuth Time Polynomial - ZD'])
             dop_poly_rg = strip_poly(band_dict[band_name]['Doppler Centroid vs Range Time Polynomial'])
         else:
             raise ValueError('Unhandled mission id {}'.format(self._mission_id))


### PR DESCRIPTION
# Description

This is a follow up to the change made in https://github.com/ngageoint/sarpy/pull/272

That modification produced correct SICDs most of the time, but vsco observed 3 instances of incorrect DeltaKCOA polys in 100 datasets since then.

Upon further investigation, CSG appears to use their geometry-based estimates of the doppler centroid to determine the processing aperture. Unfortunately, if they get a data-driven estimate (indicated by a value other than GEOMETRY in the field Doppler Centroid Estimation Method, they put that in the fields Doppler Centroid vs Azimuth Time Polynomial, Doppler Centroid vs Azimuth Time Polynomial - ZD, Doppler Centroid vs Range Time Polynomial, Doppler Centroid vs Range Time Polynomial - ZD, Doppler Centroid vs Times 2D Model, and Doppler Centroid vs Times 2D Model - ZD. When the data-driven estimate is different than the geometry-driven estimate, sarpy produces incorrect TimeCOA, and DeltaKCOA polynomials.

This PR updates sarpy to use the * - RAW fields.  The azimuth-time polynomial is transformed to polynomials over the zero-doppler time by evaluating the polynomials at various slow-times and using the doppler-rate to determine when closest approach is.  zd_time = slow_time -doppler_centroid / doppler_rate.  The doppler centroids are then be fit to the zero-doppler times using the pre-existing ZD reference time.

# Testing

Attached are the results from a dataset converted before and after this update.

## Before

![before_update](https://user-images.githubusercontent.com/71520944/140399250-a9679334-5ae9-44c9-b2ce-dd3080a6a411.png)

## After

![after_update](https://user-images.githubusercontent.com/71520944/140399278-f8a51468-9e0c-466b-bb42-32c090607814.png)

In addition, all 100 CSG datasets we have access to were reprocessed with the changes in this branch and no evidence of incorrect DeltaKCOA polynomials was found.
