### PR TITLE
Cphd consistency update

### DIFF
--- a/pytests/test_consistency.py
+++ b/pytests/test_consistency.py
@@ -101,6 +101,10 @@ def test_all(dummycon, capsys):
     assert len(dummycon.all()) == 11
     assert len(dummycon.failures()) == 5
 
+    num_checks_by_part = [len(x) for x in (dummycon.passes(), dummycon.skips(), dummycon.failures())]
+    assert all(x > 0 for x in num_checks_by_part)
+    assert sum(num_checks_by_part) == len(dummycon.all())
+
     failures = dummycon.failures()
     details = itertools.chain.from_iterable([value['details'] for value in failures.values()])
     passed = [item for item in details if item['passed']]

--- a/pytests/test_consistency.py
+++ b/pytests/test_consistency.py
@@ -127,10 +127,28 @@ def test_all(dummycon, capsys):
 
 def test_one(dummycon):
     dummycon.check('check_need_pass')
+    assert not dummycon.failures()
 
 
 def test_multiple(dummycon):
     dummycon.check(['check_need_pass', 'check_need_fail'])
+    assert set(dummycon.failures()) == {'check_need_fail'}
+    assert set(dummycon.all()).difference(dummycon.failures()) == {'check_need_pass'}
+
+
+def test_check_with_ignore_pattern(dummycon):
+    # all checks must start with check_
+    dummycon.check(ignore_patterns=['check_'])
+    assert set(dummycon.all()) == set()
+
+
+@pytest.mark.parametrize('should_ignore', [True, False])
+def test_check_with_ignore_specific(dummycon, should_ignore):
+    test_name = 'check_exception'
+    ignore_patterns = [test_name] if should_ignore else []
+    dummycon.check(ignore_patterns=ignore_patterns)
+    was_tested = (test_name in dummycon.all())
+    assert was_tested != should_ignore
 
 
 def test_invalid(dummycon):

--- a/pytests/test_cphd_consistency.py
+++ b/pytests/test_cphd_consistency.py
@@ -21,7 +21,6 @@ from sarpy.consistency.cphd_consistency import main, CphdConsistency, \
 
 TEST_FILE_NAMES = {
     'simple': 'spotlight_example.cphd',
-    'has_antenna': 'has_antenna.cphd',
     'bistatic': 'bistatic.cphd',
 }
 
@@ -51,15 +50,6 @@ def bistatic_cphd():
     file_path = TEST_FILE_PATHS.get('bistatic', None)
     if file_path is None:
         pytest.skip('bistatic cphd test file not found')
-    else:
-        return file_path
-
-
-@pytest.fixture(scope='module')
-def antenna_cphd():
-    file_path = TEST_FILE_PATHS.get('has_antenna', None)
-    if file_path is None:
-        pytest.skip('antenna cphd test file not found')
     else:
         return file_path
 
@@ -129,13 +119,6 @@ def _read_xml_str(cphd_path):
 @pytest.fixture(scope='module')
 def good_xml_str(good_cphd):
     return _read_xml_str(good_cphd)
-
-
-@pytest.fixture(scope='module')
-def good_xml_with_antenna(antenna_cphd):
-    xml_str = _read_xml_str(antenna_cphd)
-    xml_root = etree.fromstring(xml_str)
-    return strip_namespace(xml_root)
 
 
 @pytest.fixture
@@ -797,9 +780,9 @@ def test_extended_imagearea_polygon_bad_extent(xml_with_extendedarea):
     assert (len(cphd_con.failures()) > 0) == HAVE_SHAPELY
 
 
-def test_antenna_missing_channel_node(good_xml_with_antenna):
-    bad_xml = copy_xml(good_xml_with_antenna)
-    remove_nodes(*bad_xml.findall('./Channel/Parameters/Antenna'))
+def test_antenna_missing_channel_node(good_xml):
+    bad_xml = copy_xml(good_xml['with_ns'])
+    remove_nodes(*bad_xml.xpath('./ns:Channel/ns:Parameters/ns:Antenna', namespaces=good_xml['nsmap']))
 
     cphd_con = CphdConsistency(
         bad_xml, pvps=None, header=None, filename=None, check_signal_data=False)

