### PR TITLE
1.3.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ SarPy follows a continuous release process, so there are fairly frequent release
 Since essentially every (squash merge) commit corresponds to a release, specific 
 release points are not being annotated in GitHub.
 
+## [1.3.10] - 2022-10-24
+### Fixed
+- Updated error message for IQ handing in CPHD reader.
+- Refactored reference to MIL-STD-2500C NITF spec to "Joint BIIF Profile (JBP)"
+- Fixed bug in correctly accounting for row stride from file like object. [Pull Request 348](https://github.com/ngageoint/sarpy/pull/348)
+- Fixed bug with SICD converter correctly conform to described relationship in the SICD D&I.  [Pull Request 349](https://github.com/ngageoint/sarpy/pull/349)
+- Fixed bug with Grid.Col.DeltaKCOA poly correctly populated based on collection metadate 
+and constant COA. [Pull Request 350](https://github.com/ngageoint/sarpy/pull/350)
+- Added remap.py unit test. [Pull Request 351](https://github.com/ngageoint/sarpy/pull/351)
+
 ## [1.3.9] - 2022-10-13
 ### Fixed
 - Fixed a bug in correctly handling IQ error in CPHD reader.

--- a/sarpy/__about__.py
+++ b/sarpy/__about__.py
@@ -27,7 +27,7 @@ __all__ = ['__version__',
            '__license__', '__copyright__']
 
 from sarpy.__details__ import __classification__, _post_identifier
-_version_number = '1.3.9'
+_version_number = '1.3.10'
 
 __version__ = _version_number + _post_identifier
 

--- a/sarpy/io/complex/capella.py
+++ b/sarpy/io/complex/capella.py
@@ -315,7 +315,7 @@ class CapellaDetails(object):
                         TStart=0,
                         TEnd=duration,
                         IPPStart=0,
-                        IPPEnd=duration*prf,
+                        IPPEnd=round(duration*prf) - 1,
                         IPPPoly=(0, prf)), ])
 
         def get_image_formation() -> ImageFormationType:

--- a/sarpy/io/complex/csk.py
+++ b/sarpy/io/complex/csk.py
@@ -477,7 +477,7 @@ class CSKDetails(object):
             prf = band_dict[band_name]['PRF']
             duration = sicd.Timeline.CollectDuration
             ipp_el = sicd.Timeline.IPP[0]
-            ipp_el.IPPEnd = duration*prf
+            ipp_el.IPPEnd = round(duration*prf) - 1
             ipp_el.TEnd = duration
             ipp_el.IPPPoly = Poly1DType(Coefs=(0, prf))
 

--- a/sarpy/io/complex/gff.py
+++ b/sarpy/io/complex/gff.py
@@ -1438,7 +1438,7 @@ class _GFFInterpreter2(_GFFInterpreter):
                     TEnd=collect_duration,
                     IPPStart=0,
                     IPPEnd=ipp_end,
-                    IPPPoly=[0, ipp_end/collect_duration]), ]
+                    IPPPoly=[0, (ipp_end + 1)/collect_duration]), ]
             except AttributeError:
                 ipp = None
             return TimelineType(

--- a/sarpy/io/complex/iceye.py
+++ b/sarpy/io/complex/iceye.py
@@ -174,7 +174,7 @@ class ICEYEDetails(object):
                 CollectStart=start_time,
                 CollectDuration=duration,
                 IPP=[IPPSetType(index=0, TStart=0, TEnd=duration,
-                                IPPStart=0, IPPEnd=int(round(acq_prf*duration)),
+                                IPPStart=0, IPPEnd=int(round(acq_prf*duration) - 1),
                                 IPPPoly=[0, acq_prf]), ])
 
         def get_position() -> PositionType:

--- a/sarpy/io/complex/nisar.py
+++ b/sarpy/io/complex/nisar.py
@@ -383,7 +383,7 @@ class NISARDetails(object):
 
         def update_timeline() -> None:
             prf = gp['nominalAcquisitionPRF'][()]
-            t_sicd.Timeline.IPP[0].IPPEnd = prf*t_sicd.Timeline.CollectDuration
+            t_sicd.Timeline.IPP[0].IPPEnd = round(prf*t_sicd.Timeline.CollectDuration) - 1
             t_sicd.Timeline.IPP[0].IPPPoly = [0, prf]
 
         def define_radar_collection() -> List[str]:

