### PR TITLE
Fix slicing of raw data reads.

### DIFF
--- a/sarpy/io/general/data_segment.py
+++ b/sarpy/io/general/data_segment.py
@@ -2465,7 +2465,7 @@ class FileReadDataSegment(DataSegment):
         data = numpy.frombuffer(data, self._raw_dtype, rows*pixel_per_row)
         data = numpy.reshape(data, (rows, ) + self.raw_shape[1:])
         # extract our data
-        out = data[(init_slice, ) + subscript[1:]]
+        out = data[(numpy.s_[:], ) + subscript[1:]]
         out = numpy.reshape(out, out_shape)
         if init_reverse:
             out = numpy.flip(out, axis=0)


### PR DESCRIPTION
When deciding what data to read we've already applied the row
constraints and should not try to apply `init_slice` which
is in the frame of the full image, not the extracted rows.

Fixed #334 