--- a/sarpy/consistency/consistency.py
+++ b/sarpy/consistency/consistency.py
@@ -282,6 +282,30 @@ class ConsistencyChecker(object):
                     retval[k]['details'] = [d for d in v['details'] if not d['passed']]
         return retval
 
+    def passes(self):
+        """
+        Returns passed checks that are not wholly No-Op.
+
+        Returns
+        -------
+        Dict
+            Dictionary containing checks that are not wholly No-Op
+        """
+        return {k: v for k, v in self.all().items()
+                if v['passed'] and any(d['severity'] != 'No-Op' for d in v['details'])}
+
+    def skips(self):
+        """
+        Returns passed checks that are wholly No-Op.
+
+        Returns
+        -------
+        Dict
+            Dictionary containing checks that are wholly No-Op
+        """
+        return {k: v for k, v in self.all().items()
+                if v['passed'] and all(d['severity'] == 'No-Op' for d in v['details'])}
+
     def print_result(self, include_passed_asserts=True, color=True, include_passed_checks=False, width=120,
                      skip_detail=False, fail_detail=False, pass_detail=False):
         """

--- a/sarpy/consistency/consistency.py
+++ b/sarpy/consistency/consistency.py
@@ -11,6 +11,7 @@ __author__ = "Nathan Bombaci, Valkyrie"
 import collections
 import contextlib
 import linecache
+import re
 import sys
 import textwrap
 from typing import List, Dict, Callable
@@ -66,7 +67,7 @@ class ConsistencyChecker(object):
         attrs = [getattr(self, name) for name in sorted(names)]
         self.funcs = [attr for attr in attrs if hasattr(attr, '__call__')]
 
-    def check(self, func_name=None):
+    def check(self, func_name=None, *, ignore_patterns=None):
         """
         Run checks.
 
@@ -75,6 +76,8 @@ class ConsistencyChecker(object):
         func_name: None|str|List[str]
             List of check functions to run.  If omitted, then all check functions
             will be run.
