### PR TITLE
Added ICEYE product type translation for simplicity

### DIFF
--- a/sarpy/io/complex/iceye.py
+++ b/sarpy/io/complex/iceye.py
@@ -141,17 +141,14 @@ class ICEYEDetails(object):
         def get_collection_info():
             # type: () -> CollectionInfoType
 
-            iceye_product_type_map = {
-                    "SpotlightExtendedArea":"sliding_spotlight",
-                    "SpotlightExtendedRange": "spotlight",
-                    "SpotlightExtendedDwell": "spotlight",
-                    "SpotlightHigh": "spotlight",
+            iceye_product_type_mode_type = {
+                    "SpotlightExtendedArea":"DYNAMIC STRIPMAP",
                     }
 
-            if _stringify(hf['product_type'][()]) in iceye_product_type_map:
-                converted_mode = iceye_product_type_map[_stringify(hf['product_type'][()])]
+            if _stringify(hf['product_type'][()]) in iceye_product_type_mode_type:
+                converted_mode_type = iceye_product_type_mode_type[_stringify(hf['product_type'][()])]
             else:
-                converted_mode = _stringify(hf['product_type'][()])
+                converted_mode_type = _stringify(hf['acquisition_mode'][()]).upper()
 
             return CollectionInfoType(
                 CollectorName=_stringify(hf['satellite_name'][()]),
@@ -159,8 +156,8 @@ class ICEYEDetails(object):
                 CollectType='MONOSTATIC',
                 Classification='UNCLASSIFIED',
                 RadarMode=RadarModeType(
-                    ModeType=_stringify(hf['acquisition_mode'][()]).upper(),
-                    ModeID=converted_mode,
+                    ModeType=converted_mode_type,
+                    ModeID=_stringify(hf['product_type'][()]),
                     )
                 )
 

--- a/sarpy/io/complex/iceye.py
+++ b/sarpy/io/complex/iceye.py
@@ -140,6 +140,19 @@ class ICEYEDetails(object):
 
         def get_collection_info():
             # type: () -> CollectionInfoType
+
+            iceye_product_type_map = {
+                    "SpotlightExtendedArea":"sliding_spotlight",
+                    "SpotlightExtendedRange": "spotlight",
+                    "SpotlightExtendedDwell": "spotlight",
+                    "SpotlightHigh": "spotlight",
+                    }
+
+            if _stringify(hf['product_type'][()]) in iceye_product_type_map:
+                converted_mode = iceye_product_type_map[_stringify(hf['product_type'][()])]
+            else:
+                converted_mode = _stringify(hf['product_type'][()])
+
             return CollectionInfoType(
                 CollectorName=_stringify(hf['satellite_name'][()]),
                 CoreName=_stringify(hf['product_name'][()]),
@@ -147,7 +160,9 @@ class ICEYEDetails(object):
                 Classification='UNCLASSIFIED',
                 RadarMode=RadarModeType(
                     ModeType=_stringify(hf['acquisition_mode'][()]).upper(),
-                    ModeID=_stringify(hf['product_type'][()])))
+                    ModeID=converted_mode,
+                    )
+                )
 
         def get_image_creation():
             # type: () -> ImageCreationType


### PR DESCRIPTION
Created translation table, to change from our few distinctive spotlight types into something less convoluted and put the result into ModeID field.