### PR TITLE
Check if BaseReader exists before calling close.

### DIFF
--- a/sarpy/io/general/nitf.py
+++ b/sarpy/io/general/nitf.py
@@ -2431,7 +2431,8 @@ class NITFReader(BaseReader):
 
     def close(self) -> None:
         self._image_segment_data_segments = None
-        BaseReader.close(self)
+        if BaseReader is not None:
+            BaseReader.close(self)
 
 
 ########


### PR DESCRIPTION
Exception ignored in: <function BaseReader.__del__ at 0x7f15b7ec34c0>
Traceback (most recent call last):
  File "/home/kjurka/git/sarpy/sarpy/io/general/base.py", line 463, in __del__
  File "/home/kjurka/git/sarpy/sarpy/io/general/nitf.py", line 2434, in close
AttributeError: 'NoneType' object has no attribute 'close'