### PR TITLE
Added remap.py unit test

### DIFF
--- a/sarpy/visualization/remap.py
+++ b/sarpy/visualization/remap.py
@@ -60,7 +60,7 @@ def clip_cast(
 
     np_type = numpy.dtype(dtype)
     min_value = numpy.iinfo(np_type).min if min_value is None else max(min_value, numpy.iinfo(np_type).min)
-    max_value = numpy.iinfo(np_type).max if max_value is None else max(max_value, numpy.iinfo(np_type).max)
+    max_value = numpy.iinfo(np_type).max if max_value is None else min(max_value, numpy.iinfo(np_type).max)
     return numpy.clip(array, min_value, max_value).astype(np_type)
 
 
@@ -121,7 +121,7 @@ def amplitude_to_density(
         # clarity in historical reference
         # Originally, C_L and C_H were static values drawn from a determined set
         # of remap look-up tables. The C_L/C_H values were presumably based roughly
-        # on mean amplitude and desired rempa brightness/contrast. The dmin value
+        # on mean amplitude and desired remap brightness/contrast. The dmin value
         # was fixed as 30.
         return slope*numpy.log10(numpy.maximum(amplitude, EPS)) + constant
 
@@ -777,7 +777,7 @@ class Linear(MonochromaticRemap):
     @property
     def max_value(self) -> Optional[float]:
         """
-        None|float:  The minimum value allowed (clipped above this)
+        None|float:  The maximum value allowed (clipped above this)
         """
 
         return self._max_value
@@ -1180,7 +1180,7 @@ class PEDF(MonochromaticRemap):
     def are_global_parameters_set(self) -> bool:
         """
         bool: Are (all) global parameters used for applying this remap function
-        set? In this case, this is the `min_value` and `max_value` properties.
+        set? In this case, this is the `data_mean` property.
         """
 
         return self._density.are_global_parameters_set

--- a/tests/visualization/test_remap.py
+++ b/tests/visualization/test_remap.py
@@ -1,0 +1,353 @@
+#
+# Copyright 2022 Valkyrie Systems Corporation
+#
+# Licensed under MIT License.  See LICENSE.
+#
+import collections
+import unittest
+
+import numpy as np
+
+from sarpy.visualization import remap
+
+try:
+    import matplotlib.pyplot as plt
+
+    MATPLOTLIB_AVAILABLE = True
+except ImportError:
+    MATPLOTLIB_AVAILABLE = False
+
+
+class NoOpRemap(remap.RemapFunction):
+    def __init__(self):
+        super().__init__(override_name="noop")
+
+    def raw_call(self, data, **kwargs):
+        return data
+
+
+class TestRemap(unittest.TestCase):
+    def test_clip_cast(self):
+        data = np.asarray([-100000, -128, -10, 0, 10, 127, 100000], dtype=np.float64)
+
+        result = remap.clip_cast(data, np.int8)
+        np.testing.assert_array_almost_equal(result, [-128, -128, -10, 0, 10, 127, 127])
+
+        result = remap.clip_cast(data, np.int8, -100, 100)
+        np.testing.assert_array_almost_equal(result, [-100, -100, -10, 0, 10, 100, 100])
+
+        result = remap.clip_cast(data, np.int8, -500, 500)
+        np.testing.assert_array_almost_equal(result, [-128, -128, -10, 0, 10, 127, 127])
+
+        result = remap.clip_cast(data, np.int16)
+        np.testing.assert_array_almost_equal(result, [-32768, -128, -10, 0, 10, 127, 32767])
+
+    def test_amplitude_to_density_zeros(self):
+        data = np.zeros(100, dtype=np.complex64)
+        result = remap.amplitude_to_density(data.copy())
+        np.testing.assert_array_equal(data, result)
+
+    def test_amplitude_to_density(self):
+        data = np.arange(100, dtype=np.complex64)
+        result = remap.amplitude_to_density(data)
+        self.assertTrue(np.all(np.isfinite(result)))
+        with self.assertRaises(ValueError):
+            remap.amplitude_to_density(data, dmin=-1)
+        with self.assertRaises(ValueError):
+            remap.amplitude_to_density(data, dmin=255)
+        with self.assertRaises(ValueError):
+            remap.amplitude_to_density(data, mmult=0)
+
+    def test_RemapFunction(self):
+        rf = remap.RemapFunction()
+        self.assertEqual(rf.bit_depth, 8)
+        self.assertEqual(rf.dimension, 0)
+        self.assertEqual(rf.output_dtype, np.dtype(np.uint8))
+        self.assertTrue(rf.are_global_parameters_set)
+        self.assertTrue(isinstance(rf.name, str))
+        self.assertGreater(len(rf.name), 0)
+        with self.assertRaises(NotImplementedError):
+            rf(np.arange(10))
+
+        with self.assertRaises(NotImplementedError):
+            rf.calculate_global_parameters_from_reader(None)
+
+        rf = remap.RemapFunction(override_name="unit_test_remap")
+        self.assertEqual(rf.name, "unit_test_remap")
+
+        with self.assertRaises(ValueError):
+            rf = remap.RemapFunction(override_name=123)
+
+        with self.assertRaises(ValueError):
+            rf = remap.RemapFunction(dimension=10)
+
+        for bit_depth in [8.0, 16, 32]:
+            rf = remap.RemapFunction(bit_depth=bit_depth)
+            self.assertEqual(rf.output_dtype.kind, "u")
+            self.assertEqual(rf.output_dtype.itemsize, bit_depth // 8)
+
+        for bit_depth in [0, 15.0, 64]:
+            with self.assertRaises(ValueError):
+                remap.RemapFunction(bit_depth=bit_depth)
+
+        # Check that casting and clipping occurs
+        data = np.linspace(-1000, 1000)
+        remapped = NoOpRemap()(data)
+        self.assertEqual(remapped.dtype, np.dtype(np.uint8))
+        np.testing.assert_array_equal(remapped, remap.clip_cast(data))
+
+    def test_MonochromaticRemap(self):
+        mr = remap.MonochromaticRemap()
+        self.assertEqual(mr.bit_depth, 8)
+        self.assertEqual(mr.max_output_value, 255)
+        mr = remap.MonochromaticRemap(bit_depth=16)
+        self.assertEqual(mr.max_output_value, (1 << 16) - 1)
+        with self.assertRaises(ValueError):
+            mr = remap.MonochromaticRemap(bit_depth=16, max_output_value=1 << 16)
+        with self.assertRaises(ValueError):
+            mr = remap.MonochromaticRemap(bit_depth=16, max_output_value=0)
+        with self.assertRaises(NotImplementedError):
+            mr.calculate_global_parameters_from_reader(None)
+        with self.assertRaises(NotImplementedError):
+            mr(np.random.uniform(100))
+
+    def test_Density(self):
+        with self.assertRaises(ValueError):
+            remap.Density(dmin=-1)
+        with self.assertRaises(ValueError):
+            remap.Density(dmin=256)
+        with self.assertRaises(ValueError):
+            remap.Density(mmult=0.9)
+
+        data = np.random.lognormal(size=1000).astype(np.complex128)
+        dr = remap.Density()
+        nominal = dr(data)
+        self.assertEqual(nominal.dtype, np.uint8)
+        double = dr(data * 2)
+        np.testing.assert_array_equal(nominal, double)
+        self.assertFalse(dr.are_global_parameters_set)
+        self.assertTrue(remap.Density(data_mean=1).are_global_parameters_set)
+
+    def test_Linear(self):
+        data = np.linspace(2, 1, 512)
+        lr = remap.Linear()
+        self.assertFalse(lr.are_global_parameters_set)
+        self.assertTrue(remap.Linear(min_value=1, max_value=2).are_global_parameters_set)
+        nominal = lr(data)
+        self.assertGreaterEqual(np.count_nonzero(nominal), data.size - 3)
+        self.assertEqual(nominal.dtype, np.uint8)
+        self.assertEqual(nominal.min(), 0)
+        self.assertEqual(nominal.max(), 255)
+
+        double = lr(data * 2)
+        np.testing.assert_array_equal(nominal, double)
+
+        lr.min_value = data.mean()
+        with_min = lr(data)
+        self.assertEqual(np.count_nonzero(with_min), data.size / 2 - 1)
+        with self.assertRaises(ValueError):
+            lr.min_value = np.inf
+        lr.min_value = None
+        self.assertGreaterEqual(np.count_nonzero(lr(data)), data.size - 3)
+
+        lr.max_value = data.mean()
+        with_max = lr(data)
+        self.assertEqual(np.sum(with_max == 255), np.sum(data >= data.mean()))
+        with self.assertRaises(ValueError):
+            lr.max_value = np.inf
+        lr.max_value = None
+        np.testing.assert_array_equal(lr(data), nominal)
+        double = lr(data * 2)
+        np.testing.assert_array_equal(nominal, double)
+
+    def test_Logarithmic(self):
+        data = np.linspace(2, 1, 512)
+        lr = remap.Logarithmic()
+        self.assertFalse(lr.are_global_parameters_set)
+        self.assertTrue(remap.Logarithmic(min_value=1, max_value=2).are_global_parameters_set)
+        nominal = lr(data)
+        self.assertEqual(nominal.dtype, np.uint8)
+        self.assertEqual(nominal.min(), 0)
+        self.assertEqual(nominal.max(), 255)
+
+        lr.max_value = 1.5
+        with_max = lr(data)
+        self.assertEqual(nominal.min(), 0)
+        np.testing.assert_array_equal(with_max[:256], 255)
+        np.testing.assert_array_less(with_max[256:], 255)
+
+        lr.max_value = None
+        lr.min_value = 1.5
+        with_max = lr(data)
+        self.assertEqual(nominal.max(), 255)
+        np.testing.assert_array_equal(with_max[256:], 0)
+
+    def test_Logarithmic_const(self):
+        data = np.full(1000, 1.0, dtype=np.complex64)
+        lr = remap.Logarithmic()
+        np.testing.assert_array_equal(lr(data), 0)
+
+    def test_PEDF(self):
+        self.assertFalse(remap.PEDF().are_global_parameters_set)
+        self.assertTrue(remap.PEDF(data_mean=0.5).are_global_parameters_set)
+        data = np.random.lognormal(size=1000).astype(np.complex128)
+        pedf = remap.PEDF()(data)
+        self.assertEqual(pedf.dtype, np.uint8)
+        self.assertEqual(pedf.min(), 0)
+
+    def test_NRL(self):
+        self.assertFalse(remap.NRL().are_global_parameters_set)
+        self.assertTrue(remap.NRL(stats=(0, 2, 1)).are_global_parameters_set)
+
+        data = np.random.lognormal(size=1000).astype(np.complex128)
+        nrl = remap.NRL()(data)
+        self.assertEqual(nrl.dtype, np.uint8)
+        self.assertEqual(nrl.min(), 0)
+        self.assertEqual(nrl.max(), 255)
+
+        with self.assertRaises(ValueError):
+            remap.NRL(percentile=0)
+        with self.assertRaises(ValueError):
+            remap.NRL(percentile=100)
+        with self.assertRaises(ValueError):
+            remap.NRL(max_output_value=100, knee=101)
+
+    def test_NRL_near_const(self):
+        data = np.full(1000, 1.0, dtype=np.complex64)
+        data[-1] += 1e-6
+        with self.assertLogs('sarpy.visualization.remap', level='WARNING') as lc:
+            nrl = remap.NRL()(data)
+            self.assertTrue(any('at least significantly constant' in msg for msg in lc.output))
+        expected = np.zeros(data.size, dtype=np.uint8)
+        expected[-1] = 255
+        np.testing.assert_array_equal(nrl, expected)
+
+    def test_NRL_inf(self):
+        data = np.full(1000, np.inf, dtype=np.complex64)
+        nrl = remap.NRL()(data)
+        np.testing.assert_array_equal(nrl, 0)
+
+    def test_MonoRemaps(self):
+        data = np.random.lognormal(size=1000).astype(np.complex128)
+        adata = np.abs(data)
+        nominal = remap.Density()(data)
+        brighter = remap.Brighter()(data)
+        darker = remap.Darker()(data)
+        self.assertEqual(nominal.dtype, np.uint8)
+        self.assertEqual(brighter.dtype, np.uint8)
+        self.assertEqual(darker.dtype, np.uint8)
+        self.assertTrue(np.all(brighter >= nominal))
+        self.assertGreater(np.mean(brighter), np.mean(nominal))
+        self.assertTrue(np.all(darker <= nominal))
+        self.assertLess(np.mean(darker), np.mean(nominal))
+
+        hc = remap.High_Contrast()(data)
+        self.assertEqual(hc.dtype, np.uint8)
+        self.assertGreater(np.sum(hc == 0), np.sum(nominal == 0))
+        self.assertGreater(np.sum(hc == 255), np.sum(nominal == 255))
+
+        linear = remap.Linear()(data)
+        self.assertEqual(linear.dtype, np.uint8)
+        self.assertAlmostEqual(max(linear / adata), 255 / max(adata))
+
+        log = remap.Logarithmic()(data)
+        self.assertEqual(log.dtype, np.uint8)
+        self.assertTrue(np.all(linear <= log))
+
+        nrl = remap.NRL()(data)
+        self.assertTrue(np.all(nrl >= linear))
+
+    def test_LUTRemap(self):
+        data = np.concatenate((np.arange(256), np.arange(256)[::-1]))
+        lut = np.zeros((256, 3), dtype=np.uint8)
+        lut[:, 0] = np.arange(256)
+        lut[:, 1] = np.arange(256)[::-1]
+        lut[:, 2] = np.roll(np.arange(256), 128)
+
+        lutr = remap.LUT8bit(mono_remap=remap.Linear(), lookup_table=lut)
+        result = lutr(data)
+        np.testing.assert_array_equal(result.shape, data.shape + (3,))
+        np.testing.assert_array_equal(result[:256], lut)
+        np.testing.assert_array_equal(result[256:], lut[::-1])
+
+        class NonMono(remap.RemapFunction):
+            pass
+
+        with self.assertRaises(ValueError):
+            remap.LUT8bit(mono_remap=NonMono, lookup_table=lut)
+
+    @unittest.skipIf(not MATPLOTLIB_AVAILABLE, "matplotlib not available")
+    def test_LUTRemap_matplotlib(self):
+        data = np.arange(0, 512, 2)[::-1]
+
+        lutr = remap.LUT8bit(mono_remap=remap.Linear(), lookup_table="binary")
+        result = lutr(data)
+        np.testing.assert_array_equal(result.shape, data.shape + (3,))
+        np.testing.assert_array_equal(result[:, 0], result[:, 1])
+        np.testing.assert_array_equal(result[:, 0], result[:, 2])
+        np.testing.assert_array_equal(result[:, 0], result[:, 2])
+        self.assertTrue(np.all(np.abs(result[:, 0] - np.arange(256)) <= 1))
+
+    def test_remap_names(self):
+        remap._DEFAULTS_REGISTERED = False
+        remap._REMAP_DICT = collections.OrderedDict()
+        default_names = remap.get_remap_names()
+        self.assertIn("nrl", default_names)
+        self.assertIn("density", default_names)
+        self.assertIn("high_contrast", default_names)
+        self.assertIn("brighter", default_names)
+        self.assertIn("darker", default_names)
+        self.assertIn("linear", default_names)
+        self.assertIn("log", default_names)
+        self.assertIn("pedf", default_names)
+
+        if MATPLOTLIB_AVAILABLE:
+            self.assertIn("viridis", default_names)
+            self.assertIn("magma", default_names)
+            self.assertIn("rainbow", default_names)
+            self.assertIn("bone", default_names)
+
+        noop_remap = NoOpRemap()
+        remap.register_remap(noop_remap)
+        updated_names = remap.get_remap_names()
+        self.assertEqual(set(updated_names) - set(default_names), {"noop"})
+        with self.assertRaises(TypeError):
+            remap.register_remap(lambda x: x)
+
+        another_noop_remap = NoOpRemap()
+        remap.register_remap(another_noop_remap)
+        self.assertIs(noop_remap, remap.get_registered_remap("noop"))  # didn't overwrite
+        remap.register_remap(another_noop_remap, overwrite=True)
+        self.assertIs(another_noop_remap, remap.get_registered_remap("noop"))  # did overwrite
+
+        remap._DEFAULTS_REGISTERED = False
+        remap._REMAP_DICT = collections.OrderedDict()
+
+    def test_get_registered_remap(self):
+        with self.assertRaises(KeyError):
+            remap.get_registered_remap("__fake__")
+        self.assertEqual(remap.get_registered_remap("__fake__", "default"), "default")
+
+    def test_get_remap_list(self):
+        remap_list = remap.get_remap_list()
+        self.assertSetEqual(set(item[0] for item in remap_list), set(remap.get_remap_names()))
+        self.assertIsInstance(dict(remap_list)["density"], remap.Density)
+
+    def test_flat_interface(self):
+        data = np.random.lognormal(size=1000).astype(np.complex128)
+        with self.assertWarns(DeprecationWarning):
+            np.testing.assert_array_equal(remap.density(data), remap.Density()(data))
+        with self.assertWarns(DeprecationWarning):
+            np.testing.assert_array_equal(remap.brighter(data), remap.Brighter()(data))
+        with self.assertWarns(DeprecationWarning):
+            np.testing.assert_array_equal(remap.darker(data), remap.Darker()(data))
+        with self.assertWarns(DeprecationWarning):
+            np.testing.assert_array_equal(remap.high_contrast(data), remap.High_Contrast()(data))
+        with self.assertWarns(DeprecationWarning):
+            np.testing.assert_array_equal(remap.linear(data), remap.Linear()(data))
+        with self.assertWarns(DeprecationWarning):
+            np.testing.assert_array_equal(remap.log(data), remap.Logarithmic()(data))
+        with self.assertWarns(DeprecationWarning):
+            np.testing.assert_array_equal(remap.pedf(data), remap.PEDF()(data))
+        with self.assertWarns(DeprecationWarning):
+            np.testing.assert_array_equal(remap.nrl(data), remap.NRL()(data))


### PR DESCRIPTION
This is a step towards improving the test coverage, espically when vendor data isn't available to run the converters.

In master
```
$ pytest --cov=sarpy.visualization.remap --cov-report term-missing
```
```
Name                                                                                                                   Stmts   Miss  Cover   Missing
----------------------------------------------------------------------------------------------------------------------------------------------------
sarpy/visualization/remap.py     574    400    30%   28-29, 61-64, 100-126, 149, 175-179, 213-218, 228, 231-234, 243, 254-259, 269, 280-284, 292-299, 308, 331, 358, 364, 371-381, 406, 435-437, 445, 448-457, 462, 465, 517-525, 533, 536-539, 546, 549-552, 559, 563-567, 576, 600-604, 633, 642-643, 660, 685, 710, 747-758, 765, 769-775, 783, 787-793, 802, 809-828, 859-879, 915, 924-925, 955-962, 969, 973-979, 987, 991-997, 1006, 1013-1032, 1063-1084, 1120, 1129-1130, 1173-1175, 1186, 1210-1214, 1243, 1252, 1289-1295, 1303, 1306-1314, 1323, 1326-1333, 1341, 1344-1347, 1353-1364, 1373, 1398-1428, 1458, 1467-1468, 1508-1519, 1530, 1537, 1540-1542, 1550, 1556-1575, 1583, 1603, 1609, 1616, 1640-1653, 1658-1686, 1698-1700, 1713-1719, 1742-1749, 1775-1779, 1796-1800, 1817-1821, 1838-1842, 1862-1866, 1886-1890, 1908-1912, 1932-1936
----------------------------------------------------------------------------------------------------------------------------------------------------
TOTAL                                                                                                                    574    400    30%
```


The added unit test
```
$ pytest --cov=sarpy.visualization.remap --cov-report term-missing tests/visualization/test_remap.py 
```
```
Name                           Stmts   Miss  Cover   Missing
------------------------------------------------------------
sarpy/visualization/remap.py     574     49    91%   28-29, 299, 371-381, 559, 642-643, 810, 812, 826, 876, 924-925, 974, 978, 996, 1014, 1016, 1030, 1129-1130, 1252, 1327, 1362, 1421, 1467-1468, 1550, 1559, 1568, 1571, 1583, 1616, 1641, 1659, 1671-1672, 1675-1676, 1679-1680, 1683-1684, 1714
------------------------------------------------------------
TOTAL                            574     49    91%
```

There are some parts of `remap.py` which rely on SICD reader objects, so those code paths aren't yet tested. 