### PR TITLE
Fix converter bug

### DIFF
--- a/sarpy/io/complex/converter.py
+++ b/sarpy/io/complex/converter.py
@@ -238,7 +238,7 @@ class Converter(object):
         block_start = self._row_limits[0]
         while block_start < self._row_limits[1]:
             block_end = min(block_start + rows_per_block, self._row_limits[1])
-            data = self._reader[block_start:block_end, self._col_limits[0]:self._col_limits[1], self._frame]
+            data = self._reader[block_start:block_end, self._col_limits[0]:self._col_limits[1], self._frame, 'nosqueeze']
             self._writer.write_chip(data, start_indices=(block_start - self._row_limits[0], 0))
             logger.info('Done writing block {}-{} to file {}'.format(block_start, block_end, self._file_name))
             block_start = block_end

--- a/tests/io/complex/test_sicd.py
+++ b/tests/io/complex/test_sicd.py
@@ -1,7 +1,6 @@
 import os
 import json
 import tempfile
-import shutil
 import unittest
 
 from sarpy.io.complex.converter import conversion_utility
@@ -54,11 +53,10 @@ class TestSICDWriting(unittest.TestCase):
                                     msg='SICD structure serialized from file {} is '
                                         'not valid versus schema {}'.format(fil, the_schema))
 
-            # create a temp directory
-            temp_directory = tempfile.mkdtemp()
-
             with self.subTest(msg='Test conversion (recreation) of the sicd file {}'.format(fil)):
-                conversion_utility(reader, temp_directory)
+                with tempfile.TemporaryDirectory() as tmpdirname:
+                    conversion_utility(reader, tmpdirname)
 
-            # clean up the temporary directory
-            shutil.rmtree(temp_directory)
+            with self.subTest(msg='Test writing a single row of the sicd file {}'.format(fil)):
+                with tempfile.TemporaryDirectory() as tmpdirname:
+                    conversion_utility(reader, tmpdirname, row_limits=(0,1))


### PR DESCRIPTION
While working with SICD data, we came across an issue where, in the converter, the final block of data contained exactly one row. When that happened, self._reader.__getitem__ was returning a 1D array, but the rest of the code was expecting it to be 2D.

In this PR, We offer a fix to address the problem.
- Add `nosqueeze` to the read
- Add a unit test to demonstrate the solution works

We also made a slight modification to the `temp_directory` handling to allow automatic cleanup so that we could run back-to-back tests without intermediate files interfering.


### TESTING
_**Output of the unit tests before the fix:**_

pytest tests/io/complex/test_sicd.py 
================================================================================== test session starts ==================================================================================
platform linux -- Python 3.9.15, pytest-6.2.4, py-1.11.0, pluggy-0.13.1
rootdir: /home/vscuser/repos/sarpy_main
plugins: cov-2.12.1
collected 1 item                                                                                                                                                               

tests/io/complex/test_sicd.py F                                                                                                                                          [100%]

=================================================================================== FAILURES ===================================================================================
________________________________________ TestSICDWriting.test_sicd_creation ___________________________________________

self = <tests.io.complex.test_sicd.TestSICDWriting testMethod=test_sicd_creation>

    @unittest.skipIf(len(sicd_files) == 0, 'No sicd files found')
    def test_sicd_creation(self):
        for fil in sicd_files:
            reader = SICDReader(fil)
    
            # check that sicd structure serializes according to the schema
            if etree is not None:
                sicd = reader.get_sicds_as_tuple()[0]
                xml_doc = etree.fromstring(sicd.to_xml_bytes())
                xml_schema = etree.XMLSchema(file=the_schema)
                with self.subTest(msg='validate xml produced from sicd structure'):
                    self.assertTrue(xml_schema.validate(xml_doc),
                                    msg='SICD structure serialized from file {} is '
                                        'not valid versus schema {}'.format(fil, the_schema))
    
            with tempfile.TemporaryDirectory() as tmpdirname:
                with self.subTest(msg='Test conversion (recreation) of the sicd file {}'.format(fil)):
                    conversion_utility(reader, tmpdirname)
    
            with tempfile.TemporaryDirectory() as tmpdirname:
                with self.subTest(msg='Test writing a single row of the sicd file {}'.format(fil)):
>                   conversion_utility(reader, tmpdirname, row_limits=(0,1))

tests/io/complex/test_sicd.py:63: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
sarpy/io/complex/converter.py:426: in conversion_utility
    converter.write_data(max_block_size=max_block_size)
sarpy/io/complex/converter.py:242: in write_data
    self._writer.write_chip(data, start_indices=(block_start - self._row_limits[0], 0))
sarpy/io/general/base.py:715: in write_chip
    self.__call__(data, start_indices=start_indices, subscript=subscript, index=index, raw=False)
sarpy/io/general/base.py:818: in __call__
    return ds.write(data, start_indices=start_indices, subscript=subscript)
sarpy/io/general/data_segment.py:712: in write
    subscript = _infer_subscript_for_write(
sarpy/io/general/data_segment.py:174: in _infer_subscript_for_write
    subscript, result_shape = get_subscript_result_size(subscript, full_shape)
sarpy/io/general/slice_parsing.py:209: in get_subscript_result_size
    subscript = verify_subscript(subscript, corresponding_shape)
sarpy/io/general/slice_parsing.py:158: in verify_subscript
    out = [verify_slice(item_i, corresponding_shape[i]) for i, item_i in enumerate(subscript)]
sarpy/io/general/slice_parsing.py:158: in <listcomp>
    out = [verify_slice(item_i, corresponding_shape[i]) for i, item_i in enumerate(subscript)]
sarpy/io/general/slice_parsing.py:84: in verify_slice
    stop = check_bound(item.stop)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

entry = 1723

    def check_bound(entry: Union[None, int]) -> Union[None, int]:
        if entry is None:
            return entry
        elif -max_element <= entry < 0:
            entry += max_element
            return entry
        elif 0 <= entry <= max_element:
            return entry
        else:
>           raise ValueError('Got out of bounds argument ({}) in slice limited by `{}`'.format(entry, max_element))
E           ValueError: Got out of bounds argument (1723) in slice limited by `1`

sarpy/io/general/slice_parsing.py:69: ValueError
---------------------------------------------------------- Captured log call -----------------------------------------------------------
ERROR    sarpy.io.complex.converter:converter.py:258 The Converter file converter generated an exception during processing.
	The file /tmp/tmpk7_n5sqi/SyntheticCore_001_184124_SL0099L_00N000E_001X___SVV_0101_SPY_SICD.nitf may be only partially generated and corrupt.
=================================================================================== short test summary info ===================================================================================
FAILED tests/io/complex/test_sicd.py::TestSICDWriting::test_sicd_creation - ValueError: Got out of bounds argument (1723) in slice limited by `1`
==================================================================================== 1 failed in 0.75s ====================================================================================





_Below is the unit test output from this branch:_

pytest tests/io/complex/test_sicd.py 
=================================================================================== test session starts ====================================================================================
platform linux -- Python 3.9.15, pytest-6.2.4, py-1.11.0, pluggy-0.13.1
rootdir: /home/vscuser/repos/sarpy
plugins: cov-2.12.1
collected 1 item                                                                                                                                                               

tests/io/complex/test_sicd.py .                                                                                                                                          [100%]

==================================================================================== 1 passed in 0.50s ====================================================================================