+        ignore_patterns: list-like of str
+            Skips tests if zero or more characters at the beginning of their name match the regular expression patterns
         """
         # run specified test(s) or all of them
         if func_name is None:
@@ -88,6 +91,9 @@ class ConsistencyChecker(object):
                 raise ValueError("Functions not found: {}".format(not_found))
 
             funcs = [func for func in self.funcs if func.__name__ in func_name]
+
+        for pattern in (ignore_patterns or []):
+            funcs = [func for func in funcs if not re.match(pattern, func.__name__)]
 
         for func in funcs:
             self._run_check(func)

--- a/sarpy/consistency/cphd_consistency.py
+++ b/sarpy/consistency/cphd_consistency.py
@@ -321,7 +321,8 @@ class CphdConsistency(con.ConsistencyChecker):
             with open(self.filename, 'rb') as fd:
                 first_line = fd.readline().decode()
             assert first_line.startswith('CPHD/')
-            file_type_header_version = first_line.removeprefix('CPHD/').removesuffix('\n')
+            assert first_line.endswith('\n')
+            file_type_header_version = first_line[len('CPHD/'):-1]
             with self.need("version in File Type Header matches the version in the XML"):
                 assert self.version == file_type_header_version
 
@@ -1264,8 +1265,8 @@ class CphdConsistency(con.ConsistencyChecker):
 
         def check_poly(poly_elem):
             path = poly_elem.getroottree().getpath(poly_elem)
-            order_by_dim = {dim: int(order_str)
-                            for dim in (1, 2) if (order_str := poly_elem.get(f'order{dim}')) is not None}
+            order_by_dim = {dim: int(poly_elem.get(f'order{dim}'))
+                            for dim in (1, 2) if poly_elem.get(f'order{dim}') is not None}
             coef_exponents = [tuple(int(coef.get(f'exponent{dim}')) for dim in order_by_dim)
                               for coef in poly_elem.findall('./Coef')]
             repeated_coef_exponents = _get_repeated_elements(coef_exponents)
@@ -1703,7 +1704,7 @@ def main(args=None):
     parser.add_argument('--noschema', action='append_const', const='check_against_schema', dest='ignore',
                         help="Disable schema checks")
     parser.add_argument('--signal-data', action='store_true', help="Check the signal data for NaN and +/- Inf")
-    parser.add_argument('--ignore', action='extend', nargs='+', metavar='PATTERN',
+    parser.add_argument('--ignore', action='append', metavar='PATTERN',
                         help=("Skip any check matching PATTERN at the beginning of its name. Can be specified more than"
                               " once."))
     config = parser.parse_args(args)

--- a/tests/io/phase_history/test_cphd.py
+++ b/tests/io/phase_history/test_cphd.py
@@ -9,12 +9,8 @@ import numpy.testing
 from sarpy.io.phase_history.cphd import CPHDReader, CPHDReader0_3, CPHDReader1, CPHDWriter1
 from sarpy.io.phase_history.converter import open_phase_history
 import sarpy.consistency.cphd_consistency
-from sarpy.io.phase_history.cphd_schema import get_schema_path, get_default_version_string
 
 from tests import parse_file_entry
-
-DEFAULT_VERSION = get_default_version_string()
-DEFAULT_SCHEMA = get_schema_path(DEFAULT_VERSION)
 
 cphd_file_types = {}
 
@@ -142,7 +138,7 @@ def generic_writer_test(cphd_reader, the_directory):
     for signal_key in reread_signal:
         numpy.testing.assert_array_equal(read_signal[signal_key], reread_signal[signal_key])
 
-    assert not sarpy.consistency.cphd_consistency.main([written_cphd_name, '--schema', DEFAULT_SCHEMA, '--signal-data'])
+    assert not sarpy.consistency.cphd_consistency.main([written_cphd_name, '--signal-data'])
 
 
 class TestCPHD(unittest.TestCase):


### PR DESCRIPTION
# Description
This PR updates SarPy's `cphd_consistency` module in a number of ways. To attempt to reduce the integration burden, there are three commits that fix a few bugs, improve the testability, and introduce additional checks. @Darder, please let us know if the commit history is sufficient for reviewability or if you'd prefer three PRs in sequence.

<details><summary>Commit 1: Cphd consistency autodetect schema</summary>

### Dependencies
As seen in [other SarPy PRs](https://github.com/ngageoint/sarpy/pull/361#issuecomment-1409099137), there is currently a disconnect in the implementation and unittests for how missing imports (networkx, shapely) are treated for cphd_consistency:
- implementation: skips the check
- unittest: asserts the check was run regardless of import

This PR updates the unittest asserts to adjust the check behavior to actually test the implementation.

### Auto-detect schema
Currently, SarPy's unittests and `cphd_consistency` CLI assume CPHD version=1.0.1 which is odd because:
- SarPy tests are bring-your-own-data
- SarPy default's to CPHD version 1.1.0 in at least [one other place](https://github.com/ngageoint/sarpy/blob/445b935e4ba536488a4b47e93ca68f480855d972/sarpy/io/phase_history/cphd_schema/__init__.py#L13)

To resolve this, we propose making schema an optional arg in `cphd_consistency` and attempting to auto-detect the version-specific schema based on the XML instance.

### New check: `check_file_type_header`
If possible, attempt to match the file header and XML versions

<details><summary>example fail message</summary>

```
check_file_type_header: Version in File Type Header matches the version in the XML
    [Error] Need: version in File Type Header matches the version in the XML
        line#137: assert self.version == file_type_header_version
        assert '1.0.1' == '1.0QQ'
         +  where '1.0.1' = <CphdConsistency object at 0x7f2a49b4afd0>.version

```

</details>

### New `--ignore` flag for skipping tests
Skipping tests can be useful for filtering known issues from cphd_consistency output.

<details><summary>demo</summary>

```
(sarpy) 15:38:36 [sarpy] (1241)$ python -m sarpy.consistency.cphd_consistency /data/out.cphd.xml
check_against_schema: 
        The XML matches the schema.
        
    [Error] Need: Schema available for checking xml whose root tag = {http://api.nsgreg.nga.mil/schema/cphd/1.0.21}CPHD
                                                                                                                                                                                                                                                                                                                                                                                                                                
(sarpy) 15:55:47 [sarpy] (1242)$ python -m sarpy.consistency.cphd_consistency /data/out.cphd.xml --ignore check_against_schema
(sarpy) 15:55:57 [sarpy] (1243)$ 
```

</details>

</details>

<details><summary>Commit 2: CPHD Consistency - bugfix and additional checks</summary>

### Bugfix - erroneous `check_channel_dwell_exist` message
There is a disconnect between the empty-match behavior of `get_by_id` (which currently errors out) and its usage throughout `cphd_consistency` (expecting None).

This disconnect was responsible for confusing consistency messages (note the `Exception Raised`)

<details><summary>Was</summary>

```
(qa_kit) 14:06:45 [qa_kit] (1012)$ cphd_consistency /data/out.cphd.xml 
check_channel_dwell_exist_Channel_swath_6_burst_0: The referenced Dwell and COD nodes exist for channel Channel_swath_6_burst_0.
    [Error] Need: Exception Raised
```

</details>

With this bugfix and some added  detail to the message, this branch changes this to:

<details><summary>Now</summary>

```
(qa_kit) 13:20:11 [qa_kit] (1082)$ cphd_consistency /data/out.cphd.xml
check_channel_dwell_exist_Channel_swath_6_burst_0: The referenced Dwell and COD nodes exist for channel Channel_swath_6_burst_0.
    [Error] Need: /Dwell/CODTime with Identifier=Channel_swath_6_burst_0MANUALBAD exists for DwellTime in channel=Channel_swath_6_burst_0
    [Error] Need: /Dwell/DwellTime with Identifier=Channel_swath_6_burst_0MANUALBAD exists for DwellTime in channel=Channel_swath_6_burst_0
```

</details>

### Additional Checks

#### `check_identifier_uniqueness`

<details><summary>example</summary>

```
check_identifier_uniqueness: Identifier nodes are unique.
    [Pass] Need: Identifiers {'./Antenna/AntCoordFrame/Identifier'} are unique
    [Pass] Need: Identifiers {'./Antenna/AntPattern/Identifier'} are unique
    [Pass] Need: Identifiers {'./Antenna/AntPhaseCenter/Identifier'} are unique
    [Pass] Need: Identifiers {'./Channel/Parameters/Identifier'} are unique
    [Error] Need: Identifiers {'./Data/Channel/Identifier'} are unique
    [Pass] Need: Identifiers {'./Data/SupportArray/Identifier'} are unique
    [Pass] Need: Identifiers {'./Dwell/CODTime/Identifier'} are unique
    [Pass] Need: Identifiers {'./Dwell/DwellTime/Identifier'} are unique
    [Pass] Need: Identifiers {'./SceneCoordinates/ImageGrid/SegmentList/Segment/Identifier'} are unique
    [Pass] Need: Identifiers {'./TxRcv/RcvParameters/Identifier'} are unique
    [Pass] Need: Identifiers {'./TxRcv/TxWFParameters/Identifier'} are unique
    [Pass] Need: Identifiers {'./SupportArray/AntGainPhase/Identifier', './SupportArray/AddedSupportArray/Identifier', './SupportArray/IAZArray/Identifier'} are unique
```

</details>

#### `check_polynomials`

<details><summary>example</summary>

```
check_polynomials: Polynomial types are correctly specified.
    [Pass] Need: /CPHD/Antenna/AntCoordFrame/XAxisPoly/X is correctly specified
    [Pass] Need: /CPHD/Antenna/AntCoordFrame/XAxisPoly/Y is correctly specified
    [Pass] Need: /CPHD/Antenna/AntCoordFrame/XAxisPoly/Z is correctly specified
    [Pass] Need: /CPHD/Antenna/AntCoordFrame/YAxisPoly/X is correctly specified
    [Pass] Need: /CPHD/Antenna/AntCoordFrame/YAxisPoly/Y is correctly specified
    [Pass] Need: /CPHD/Antenna/AntCoordFrame/YAxisPoly/Z is correctly specified
    [Pass] Need: /CPHD/Antenna/AntPattern/GainBSPoly is correctly specified
    [Pass] Need: /CPHD/Antenna/AntPattern/EB/DCXPoly is correctly specified
    [Pass] Need: /CPHD/Antenna/AntPattern/EB/DCYPoly is correctly specified
    [Error] Need: /CPHD/Dwell/CODTime/CODTimePoly is correctly specified
        line#1209: assert not dim_coefs_above_order
    [Pass] Need: /CPHD/Dwell/DwellTime/DwellTimePoly is correctly specified
    [Pass] Need: /CPHD/Antenna/AntPattern/Array/GainPoly is correctly specified
    [Pass] Need: /CPHD/Antenna/AntPattern/Array/PhasePoly is correctly specified
    [Pass] Need: /CPHD/Antenna/AntPattern/Element/GainPoly is correctly specified
    [Pass] Need: /CPHD/Antenna/AntPattern/Element/PhasePoly is correctly specified

check_polynomials: Polynomial types are correctly specified.
    [Pass] Need: /CPHD/Antenna/AntCoordFrame/XAxisPoly/X is correctly specified
    [Pass] Need: /CPHD/Antenna/AntCoordFrame/XAxisPoly/Y is correctly specified
    [Pass] Need: /CPHD/Antenna/AntCoordFrame/XAxisPoly/Z is correctly specified
    [Pass] Need: /CPHD/Antenna/AntCoordFrame/YAxisPoly/X is correctly specified
    [Pass] Need: /CPHD/Antenna/AntCoordFrame/YAxisPoly/Y is correctly specified
    [Pass] Need: /CPHD/Antenna/AntCoordFrame/YAxisPoly/Z is correctly specified
    [Pass] Need: /CPHD/Antenna/AntPattern/GainBSPoly is correctly specified
    [Pass] Need: /CPHD/Antenna/AntPattern/EB/DCXPoly is correctly specified
    [Pass] Need: /CPHD/Antenna/AntPattern/EB/DCYPoly is correctly specified
    [Pass] Need: /CPHD/Dwell/CODTime/CODTimePoly is correctly specified
    [Error] Need: /CPHD/Dwell/DwellTime/DwellTimePoly is correctly specified
        line#1210: assert not repeated_coef_exponents
    [Pass] Need: /CPHD/Antenna/AntPattern/Array/GainPoly is correctly specified
    [Pass] Need: /CPHD/Antenna/AntPattern/Array/PhasePoly is correctly specified
    [Pass] Need: /CPHD/Antenna/AntPattern/Element/GainPoly is correctly specified
    [Pass] Need: /CPHD/Antenna/AntPattern/Element/PhasePoly is correctly specified

```

</details>

#### `check_channel_normal_signal_pvp`

<details><summary>example</summary>

```
check_channel_normal_signal_pvp_Channel_swath_10_burst_0: SIGNAL PVP = 1 for at least half of the vectors for channel Channel_swath_10_burst_0.
    [Warning] Want: SIGNAL PVP = 1 for at least half of the vectors
```

</details>

</details>

<details><summary>Commit 3: CPHD Consistency - ToaExtSaved</summary>

### New `TOAExtended.TOAExtSaved` check

<details><summary>example</summary>

```
check_channel_toaextsaved_1: PVP agrees with TOAExtSaved for channel 1.
    [Warning] Want: TOA extended swath parameters are specified together
    [Skip] Unmet: assert {'TOAE1', 'TOAE2'}.issubset(pvp.dtype.fields)

```

</details>

### New optional PVPs checks

<details><summary>check_optional_pvps_fx</summary>

```
check_optional_pvps_fx: 
        FXN1 & FXN2 PVPs are included appropriately.
        
    [Error] Need: FXN1/FXN2 only allowed when /Global/DomainType = FX and must be included together
```

</details>

<details><summary>check_optional_pvps_toa</summary>

```
check_optional_pvps_toa: 
        TOAE1 & TOAE2 PVPs are included appropriately.
        
    [Error] Need: TOAE1/TOAE2 must be included together
```

</details>

### Other changes
- adds `passes` and `skips` to `ConsistencyChecker` (akin to `failures`; used for stronger asserts in unittests)
- simplify `pytest.skip` usage in `test_cphd_consistency`

</details>

# Test Plan
I ran SarPy's test suite in a python=3.10 environment with `SARPY_TEST_PATH` set and unset, and in an environment without lxml & networkx

<details><summary>With SARPY_TEST_PATH</summary>

```
======================================================================================================================================================================================================================================= test session starts =======================================================================================================================================================================================================================================
platform linux -- Python 3.10.9, pytest-7.1.2, pluggy-1.0.0
rootdir: /home/vscuser/git/glweb/software/third-party/sarpy
plugins: cov-3.0.0
collected 132 items                                                                                                                                                                                                                                                                                                                                                                                                                                                                               

pytests/test_consistency.py ........                                                                                                                                                                                                                                                                                                                                                                                                                                                        [  6%]
pytests/test_cphd_consistency.py ...................................................                                                                                                                                                                                                                                                                                                                                                                                                        [ 44%]
tests/test_class_string.py .                                                                                                                                                                                                                                                                                                                                                                                                                                                                [ 45%]
tests/geometry/test_geocoords.py ...                                                                                                                                                                                                                                                                                                                                                                                                                                                        [ 47%]
tests/geometry/test_geometry_elements.py ....                                                                                                                                                                                                                                                                                                                                                                                                                                               [ 50%]
tests/geometry/test_latlon.py ...                                                                                                                                                                                                                                                                                                                                                                                                                                                           [ 53%]
tests/io/DEM/test_geoid.py s                                                                                                                                                                                                                                                                                                                                                                                                                                                                [ 53%]
tests/io/complex/test_reader.py sssssssssss                                                                                                                                                                                                                                                                                                                                                                                                                                                 [ 62%]
tests/io/complex/test_remote.py .                                                                                                                                                                                                                                                                                                                                                                                                                                                           [ 62%]
tests/io/complex/test_sicd.py s                                                                                                                                                                                                                                                                                                                                                                                                                                                             [ 63%]
tests/io/complex/test_utils.py .                                                                                                                                                                                                                                                                                                                                                                                                                                                            [ 64%]
tests/io/general/test_base.py ...                                                                                                                                                                                                                                                                                                                                                                                                                                                           [ 66%]
tests/io/general/test_data_segment.py ..........                                                                                                                                                                                                                                                                                                                                                                                                                                            [ 74%]
tests/io/general/test_format_function.py .......                                                                                                                                                                                                                                                                                                                                                                                                                                            [ 79%]
tests/io/general/test_nitf_headers.py s                                                                                                                                                                                                                                                                                                                                                                                                                                                     [ 80%]
tests/io/general/test_tre.py .                                                                                                                                                                                                                                                                                                                                                                                                                                                              [ 81%]
tests/io/phase_history/test_cphd.py .                                                                                                                                                                                                                                                                                                                                                                                                                                                       [ 81%]
tests/io/phase_history/cphd1_elements/test_utils.py .                                                                                                                                                                                                                                                                                                                                                                                                                                       [ 82%]
tests/io/product/test_reader.py s                                                                                                                                                                                                                                                                                                                                                                                                                                                           [ 83%]
tests/io/product/test_sidd_writing.py s                                                                                                                                                                                                                                                                                                                                                                                                                                                     [ 84%]
tests/io/received/test_crsd.py s                                                                                                                                                                                                                                                                                                                                                                                                                                                            [ 84%]
tests/visualization/test_remap.py ....................                                                                                                                                                                                                                                                                                                                                                                                                                                      [100%]

======================================================================================================================================================================================================================================== warnings summary =========================================================================================================================================================================================================================================
tests/visualization/test_remap.py::TestRemap::test_LUTRemap_matplotlib
tests/visualization/test_remap.py::TestRemap::test_remap_names
tests/visualization/test_remap.py::TestRemap::test_remap_names
tests/visualization/test_remap.py::TestRemap::test_remap_names
tests/visualization/test_remap.py::TestRemap::test_remap_names
  /home/vscuser/miniconda3/envs/sarpy/lib/python3.10/site-packages/sarpy-1.3.16-py3.10.egg/sarpy/visualization/remap.py:1562: PendingDeprecationWarning: The get_cmap function will be deprecated in a future version. Use ``matplotlib.colormaps[name]`` or ``matplotlib.colormaps.get_cmap(obj)`` instead.
    cmap = cm.get_cmap(value, max_out_size+1)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================================================================================================================================================================================== 115 passed, 17 skipped, 5 warnings in 16.71s ===========================================================================================================================================================================================================================

```

</details>

<details><summary>Without SARPY_TEST_PATH</summary>

```
======================================================================================================================================================================================================================================= test session starts =======================================================================================================================================================================================================================================
platform linux -- Python 3.10.9, pytest-7.1.2, pluggy-1.0.0
rootdir: /home/vscuser/git/glweb/software/third-party/sarpy
plugins: cov-3.0.0
collected 130 items                                                                                                                                                                                                                                                                                                                                                                                                                                                                               

pytests/test_consistency.py ........                                                                                                                                                                                                                                                                                                                                                                                                                                                        [  6%]
pytests/test_cphd_consistency.py sssssssssssssssssssssssssssssssssssssssssssssssss                                                                                                                                                                                                                                                                                                                                                                                                          [ 43%]
tests/test_class_string.py .                                                                                                                                                                                                                                                                                                                                                                                                                                                                [ 44%]
tests/geometry/test_geocoords.py ...                                                                                                                                                                                                                                                                                                                                                                                                                                                        [ 46%]
tests/geometry/test_geometry_elements.py ....                                                                                                                                                                                                                                                                                                                                                                                                                                               [ 50%]
tests/geometry/test_latlon.py ...                                                                                                                                                                                                                                                                                                                                                                                                                                                           [ 52%]
tests/io/DEM/test_geoid.py s                                                                                                                                                                                                                                                                                                                                                                                                                                                                [ 53%]
tests/io/complex/test_reader.py sssssssssss                                                                                                                                                                                                                                                                                                                                                                                                                                                 [ 61%]
tests/io/complex/test_remote.py .                                                                                                                                                                                                                                                                                                                                                                                                                                                           [ 62%]
tests/io/complex/test_sicd.py s                                                                                                                                                                                                                                                                                                                                                                                                                                                             [ 63%]
tests/io/complex/test_utils.py .                                                                                                                                                                                                                                                                                                                                                                                                                                                            [ 63%]
tests/io/general/test_base.py ...                                                                                                                                                                                                                                                                                                                                                                                                                                                           [ 66%]
tests/io/general/test_data_segment.py ..........                                                                                                                                                                                                                                                                                                                                                                                                                                            [ 73%]
tests/io/general/test_format_function.py .......                                                                                                                                                                                                                                                                                                                                                                                                                                            [ 79%]
tests/io/general/test_nitf_headers.py s                                                                                                                                                                                                                                                                                                                                                                                                                                                     [ 80%]
tests/io/general/test_tre.py .                                                                                                                                                                                                                                                                                                                                                                                                                                                              [ 80%]
tests/io/phase_history/test_cphd.py s                                                                                                                                                                                                                                                                                                                                                                                                                                                       [ 81%]
tests/io/phase_history/cphd1_elements/test_utils.py .                                                                                                                                                                                                                                                                                                                                                                                                                                       [ 82%]
tests/io/product/test_reader.py s                                                                                                                                                                                                                                                                                                                                                                                                                                                           [ 83%]
tests/io/product/test_sidd_writing.py s                                                                                                                                                                                                                                                                                                                                                                                                                                                     [ 83%]
tests/io/received/test_crsd.py s                                                                                                                                                                                                                                                                                                                                                                                                                                                            [ 84%]
tests/visualization/test_remap.py ....................                                                                                                                                                                                                                                                                                                                                                                                                                                      [100%]

======================================================================================================================================================================================================================================== warnings summary =========================================================================================================================================================================================================================================
tests/visualization/test_remap.py::TestRemap::test_LUTRemap_matplotlib
tests/visualization/test_remap.py::TestRemap::test_remap_names
tests/visualization/test_remap.py::TestRemap::test_remap_names
tests/visualization/test_remap.py::TestRemap::test_remap_names
tests/visualization/test_remap.py::TestRemap::test_remap_names
  /home/vscuser/miniconda3/envs/sarpy/lib/python3.10/site-packages/sarpy-1.3.16-py3.10.egg/sarpy/visualization/remap.py:1562: PendingDeprecationWarning: The get_cmap function will be deprecated in a future version. Use ``matplotlib.colormaps[name]`` or ``matplotlib.colormaps.get_cmap(obj)`` instead.
    cmap = cm.get_cmap(value, max_out_size+1)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================================================================================================================================================================================================================== 63 passed, 67 skipped, 5 warnings in 13.41s ===========================================================================================================================================================================================================================

```

</details>