--- a/sarpy/io/complex/palsar2.py
+++ b/sarpy/io/complex/palsar2.py
@@ -1361,7 +1361,7 @@ class PALSARDetails(object):
                 IPP=[IPPSetType(TStart=0,
                                 TEnd=duration,
                                 IPPStart=0,
-                                IPPEnd=int(prf*duration),
+                                IPPEnd=round(prf*duration) - 1,
                                 IPPPoly=[0, prf]), ])
 
         def get_position() -> PositionType:

--- a/sarpy/io/complex/sentinel.py
+++ b/sarpy/io/complex/sentinel.py
@@ -547,7 +547,7 @@ class SentinelDetails(object):
             timeline.CollectStart = start
             timeline.CollectDuration = duration
             timeline.IPP[0].TEnd = duration
-            timeline.IPP[0].IPPEnd = int(timeline.CollectDuration*prf)
+            timeline.IPP[0].IPPEnd = round(timeline.CollectDuration*prf) - 1
             sicd.ImageFormation.TEndProc = duration
 
         def set_position(sicd, start):

--- a/sarpy/io/complex/tsx.py
+++ b/sarpy/io/complex/tsx.py
@@ -701,7 +701,7 @@ class TSXDetails(object):
                                 TEnd=collect_duration,
                                 IPPPoly=ipp_poly,
                                 IPPStart=0,
