### PR TITLE
SICD converter IPPSet fixes

### DIFF
--- a/sarpy/io/complex/capella.py
+++ b/sarpy/io/complex/capella.py
@@ -315,7 +315,7 @@ class CapellaDetails(object):
                         TStart=0,
                         TEnd=duration,
                         IPPStart=0,
-                        IPPEnd=duration*prf,
+                        IPPEnd=round(duration*prf) - 1,
                         IPPPoly=(0, prf)), ])
 
         def get_image_formation() -> ImageFormationType:

--- a/sarpy/io/complex/csk.py
+++ b/sarpy/io/complex/csk.py
@@ -477,7 +477,7 @@ class CSKDetails(object):
             prf = band_dict[band_name]['PRF']
             duration = sicd.Timeline.CollectDuration
             ipp_el = sicd.Timeline.IPP[0]
-            ipp_el.IPPEnd = duration*prf
+            ipp_el.IPPEnd = round(duration*prf) - 1
             ipp_el.TEnd = duration
             ipp_el.IPPPoly = Poly1DType(Coefs=(0, prf))
 

--- a/sarpy/io/complex/gff.py
+++ b/sarpy/io/complex/gff.py
@@ -1438,7 +1438,7 @@ class _GFFInterpreter2(_GFFInterpreter):
                     TEnd=collect_duration,
                     IPPStart=0,
                     IPPEnd=ipp_end,
-                    IPPPoly=[0, ipp_end/collect_duration]), ]
+                    IPPPoly=[0, (ipp_end + 1)/collect_duration]), ]
             except AttributeError:
                 ipp = None
             return TimelineType(

--- a/sarpy/io/complex/iceye.py
+++ b/sarpy/io/complex/iceye.py
@@ -174,7 +174,7 @@ class ICEYEDetails(object):
                 CollectStart=start_time,
                 CollectDuration=duration,
                 IPP=[IPPSetType(index=0, TStart=0, TEnd=duration,
-                                IPPStart=0, IPPEnd=int(round(acq_prf*duration)),
+                                IPPStart=0, IPPEnd=int(round(acq_prf*duration) - 1),
                                 IPPPoly=[0, acq_prf]), ])
 
         def get_position() -> PositionType:

--- a/sarpy/io/complex/nisar.py
+++ b/sarpy/io/complex/nisar.py
@@ -383,7 +383,7 @@ class NISARDetails(object):
 
         def update_timeline() -> None:
             prf = gp['nominalAcquisitionPRF'][()]
-            t_sicd.Timeline.IPP[0].IPPEnd = prf*t_sicd.Timeline.CollectDuration
+            t_sicd.Timeline.IPP[0].IPPEnd = round(prf*t_sicd.Timeline.CollectDuration) - 1
             t_sicd.Timeline.IPP[0].IPPPoly = [0, prf]
 
         def define_radar_collection() -> List[str]:

--- a/sarpy/io/complex/palsar2.py
+++ b/sarpy/io/complex/palsar2.py
@@ -1361,7 +1361,7 @@ class PALSARDetails(object):
                 IPP=[IPPSetType(TStart=0,
                                 TEnd=duration,
                                 IPPStart=0,
-                                IPPEnd=int(prf*duration),
+                                IPPEnd=round(prf*duration) - 1,
                                 IPPPoly=[0, prf]), ])
 
         def get_position() -> PositionType:

--- a/sarpy/io/complex/sentinel.py
+++ b/sarpy/io/complex/sentinel.py
@@ -547,7 +547,7 @@ class SentinelDetails(object):
             timeline.CollectStart = start
             timeline.CollectDuration = duration
             timeline.IPP[0].TEnd = duration
-            timeline.IPP[0].IPPEnd = int(timeline.CollectDuration*prf)
+            timeline.IPP[0].IPPEnd = round(timeline.CollectDuration*prf) - 1
             sicd.ImageFormation.TEndProc = duration
 
         def set_position(sicd, start):

--- a/sarpy/io/complex/tsx.py
+++ b/sarpy/io/complex/tsx.py
@@ -701,7 +701,7 @@ class TSXDetails(object):
                                 TEnd=collect_duration,
                                 IPPPoly=ipp_poly,
                                 IPPStart=0,
-                                IPPEnd=int(ipp_poly(collect_duration)))])
+                                IPPEnd=int(round(ipp_poly(collect_duration))) - 1)])
 
         def set_position():
             times_s = numpy.array(


### PR DESCRIPTION
While working with ICEYE, CSK, TSX, and Capella imagery, it was observed that the IPPSets in SICDs made by these converters did not conform to the relationship described in the SICD D&I.

From Section 4.5, page 93 of the SICD 1.3.0 D&I:  "For a given interval, time tS(idx) is the start of IPP kS(idx) and time tE(idx) is the end of IPP kE(idx)."

This means that evaluating the IPPPoly at TEnd should not yield IPPEnd.  It should roughly yield IPPEnd + 1.  Figure 4.5-2 on page 94 also shows this relationship.

The gff, nisar, palsar2, and sentinel converters were modified as they create the IPPSets similarly.