### PR TITLE
Use DEM block mask to index flattened view of original array

### DIFF
--- a/sarpy/geometry/point_projection.py
+++ b/sarpy/geometry/point_projection.py
@@ -1789,7 +1789,7 @@ def image_to_ground_dem(
                     (llh_rough[:, 1] >= entry[2]) & (llh_rough[:, 1] <= entry[3]))
             if numpy.any(mask):
                 coords[mask, :] = _image_to_ground_dem_block(
-                    im_points[mask, :], coa_proj, dem_interpolator, vertical_step_size,
+                    im_points_view[mask, :], coa_proj, dem_interpolator, vertical_step_size,
                     entry, block_size, lat_grid_size, lon_grid_size)
     if len(orig_shape) == 1:
         coords = numpy.reshape(coords, (-1,))


### PR DESCRIPTION
`mask` is a 1-dimensional boolean array, `True` where points are inside
the current DEM block, so it must be used to index `im_points_view`, a
view of the original array `im_points` flattened along its leading
dimensions, and not `im_points` itself.