-                                IPPEnd=int(ipp_poly(collect_duration)))])
+                                IPPEnd=int(round(ipp_poly(collect_duration))) - 1)])
 
         def set_position():
             times_s = numpy.array(

--- a/sarpy/io/general/data_segment.py
+++ b/sarpy/io/general/data_segment.py
@@ -2448,7 +2448,7 @@ class FileReadDataSegment(DataSegment):
         row_stride = self.raw_dtype.itemsize*pixel_per_row
 
         start_row = init_slice.start
-        rows = out_shape[0]
+        rows = out_shape[0] * init_slice.step
 
         # read the whole contiguous chunk from start_row up to the final row
         # seek to the proper start location
@@ -2466,7 +2466,7 @@ class FileReadDataSegment(DataSegment):
         data = numpy.frombuffer(data, self._raw_dtype, rows*pixel_per_row)
         data = numpy.reshape(data, (rows, ) + self.raw_shape[1:])
         # extract our data
-        out = data[(slice(None, None, 1), ) + subscript[1:]]
+        out = data[(slice(None, None, init_slice.step), ) + subscript[1:]]
         out = numpy.reshape(out, out_shape)
         if init_reverse:
             out = numpy.flip(out, axis=0)

--- a/sarpy/io/general/nitf_elements/des.py
+++ b/sarpy/io/general/nitf_elements/des.py
@@ -128,7 +128,7 @@ class DESUserHeader(Unstructured):
 
 class DataExtensionHeader(NITFElement):
     """
-    The data extension subheader - see standards document MIL-STD-2500C for more
+    The data extension subheader - see standards document Joint BIIF Profile (JBP) for more
     information.
     """
 
@@ -315,7 +315,7 @@ class DataExtensionHeader(NITFElement):
 
 class DataExtensionHeader0(NITFElement):
     """
-    The data extension subheader - see standards document MIL-STD-2500C for more
+    The data extension subheader - see standards document Joint BIIF Profile (JBP) for more
     information.
     """
 

--- a/sarpy/io/general/nitf_elements/graphics.py
+++ b/sarpy/io/general/nitf_elements/graphics.py
@@ -12,7 +12,7 @@ from .security import NITFSecurityTags
 
 class GraphicsSegmentHeader(NITFElement):
     """
-    Graphics segment subheader - see standards document MIL-STD-2500C for more
+    Graphics segment subheader - see standards document Joint BIIF Profile (JBP) for more
     information.
     """
     _ordering = (

--- a/sarpy/io/general/nitf_elements/image.py
+++ b/sarpy/io/general/nitf_elements/image.py
@@ -455,7 +455,7 @@ class MaskSubheader(NITFElement):
 
 class ImageSegmentHeader(NITFElement):
     """
-    The image segment header - see standards document MIL-STD-2500C for more
+    The image segment header - see standards document Joint BIIF Profile (JBP) for more
     information.
     """
 

--- a/sarpy/io/general/nitf_elements/nitf_head.py
+++ b/sarpy/io/general/nitf_elements/nitf_head.py
@@ -66,7 +66,7 @@ class ReservedExtensionsType(_ItemArrayHeaders):
 class NITFHeader(NITFElement):
     """
     The main NITF file header for NITF version 2.1 - see standards document
-    MIL-STD-2500C for more information.
+    Joint BIIF Profile (JBP) for more information.
     """
 
     _ordering = (

--- a/sarpy/io/general/nitf_elements/res.py
+++ b/sarpy/io/general/nitf_elements/res.py
@@ -18,7 +18,7 @@ class RESUserHeader(Unstructured):
 
 class ReservedExtensionHeader(NITFElement):
     """
-    The reserved extension subheader - see standards document MIL-STD-2500C for more
+    The reserved extension subheader - see standards document Joint BIIF Profile (JBP) for more
     information.
     """
 

--- a/sarpy/io/general/nitf_elements/security.py
+++ b/sarpy/io/general/nitf_elements/security.py
@@ -15,7 +15,7 @@ from .base import NITFElement, _StringDescriptor, _StringEnumDescriptor, _parse_
 class NITFSecurityTags(NITFElement):
     """
     The NITF security tags object for NITF version 2.1 - see standards document
-    MIL-STD-2500C for more information.
+    Joint BIIF Profile (JBP) for more information.
 
     In the NITF standard, this object is simply redefined (is an identical way)
     for each of the main header and subheader objects. This object is intended to

--- a/sarpy/io/general/nitf_elements/text.py
+++ b/sarpy/io/general/nitf_elements/text.py
@@ -17,7 +17,7 @@ from .security import NITFSecurityTags, NITFSecurityTags0
 class TextSegmentHeader(NITFElement):
     """
     Text Segment Subheader for NITF version 2.1 - see standards document
-    MIL-STD-2500C for more information.
+    Joint BIIF Profile (JBP) for more information.
     """
 
     _ordering = (

--- a/sarpy/io/phase_history/cphd.py
+++ b/sarpy/io/phase_history/cphd.py
@@ -110,8 +110,7 @@ class AmpScalingFunction(ComplexFormatFunction):
 
         if self.order != 'IQ':
             raise ValueError(
-                'A magnitude lookup table has been supplied,\n\t'
-                'but the order is not one of `MP` or `PM`')
+                'CPHD requires data in IQ order.')
 
         if not isinstance(array, numpy.ndarray):
             raise ValueError('requires a numpy.ndarray, got {}'.format(type(array)))

--- a/sarpy/visualization/remap.py
+++ b/sarpy/visualization/remap.py
@@ -60,7 +60,7 @@ def clip_cast(
 
     np_type = numpy.dtype(dtype)
     min_value = numpy.iinfo(np_type).min if min_value is None else max(min_value, numpy.iinfo(np_type).min)
-    max_value = numpy.iinfo(np_type).max if max_value is None else max(max_value, numpy.iinfo(np_type).max)
+    max_value = numpy.iinfo(np_type).max if max_value is None else min(max_value, numpy.iinfo(np_type).max)
     return numpy.clip(array, min_value, max_value).astype(np_type)
 
 
@@ -121,7 +121,7 @@ def amplitude_to_density(
         # clarity in historical reference
         # Originally, C_L and C_H were static values drawn from a determined set
         # of remap look-up tables. The C_L/C_H values were presumably based roughly
-        # on mean amplitude and desired rempa brightness/contrast. The dmin value
+        # on mean amplitude and desired remap brightness/contrast. The dmin value
         # was fixed as 30.
         return slope*numpy.log10(numpy.maximum(amplitude, EPS)) + constant
 
@@ -777,7 +777,7 @@ class Linear(MonochromaticRemap):
     @property
     def max_value(self) -> Optional[float]:
         """
-        None|float:  The minimum value allowed (clipped above this)
+        None|float:  The maximum value allowed (clipped above this)
         """
 
         return self._max_value
@@ -1180,7 +1180,7 @@ class PEDF(MonochromaticRemap):
     def are_global_parameters_set(self) -> bool:
         """
         bool: Are (all) global parameters used for applying this remap function
-        set? In this case, this is the `min_value` and `max_value` properties.
+        set? In this case, this is the `data_mean` property.
         """
 
         return self._density.are_global_parameters_set

--- a/tests/visualization/test_remap.py
+++ b/tests/visualization/test_remap.py
@@ -1,0 +1,353 @@
+#
+# Copyright 2022 Valkyrie Systems Corporation
+#
+# Licensed under MIT License.  See LICENSE.
+#
+import collections
+import unittest
+
+import numpy as np
+
+from sarpy.visualization import remap
+
+try:
+    import matplotlib.pyplot as plt
+
+    MATPLOTLIB_AVAILABLE = True
+except ImportError:
+    MATPLOTLIB_AVAILABLE = False
+
+
+class NoOpRemap(remap.RemapFunction):
+    def __init__(self):
+        super().__init__(override_name="noop")
+
+    def raw_call(self, data, **kwargs):
+        return data
+
+
+class TestRemap(unittest.TestCase):
+    def test_clip_cast(self):
+        data = np.asarray([-100000, -128, -10, 0, 10, 127, 100000], dtype=np.float64)
+
+        result = remap.clip_cast(data, np.int8)
+        np.testing.assert_array_almost_equal(result, [-128, -128, -10, 0, 10, 127, 127])
+
+        result = remap.clip_cast(data, np.int8, -100, 100)
+        np.testing.assert_array_almost_equal(result, [-100, -100, -10, 0, 10, 100, 100])
+
+        result = remap.clip_cast(data, np.int8, -500, 500)
+        np.testing.assert_array_almost_equal(result, [-128, -128, -10, 0, 10, 127, 127])
+
+        result = remap.clip_cast(data, np.int16)
+        np.testing.assert_array_almost_equal(result, [-32768, -128, -10, 0, 10, 127, 32767])
+
+    def test_amplitude_to_density_zeros(self):
+        data = np.zeros(100, dtype=np.complex64)
+        result = remap.amplitude_to_density(data.copy())
+        np.testing.assert_array_equal(data, result)
+
+    def test_amplitude_to_density(self):
+        data = np.arange(100, dtype=np.complex64)
+        result = remap.amplitude_to_density(data)
+        self.assertTrue(np.all(np.isfinite(result)))
+        with self.assertRaises(ValueError):
+            remap.amplitude_to_density(data, dmin=-1)
+        with self.assertRaises(ValueError):
+            remap.amplitude_to_density(data, dmin=255)
+        with self.assertRaises(ValueError):
+            remap.amplitude_to_density(data, mmult=0)
+
+    def test_RemapFunction(self):
+        rf = remap.RemapFunction()
+        self.assertEqual(rf.bit_depth, 8)
+        self.assertEqual(rf.dimension, 0)
+        self.assertEqual(rf.output_dtype, np.dtype(np.uint8))
+        self.assertTrue(rf.are_global_parameters_set)
+        self.assertTrue(isinstance(rf.name, str))
+        self.assertGreater(len(rf.name), 0)
+        with self.assertRaises(NotImplementedError):
+            rf(np.arange(10))
+
+        with self.assertRaises(NotImplementedError):
+            rf.calculate_global_parameters_from_reader(None)
+
+        rf = remap.RemapFunction(override_name="unit_test_remap")
+        self.assertEqual(rf.name, "unit_test_remap")
+
+        with self.assertRaises(ValueError):
+            rf = remap.RemapFunction(override_name=123)
+
+        with self.assertRaises(ValueError):
+            rf = remap.RemapFunction(dimension=10)
+
+        for bit_depth in [8.0, 16, 32]:
+            rf = remap.RemapFunction(bit_depth=bit_depth)
+            self.assertEqual(rf.output_dtype.kind, "u")
+            self.assertEqual(rf.output_dtype.itemsize, bit_depth // 8)
+
+        for bit_depth in [0, 15.0, 64]:
+            with self.assertRaises(ValueError):
+                remap.RemapFunction(bit_depth=bit_depth)
+
+        # Check that casting and clipping occurs
+        data = np.linspace(-1000, 1000)
+        remapped = NoOpRemap()(data)
+        self.assertEqual(remapped.dtype, np.dtype(np.uint8))
+        np.testing.assert_array_equal(remapped, remap.clip_cast(data))
+
+    def test_MonochromaticRemap(self):
+        mr = remap.MonochromaticRemap()
+        self.assertEqual(mr.bit_depth, 8)
+        self.assertEqual(mr.max_output_value, 255)
+        mr = remap.MonochromaticRemap(bit_depth=16)
+        self.assertEqual(mr.max_output_value, (1 << 16) - 1)
+        with self.assertRaises(ValueError):
+            mr = remap.MonochromaticRemap(bit_depth=16, max_output_value=1 << 16)
+        with self.assertRaises(ValueError):
+            mr = remap.MonochromaticRemap(bit_depth=16, max_output_value=0)
+        with self.assertRaises(NotImplementedError):
+            mr.calculate_global_parameters_from_reader(None)
+        with self.assertRaises(NotImplementedError):
+            mr(np.random.uniform(100))
+
+    def test_Density(self):
+        with self.assertRaises(ValueError):
+            remap.Density(dmin=-1)
+        with self.assertRaises(ValueError):
+            remap.Density(dmin=256)
+        with self.assertRaises(ValueError):
+            remap.Density(mmult=0.9)
+
+        data = np.random.lognormal(size=1000).astype(np.complex128)
+        dr = remap.Density()
+        nominal = dr(data)
+        self.assertEqual(nominal.dtype, np.uint8)
+        double = dr(data * 2)
+        np.testing.assert_array_equal(nominal, double)
+        self.assertFalse(dr.are_global_parameters_set)
+        self.assertTrue(remap.Density(data_mean=1).are_global_parameters_set)
+
+    def test_Linear(self):
+        data = np.linspace(2, 1, 512)
+        lr = remap.Linear()
+        self.assertFalse(lr.are_global_parameters_set)
+        self.assertTrue(remap.Linear(min_value=1, max_value=2).are_global_parameters_set)
+        nominal = lr(data)
+        self.assertGreaterEqual(np.count_nonzero(nominal), data.size - 3)
+        self.assertEqual(nominal.dtype, np.uint8)
+        self.assertEqual(nominal.min(), 0)
+        self.assertEqual(nominal.max(), 255)
+
+        double = lr(data * 2)
+        np.testing.assert_array_equal(nominal, double)
+
+        lr.min_value = data.mean()
+        with_min = lr(data)
+        self.assertEqual(np.count_nonzero(with_min), data.size / 2 - 1)
+        with self.assertRaises(ValueError):
+            lr.min_value = np.inf
+        lr.min_value = None
+        self.assertGreaterEqual(np.count_nonzero(lr(data)), data.size - 3)
+
+        lr.max_value = data.mean()
+        with_max = lr(data)
+        self.assertEqual(np.sum(with_max == 255), np.sum(data >= data.mean()))
+        with self.assertRaises(ValueError):
+            lr.max_value = np.inf
+        lr.max_value = None
+        np.testing.assert_array_equal(lr(data), nominal)
+        double = lr(data * 2)
+        np.testing.assert_array_equal(nominal, double)
+
+    def test_Logarithmic(self):
+        data = np.linspace(2, 1, 512)
+        lr = remap.Logarithmic()
+        self.assertFalse(lr.are_global_parameters_set)
+        self.assertTrue(remap.Logarithmic(min_value=1, max_value=2).are_global_parameters_set)
+        nominal = lr(data)
+        self.assertEqual(nominal.dtype, np.uint8)
+        self.assertEqual(nominal.min(), 0)
+        self.assertEqual(nominal.max(), 255)
+
+        lr.max_value = 1.5
+        with_max = lr(data)
+        self.assertEqual(nominal.min(), 0)
+        np.testing.assert_array_equal(with_max[:256], 255)
+        np.testing.assert_array_less(with_max[256:], 255)
+
+        lr.max_value = None
+        lr.min_value = 1.5
+        with_max = lr(data)
+        self.assertEqual(nominal.max(), 255)
+        np.testing.assert_array_equal(with_max[256:], 0)
+
+    def test_Logarithmic_const(self):
+        data = np.full(1000, 1.0, dtype=np.complex64)
+        lr = remap.Logarithmic()
+        np.testing.assert_array_equal(lr(data), 0)
+
+    def test_PEDF(self):
+        self.assertFalse(remap.PEDF().are_global_parameters_set)
+        self.assertTrue(remap.PEDF(data_mean=0.5).are_global_parameters_set)
+        data = np.random.lognormal(size=1000).astype(np.complex128)
+        pedf = remap.PEDF()(data)
+        self.assertEqual(pedf.dtype, np.uint8)
+        self.assertEqual(pedf.min(), 0)
+
+    def test_NRL(self):
+        self.assertFalse(remap.NRL().are_global_parameters_set)
+        self.assertTrue(remap.NRL(stats=(0, 2, 1)).are_global_parameters_set)
+
+        data = np.random.lognormal(size=1000).astype(np.complex128)
+        nrl = remap.NRL()(data)
+        self.assertEqual(nrl.dtype, np.uint8)
+        self.assertEqual(nrl.min(), 0)
+        self.assertEqual(nrl.max(), 255)
+
+        with self.assertRaises(ValueError):
+            remap.NRL(percentile=0)
+        with self.assertRaises(ValueError):
+            remap.NRL(percentile=100)
+        with self.assertRaises(ValueError):
+            remap.NRL(max_output_value=100, knee=101)
+
+    def test_NRL_near_const(self):
+        data = np.full(1000, 1.0, dtype=np.complex64)
+        data[-1] += 1e-6
+        with self.assertLogs('sarpy.visualization.remap', level='WARNING') as lc:
+            nrl = remap.NRL()(data)
+            self.assertTrue(any('at least significantly constant' in msg for msg in lc.output))
+        expected = np.zeros(data.size, dtype=np.uint8)
+        expected[-1] = 255
+        np.testing.assert_array_equal(nrl, expected)
+
+    def test_NRL_inf(self):
+        data = np.full(1000, np.inf, dtype=np.complex64)
+        nrl = remap.NRL()(data)
+        np.testing.assert_array_equal(nrl, 0)
+
+    def test_MonoRemaps(self):
+        data = np.random.lognormal(size=1000).astype(np.complex128)
+        adata = np.abs(data)
+        nominal = remap.Density()(data)
+        brighter = remap.Brighter()(data)
+        darker = remap.Darker()(data)
+        self.assertEqual(nominal.dtype, np.uint8)
+        self.assertEqual(brighter.dtype, np.uint8)
+        self.assertEqual(darker.dtype, np.uint8)
+        self.assertTrue(np.all(brighter >= nominal))
+        self.assertGreater(np.mean(brighter), np.mean(nominal))
+        self.assertTrue(np.all(darker <= nominal))
+        self.assertLess(np.mean(darker), np.mean(nominal))
+
+        hc = remap.High_Contrast()(data)
+        self.assertEqual(hc.dtype, np.uint8)
+        self.assertGreater(np.sum(hc == 0), np.sum(nominal == 0))
+        self.assertGreater(np.sum(hc == 255), np.sum(nominal == 255))
+
+        linear = remap.Linear()(data)
+        self.assertEqual(linear.dtype, np.uint8)
+        self.assertAlmostEqual(max(linear / adata), 255 / max(adata))
+
+        log = remap.Logarithmic()(data)
+        self.assertEqual(log.dtype, np.uint8)
+        self.assertTrue(np.all(linear <= log))
+
+        nrl = remap.NRL()(data)
+        self.assertTrue(np.all(nrl >= linear))
+
+    def test_LUTRemap(self):
+        data = np.concatenate((np.arange(256), np.arange(256)[::-1]))
+        lut = np.zeros((256, 3), dtype=np.uint8)
+        lut[:, 0] = np.arange(256)
+        lut[:, 1] = np.arange(256)[::-1]
+        lut[:, 2] = np.roll(np.arange(256), 128)
+
+        lutr = remap.LUT8bit(mono_remap=remap.Linear(), lookup_table=lut)
+        result = lutr(data)
+        np.testing.assert_array_equal(result.shape, data.shape + (3,))
+        np.testing.assert_array_equal(result[:256], lut)
+        np.testing.assert_array_equal(result[256:], lut[::-1])
+
+        class NonMono(remap.RemapFunction):
+            pass
+
+        with self.assertRaises(ValueError):
+            remap.LUT8bit(mono_remap=NonMono, lookup_table=lut)
+
+    @unittest.skipIf(not MATPLOTLIB_AVAILABLE, "matplotlib not available")
+    def test_LUTRemap_matplotlib(self):
+        data = np.arange(0, 512, 2)[::-1]
+
+        lutr = remap.LUT8bit(mono_remap=remap.Linear(), lookup_table="binary")
+        result = lutr(data)
+        np.testing.assert_array_equal(result.shape, data.shape + (3,))
+        np.testing.assert_array_equal(result[:, 0], result[:, 1])
+        np.testing.assert_array_equal(result[:, 0], result[:, 2])
+        np.testing.assert_array_equal(result[:, 0], result[:, 2])
+        self.assertTrue(np.all(np.abs(result[:, 0] - np.arange(256)) <= 1))
+
+    def test_remap_names(self):
+        remap._DEFAULTS_REGISTERED = False
+        remap._REMAP_DICT = collections.OrderedDict()
+        default_names = remap.get_remap_names()
+        self.assertIn("nrl", default_names)
+        self.assertIn("density", default_names)
+        self.assertIn("high_contrast", default_names)
+        self.assertIn("brighter", default_names)
+        self.assertIn("darker", default_names)
+        self.assertIn("linear", default_names)
+        self.assertIn("log", default_names)
+        self.assertIn("pedf", default_names)
+
+        if MATPLOTLIB_AVAILABLE:
+            self.assertIn("viridis", default_names)
+            self.assertIn("magma", default_names)
+            self.assertIn("rainbow", default_names)
+            self.assertIn("bone", default_names)
+
+        noop_remap = NoOpRemap()
+        remap.register_remap(noop_remap)
+        updated_names = remap.get_remap_names()
+        self.assertEqual(set(updated_names) - set(default_names), {"noop"})
+        with self.assertRaises(TypeError):
+            remap.register_remap(lambda x: x)
+
+        another_noop_remap = NoOpRemap()
+        remap.register_remap(another_noop_remap)
+        self.assertIs(noop_remap, remap.get_registered_remap("noop"))  # didn't overwrite
+        remap.register_remap(another_noop_remap, overwrite=True)
+        self.assertIs(another_noop_remap, remap.get_registered_remap("noop"))  # did overwrite
+
+        remap._DEFAULTS_REGISTERED = False
+        remap._REMAP_DICT = collections.OrderedDict()
+
+    def test_get_registered_remap(self):
+        with self.assertRaises(KeyError):
+            remap.get_registered_remap("__fake__")
+        self.assertEqual(remap.get_registered_remap("__fake__", "default"), "default")
+
+    def test_get_remap_list(self):
+        remap_list = remap.get_remap_list()
+        self.assertSetEqual(set(item[0] for item in remap_list), set(remap.get_remap_names()))
+        self.assertIsInstance(dict(remap_list)["density"], remap.Density)
+
+    def test_flat_interface(self):
+        data = np.random.lognormal(size=1000).astype(np.complex128)
+        with self.assertWarns(DeprecationWarning):
+            np.testing.assert_array_equal(remap.density(data), remap.Density()(data))
+        with self.assertWarns(DeprecationWarning):
+            np.testing.assert_array_equal(remap.brighter(data), remap.Brighter()(data))
+        with self.assertWarns(DeprecationWarning):
+            np.testing.assert_array_equal(remap.darker(data), remap.Darker()(data))
+        with self.assertWarns(DeprecationWarning):
+            np.testing.assert_array_equal(remap.high_contrast(data), remap.High_Contrast()(data))
+        with self.assertWarns(DeprecationWarning):
+            np.testing.assert_array_equal(remap.linear(data), remap.Linear()(data))
+        with self.assertWarns(DeprecationWarning):
+            np.testing.assert_array_equal(remap.log(data), remap.Logarithmic()(data))
+        with self.assertWarns(DeprecationWarning):
+            np.testing.assert_array_equal(remap.pedf(data), remap.PEDF()(data))
+        with self.assertWarns(DeprecationWarning):
+            np.testing.assert_array_equal(remap.nrl(data), remap.NRL()(data))


### PR DESCRIPTION
## [1.3.10] - 2022-10-24
### Fixed
- Updated error message for IQ handing in CPHD reader.
- Refactored reference to MIL-STD-2500C NITF spec to "Joint BIIF Profile (JBP)"
- Fixed bug in correctly accounting for row stride from file like object. [Pull Request 348](https://github.com/ngageoint/sarpy/pull/348)
- Fixed bug with SICD converter correctly conform to described relationship in the SICD D&I.  [Pull Request 349](https://github.com/ngageoint/sarpy/pull/349)
- Fixed bug with Grid.Col.DeltaKCOA poly correctly populated based on collection metadate 
and constant COA. [Pull Request 350](https://github.com/ngageoint/sarpy/pull/350)
- Added remap.py unit test. [Pull Request 351](https://github.com/ngageoint/sarpy/pull/351)