### PR TITLE
Don't call chippers adjacent to the data being retrieved.

### DIFF
--- a/sarpy/io/general/base.py
+++ b/sarpy/io/general/base.py
@@ -488,7 +488,7 @@ class AggregateChipper(BaseChipper):
         """
 
         if rng[2] > 0:
-            if rng[1] < start_ind or rng[0] >= stop_ind:
+            if rng[1] <= start_ind or rng[0] >= stop_ind:
                 # there is no overlap
                 return None, None
             # find smallest element rng[0] + mult*rng[2] which is >= start_ind
@@ -499,7 +499,7 @@ class AggregateChipper(BaseChipper):
             mult2 = int(numpy.floor((max_ind - rng[0]) / rng[2]))
             ind2 = rng[0] + mult2 * rng[2]
         else:
-            if rng[0] < start_ind or rng[1] >= stop_ind:
+            if rng[0] <= start_ind or rng[1] >= stop_ind:
                 return None, None
             # find largest element rng[0] + mult*rng[2] which is <= stop_ind-1
             mult1 = 0 if rng[0] < stop_ind else int(numpy.floor((stop_ind - 1 - rng[0])/rng[2]))


### PR DESCRIPTION
With a multi-segment NITF, each image segment has its own chipper
and we need to determine which ones to ask for data.  Previously
for a read request that ended at the border of an image segment,
the next image segment was also included in the list of chippers
to call with a request size of 0 rows.  This tripped up the
BIPChipper's file backed access methods, but worked for memory
mapped access.

Now don't include this adjacent image segment/chipper in the list
of places to check for data to avoid this problem entirely.