### PR TITLE
Add point projection tests

### DIFF
--- a/tests/data/example.sicd.xml
+++ b/tests/data/example.sicd.xml
@@ -1,0 +1,1017 @@
+<SICD xmlns="urn:SICD:1.2.1">
+    <CollectionInfo>
+        <CollectorName>Synthetic</CollectorName>
+        <CoreName>SyntheticCore</CoreName>
+        <CollectType>MONOSTATIC</CollectType>
+        <RadarMode>
+            <ModeType>SPOTLIGHT</ModeType>
+        </RadarMode>
+        <Classification>UNCLASSIFIED</Classification>
+    </CollectionInfo>
+    <ImageCreation>
+        <Application>Valkyrie Systems Sage | sar_common_kit 1.9.0.0</Application>
+        <DateTime>2022-12-05T18:43:30.208726Z</DateTime>
+    </ImageCreation>
+    <ImageData>
+        <PixelType>RE32F_IM32F</PixelType>
+        <NumRows>1494</NumRows>
+        <NumCols>1723</NumCols>
+        <FirstRow>0</FirstRow>
+        <FirstCol>0</FirstCol>
+        <FullImage>
+            <NumRows>1494</NumRows>
+            <NumCols>1723</NumCols>
+        </FullImage>
+        <SCPPixel>
+            <Row>747</Row>
+            <Col>861</Col>
+        </SCPPixel>
+        <ValidData size="32">
+            <Vertex index="1">
+                <Row>256</Row>
+                <Col>343</Col>
+            </Vertex>
+            <Vertex index="2">
+                <Row>256</Row>
+                <Col>484</Col>
+            </Vertex>
+            <Vertex index="3">
+                <Row>256</Row>
+                <Col>624</Col>
+            </Vertex>
+            <Vertex index="4">
+                <Row>256</Row>
+                <Col>765</Col>
+            </Vertex>
+            <Vertex index="5">
+                <Row>256</Row>
+                <Col>905</Col>
+            </Vertex>
+            <Vertex index="6">
+                <Row>256</Row>
+                <Col>1046</Col>
+            </Vertex>
+            <Vertex index="7">
+                <Row>256</Row>
+                <Col>1186</Col>
+            </Vertex>
+            <Vertex index="8">
+                <Row>256</Row>
+                <Col>1327</Col>
+            </Vertex>
+            <Vertex index="9">
+                <Row>256</Row>
+                <Col>1468</Col>
+            </Vertex>
+            <Vertex index="10">
+                <Row>379</Row>
+                <Col>1456</Col>
+            </Vertex>
+            <Vertex index="11">
+                <Row>502</Row>
+                <Col>1445</Col>
+            </Vertex>
+            <Vertex index="12">
+                <Row>624</Row>
+                <Col>1434</Col>
+            </Vertex>
+            <Vertex index="13">
+                <Row>747</Row>
+                <Col>1423</Col>
+            </Vertex>
+            <Vertex index="14">
+                <Row>870</Row>
+                <Col>1412</Col>
+            </Vertex>
+            <Vertex index="15">
+                <Row>992</Row>
+                <Col>1401</Col>
+            </Vertex>
+            <Vertex index="16">
+                <Row>1115</Row>
+                <Col>1390</Col>
+            </Vertex>
+            <Vertex index="17">
+                <Row>1238</Row>
+                <Col>1378</Col>
+            </Vertex>
+            <Vertex index="18">
+                <Row>1238</Row>
+                <Col>1238</Col>
+            </Vertex>
+            <Vertex index="19">
+                <Row>1238</Row>
+                <Col>1097</Col>
+            </Vertex>
+            <Vertex index="20">
+                <Row>1238</Row>
+                <Col>957</Col>
+            </Vertex>
+            <Vertex index="21">
+                <Row>1238</Row>
+                <Col>817</Col>
+            </Vertex>
+            <Vertex index="22">
+                <Row>1238</Row>
+                <Col>676</Col>
+            </Vertex>
+            <Vertex index="23">
+                <Row>1238</Row>
+                <Col>536</Col>
+            </Vertex>
+            <Vertex index="24">
+                <Row>1238</Row>
+                <Col>395</Col>
+            </Vertex>
+            <Vertex index="25">
+                <Row>1238</Row>
+                <Col>255</Col>
+            </Vertex>
+            <Vertex index="26">
+                <Row>1115</Row>
+                <Col>266</Col>
+            </Vertex>
+            <Vertex index="27">
+                <Row>992</Row>
+                <Col>277</Col>
+            </Vertex>
+            <Vertex index="28">
+                <Row>870</Row>
+                <Col>288</Col>
+            </Vertex>
+            <Vertex index="29">
+                <Row>747</Row>
+                <Col>299</Col>
+            </Vertex>
+            <Vertex index="30">
+                <Row>624</Row>
+                <Col>310</Col>
+            </Vertex>
+            <Vertex index="31">
+                <Row>502</Row>
+                <Col>321</Col>
+            </Vertex>
+            <Vertex index="32">
+                <Row>379</Row>
+                <Col>332</Col>
+            </Vertex>
+        </ValidData>
+    </ImageData>
+    <GeoData>
+        <EarthModel>WGS_84</EarthModel>
+        <SCP>
+            <ECF>
+                <X>6378137</X>
+                <Y>0</Y>
+                <Z>0</Z>
+            </ECF>
+            <LLH>
+                <Lat>0</Lat>
+                <Lon>0</Lon>
+                <HAE>0</HAE>
+            </LLH>
+        </SCP>
+        <ImageCorners>
+            <ICP index="1:FRFC">
+                <Lat>0.0080807974971151136</Lat>
+                <Lon>-0.0061258326901634519</Lon>
+            </ICP>
+            <ICP index="2:FRLC">
+                <Lat>0.0056733384282420182</Lat>
+                <Lon>0.0074368679872295704</Lon>
+            </ICP>
+            <ICP index="3:LRLC">
+                <Lat>-0.008071597406306948</Lat>
+                <Lon>0.0061267096368526897</Lon>
+            </ICP>
+            <ICP index="4:LRFC">
+                <Lat>-0.0056641383373949505</Lat>
+                <Lon>-0.0074359910405444127</Lon>
+            </ICP>
+        </ImageCorners>
+        <ValidData size="32">
+            <Vertex index="1">
+                <Lat>0.005238360895824838</Lat>
+                <Lon>-0.0036433852169764111</Lon>
+            </Vertex>
+            <Vertex index="2">
+                <Lat>0.0050420582635510016</Lat>
+                <Lon>-0.0025375503997010318</Lon>
+            </Vertex>
+            <Vertex index="3">
+                <Lat>0.004845755628902701</Lat>
+                <Lon>-0.0014317155805202205</Lon>
+            </Vertex>
+            <Vertex index="4">
+                <Lat>0.0046494529921086835</Lat>
+                <Lon>-0.00032588076026081428</Lon>
+            </Vertex>
+            <Vertex index="5">
+                <Lat>0.0044531503533953975</Lat>
+                <Lon>0.00077995406025051814</Lon>
+            </Vertex>
+            <Vertex index="6">
+                <Lat>0.0042568477129873231</Lat>
+                <Lon>0.0018857888801836113</Lon>
+            </Vertex>
+            <Vertex index="7">
+                <Lat>0.004060545071107439</Lat>
+                <Lon>0.0029916236987124986</Lon>
+            </Vertex>
+            <Vertex index="8">
+                <Lat>0.0038642424279800454</Lat>
+                <Lon>0.0040974585150061532</Lon>
+            </Vertex>
+            <Vertex index="9">
+                <Lat>0.003667939783831225</Lat>
+                <Lon>0.0052032933282371652</Lon>
+            </Vertex>
+            <Vertex index="10">
+                <Lat>0.0025546522020080289</Lat>
+                <Lon>0.0050083048147242385</Lon>
+            </Vertex>
+            <Vertex index="11">
+                <Lat>0.0014413646175311253</Lat>
+                <Lon>0.0048133163010931164</Lon>
+            </Vertex>
+            <Vertex index="12">
+                <Lat>0.00032807703126864579</Lat>
+                <Lon>0.0046183277873471356</Lon>
+            </Vertex>
+            <Vertex index="13">
+                <Lat>-0.00078521055587245359</Lat>
+                <Lon>0.0044233392734964747</Lon>
+            </Vertex>
+            <Vertex index="14">
+                <Lat>-0.0018984981430081194</Lat>
+                <Lon>0.0042283507595426628</Lon>
+            </Vertex>
+            <Vertex index="15">
+                <Lat>-0.003011785729254395</Lat>
+                <Lon>0.0040333622454942607</Lon>
+            </Vertex>
+            <Vertex index="16">
+                <Lat>-0.0041250733137164937</Lat>
+                <Lon>0.0038383737313532821</Lon>
+            </Vertex>
+            <Vertex index="17">
+                <Lat>-0.0052383608955085424</Lat>
+                <Lon>0.003643385217128532</Lon>
+            </Vertex>
+            <Vertex index="18">
+                <Lat>-0.0050420582632763646</Lat>
+                <Lon>0.0025375503997804791</Lon>
+            </Vertex>
+            <Vertex index="19">
+                <Lat>-0.0048457556287156058</Lat>
+                <Lon>0.0014317155805582487</Lon>
+            </Vertex>
+            <Vertex index="20">
+                <Lat>-0.0046494529920602899</Lat>
+                <Lon>0.00032588076028108935</Lon>
+            </Vertex>
+            <Vertex index="21">
+                <Lat>-0.0044531503535271385</Lat>
+                <Lon>-0.00077995406023062997</Lon>
+            </Vertex>
+            <Vertex index="22">
+                <Lat>-0.0042568477133461038</Lat>
+                <Lon>-0.0018857888801565275</Lon>
+            </Vertex>
+            <Vertex index="23">
+                <Lat>-0.0040605450717476526</Lat>
+                <Lon>-0.0029916236986777789</Lon>
+            </Vertex>
+            <Vertex index="24">
+                <Lat>-0.0038642424289528294</Lat>
+                <Lon>-0.004097458514977414</Lon>
+            </Vertex>
+            <Vertex index="25">
+                <Lat>-0.0036679397851883686</Lat>
+                <Lon>-0.0052032933282338163</Lon>
+            </Vertex>
+            <Vertex index="26">
+                <Lat>-0.0025546522030494749</Lat>
+                <Lon>-0.0050083048147000261</Lon>
+            </Vertex>
+            <Vertex index="27">
+                <Lat>-0.0014413646182779216</Lat>
+                <Lon>-0.0048133163010521838</Lon>
+            </Vertex>
+            <Vertex index="28">
+                <Lat>-0.00032807703177041223</Lat>
+                <Lon>-0.0046183277872955016</Lon>
+            </Vertex>
+            <Vertex index="29">
+                <Lat>0.00078521055559128701</Lat>
+                <Lon>-0.0044233392734311441</Lon>
+            </Vertex>
+            <Vertex index="30">
+                <Lat>0.0018984981429170419</Lat>
+                <Lon>-0.0042283507594636036</Lon>
+            </Vertex>
+            <Vertex index="31">
+                <Lat>0.003011785729324451</Lat>
+                <Lon>-0.0040333622453953642</Lon>
+            </Vertex>
+            <Vertex index="32">
+                <Lat>0.0041250733139214331</Lat>
+                <Lon>-0.0038383737312319729</Lon>
+            </Vertex>
+        </ValidData>
+        <GeoInfo name="synthetic_targets">
+            <GeoInfo name="target0">
+                <Desc name="ecef">[6378137.0, -405.5797876726389, 579.2279653395692]</Desc>
+            </GeoInfo>
+            <GeoInfo name="target1">
+                <Desc name="ecef">[6378137.0, 86.82408883346518, 492.403876506104]</Desc>
+            </GeoInfo>
+            <GeoInfo name="target2">
+                <Desc name="ecef">[6378137.0, 579.2279653395692, 405.5797876726388]</Desc>
+            </GeoInfo>
+            <GeoInfo name="target3">
+                <Desc name="ecef">[6378137.0, -492.40387650610404, 86.8240888334652]</Desc>
+            </GeoInfo>
+            <GeoInfo name="target4">
+                <Desc name="ecef">[6378137.0, 0.0, 0.0]</Desc>
+            </GeoInfo>
+            <GeoInfo name="target5">
+                <Desc name="ecef">[6378137.0, 492.40387650610404, -86.8240888334652]</Desc>
+            </GeoInfo>
+            <GeoInfo name="target6">
+                <Desc name="ecef">[6378137.0, -579.2279653395692, -405.5797876726388]</Desc>
+            </GeoInfo>
+            <GeoInfo name="target7">
+                <Desc name="ecef">[6378137.0, -86.82408883346518, -492.403876506104]</Desc>
+            </GeoInfo>
+            <GeoInfo name="target8">
+                <Desc name="ecef">[6378137.0, 405.5797876726389, -579.2279653395692]</Desc>
+            </GeoInfo>
+        </GeoInfo>
+    </GeoData>
+    <Grid>
+        <ImagePlane>SLANT</ImagePlane>
+        <Type>RGAZIM</Type>
+        <TimeCOAPoly order1="0" order2="0">
+            <Coef exponent1="0" exponent2="0">1.6800674762530383</Coef>
+        </TimeCOAPoly>
+        <Row>
+            <UVectECF>
+                <X>-0.50000122375786304</X>
+                <Y>-0.15037583977714006</Y>
+                <Z>-0.8528692064148875</Z>
+            </UVectECF>
+            <SS>0.88229809656554448</SS>
+            <ImpRespWid>0.99747529707162585</ImpRespWid>
+            <Sgn>-1</Sgn>
+            <ImpRespBW>0.88798408351600244</ImpRespBW>
+            <KCtr>66.712157247222834</KCtr>
+            <DeltaK1>-0.44399204175799412</DeltaK1>
+            <DeltaK2>0.44399204175800833</DeltaK2>
+            <DeltaKCOAPoly order1="0" order2="0">
+                <Coef exponent1="0" exponent2="0">-0</Coef>
+            </DeltaKCOAPoly>
+        </Row>
+        <Col>
+            <UVectECF>
+                <X>-0.13518643844872713</X>
+                <Y>0.98628938466763816</Y>
+                <Z>-0.094646059985916131</Z>
+            </UVectECF>
+            <SS>0.8788669876603048</SS>
+            <ImpRespWid>0.99666461341322399</ImpRespWid>
+            <Sgn>-1</Sgn>
+            <ImpRespBW>0.88870636679539183</ImpRespBW>
+            <KCtr>1.3449549529642717e-08</KCtr>
+            <DeltaK1>-0.44435318339769592</DeltaK1>
+            <DeltaK2>0.44435318339769592</DeltaK2>
+            <DeltaKCOAPoly order1="0" order2="0">
+                <Coef exponent1="0" exponent2="0">-0</Coef>
+            </DeltaKCOAPoly>
+        </Col>
+    </Grid>
+    <Timeline>
+        <CollectStart>2022-12-05T18:41:24.051402Z</CollectStart>
+        <CollectDuration>3.4668291025146964</CollectDuration>
+        <IPP size="1">
+            <Set index="1">
+                <TStart>0.0056816659534297907</TStart>
+                <TEnd>3.4628234234795321</TEnd>
+                <IPPStart>0</IPPStart>
+                <IPPEnd>2080</IPPEnd>
+                <IPPPoly order1="5">
+                    <Coef exponent1="0">-3.4200358124461596</Coef>
+                    <Coef exponent1="1">601.94243049797956</Coef>
+                    <Coef exponent1="2">-2.5957560931224679e-05</Coef>
+                    <Coef exponent1="3">-2.0559365748016132e-08</Coef>
+                    <Coef exponent1="4">8.5465035653447778e-11</Coef>
+                    <Coef exponent1="5">1.5613913034987107e-13</Coef>
+                </IPPPoly>
+            </Set>
+        </IPP>
+    </Timeline>
+    <Position>
+        <ARPPoly>
+            <X order1="5">
+                <Coef exponent1="0">7228127.9124448663</Coef>
+                <Coef exponent1="1">352.53242998756502</Coef>
+                <Coef exponent1="2">-3.5891719134975157</Coef>
+                <Coef exponent1="3">-5.7694198643316104e-05</Coef>
+                <Coef exponent1="4">2.7699968593303768e-07</Coef>
+                <Coef exponent1="5">2.1592636134572539e-09</Coef>
+            </X>
+            <Y order1="5">
+                <Coef exponent1="0">268129.91744542622</Coef>
+                <Coef exponent1="1">-7332.3823879634392</Coef>
+                <Coef exponent1="2">-0.13313219332893028</Coef>
+                <Coef exponent1="3">0.0012135963117010783</Coef>
+                <Coef exponent1="4">1.0196690368353028e-08</Coef>
+                <Coef exponent1="5">1.3607911396273635e-11</Coef>
+            </Y>
+            <Z order1="5">
+                <Coef exponent1="0">1451527.4824241539</Coef>
+                <Coef exponent1="1">-401.08990372640221</Coef>
+                <Coef exponent1="2">-0.72076439428225647</Coef>
+                <Coef exponent1="3">6.6511087447480695e-05</Coef>
+                <Coef exponent1="4">5.6690990559856781e-08</Coef>
+                <Coef exponent1="5">3.2123861103114586e-10</Coef>
+            </Z>
+        </ARPPoly>
+        <GRPPoly>
+            <X order1="4">
+                <Coef exponent1="0">6378136.9999999972</Coef>
+                <Coef exponent1="1">-2.7603991862673482e-10</Coef>
+                <Coef exponent1="2">-8.8046691538817019e-10</Coef>
+                <Coef exponent1="3">3.6552842678534889e-10</Coef>
+                <Coef exponent1="4">-4.5501609492503518e-13</Coef>
+            </X>
+            <Y order1="4">
+                <Coef exponent1="0">0</Coef>
+                <Coef exponent1="1">0</Coef>
+                <Coef exponent1="2">0</Coef>
+                <Coef exponent1="3">0</Coef>
+                <Coef exponent1="4">0</Coef>
+            </Y>
+            <Z order1="4">
+                <Coef exponent1="0">0</Coef>
+                <Coef exponent1="1">0</Coef>
+                <Coef exponent1="2">0</Coef>
+                <Coef exponent1="3">0</Coef>
+                <Coef exponent1="4">0</Coef>
+            </Z>
+        </GRPPoly>
+        <TxAPCPoly>
+            <X order1="5">
+                <Coef exponent1="0">7228127.9122881154</Coef>
+                <Coef exponent1="1">352.53243031729494</Coef>
+                <Coef exponent1="2">-3.5891718145261389</Coef>
+                <Coef exponent1="3">-5.7760778794926364e-05</Coef>
+                <Coef exponent1="4">2.961407356089768e-07</Coef>
+                <Coef exponent1="5">1.5152746784999351e-10</Coef>
+            </X>
+            <Y order1="5">
+                <Coef exponent1="0">268129.91754994984</Coef>
+                <Coef exponent1="1">-7332.3823894408897</Coef>
+                <Coef exponent1="2">-0.13313219336015877</Coef>
+                <Coef exponent1="3">0.0012135939299440443</Coef>
+                <Coef exponent1="4">1.0894413139775905e-08</Coef>
+                <Coef exponent1="5">-6.1574812416329165e-11</Coef>
+            </Y>
+            <Z order1="5">
+                <Coef exponent1="0">1451527.4820069293</Coef>
+                <Coef exponent1="1">-401.0899032701904</Coef>
+                <Coef exponent1="2">-0.72076438617145899</Coef>
+                <Coef exponent1="3">6.6502336106517436e-05</Coef>
+                <Coef exponent1="4">5.9235211780521735e-08</Coef>
+                <Coef exponent1="5">4.8536679801755301e-11</Coef>
+            </Z>
+        </TxAPCPoly>
+        <RcvAPC size="1">
+            <RcvAPCPoly index="1">
+                <X order1="5">
+                    <Coef exponent1="0">7228127.9122881237</Coef>
+                    <Coef exponent1="1">352.53243031084878</Coef>
+                    <Coef exponent1="2">-3.5891718013492584</Coef>
+                    <Coef exponent1="3">-5.7769234785477141e-05</Coef>
+                    <Coef exponent1="4">2.985788077956373e-07</Coef>
+                    <Coef exponent1="5">-1.4884336849092922e-10</Coef>
+                </X>
+                <Y order1="5">
+                    <Coef exponent1="0">268129.91754994984</Coef>
+                    <Coef exponent1="1">-7332.3823894398674</Coef>
+                    <Coef exponent1="2">-0.13313219479068839</Coef>
+                    <Coef exponent1="3">0.0012135948482529309</Coef>
+                    <Coef exponent1="4">1.0630300780216877e-08</Coef>
+                    <Coef exponent1="5">-3.4535962553841784e-11</Coef>
+                </Y>
+                <Z order1="5">
+                    <Coef exponent1="0">1451527.4820069303</Coef>
+                    <Coef exponent1="1">-401.08990326673984</Coef>
+                    <Coef exponent1="2">-0.72076439093449318</Coef>
+                    <Coef exponent1="3">6.6505493849440306e-05</Coef>
+                    <Coef exponent1="4">5.8315612455559405e-08</Coef>
+                    <Coef exponent1="5">1.3835573401835279e-10</Coef>
+                </Z>
+            </RcvAPCPoly>
+        </RcvAPC>
+    </Position>
+    <RadarCollection>
+        <TxFrequency>
+            <Min>9933296178.0950012</Min>
+            <Max>10066703821.904999</Max>
+        </TxFrequency>
+        <Waveform size="1">
+            <WFParameters index="1"/>
+        </Waveform>
+        <TxPolarization>V</TxPolarization>
+        <RcvChannels size="1">
+            <ChanParameters index="1">
+                <TxRcvPolarization>V:V</TxRcvPolarization>
+                <RcvAPCIndex>1</RcvAPCIndex>
+            </ChanParameters>
+        </RcvChannels>
+        <Area>
+            <Corner>
+                <ACP index="1">
+                    <Lat>0.0052383608956667301</Lat>
+                    <Lon>-0.0036433852170520572</Lon>
+                    <HAE>0.039373653940856457</HAE>
+                </ACP>
+                <ACP index="2">
+                    <Lat>0.0036679397845088379</Lat>
+                    <Lon>0.0052032933282355155</Lon>
+                    <HAE>0.039283305406570435</HAE>
+                </ACP>
+                <ACP index="3">
+                    <Lat>-0.0052383608956667301</Lat>
+                    <Lon>0.0036433852170520572</Lon>
+                    <HAE>0.039373653940856457</HAE>
+                </ACP>
+                <ACP index="4">
+                    <Lat>-0.0036679397845088379</Lat>
+                    <Lon>-0.0052032933282355155</Lon>
+                    <HAE>0.039283305406570435</HAE>
+                </ACP>
+            </Corner>
+            <Plane>
+                <RefPt>
+                    <ECF>
+                        <X>6378137</X>
+                        <Y>0</Y>
+                        <Z>0</Z>
+                    </ECF>
+                    <Line>650</Line>
+                    <Sample>750</Sample>
+                </RefPt>
+                <XDir>
+                    <UVectECF>
+                        <X>0</X>
+                        <Y>-0.17364817766693033</Y>
+                        <Z>-0.98480775301220813</Z>
+                    </UVectECF>
+                    <LineSpacing>0.76980043496519579</LineSpacing>
+                    <NumLines>1301</NumLines>
+                    <FirstLine>0</FirstLine>
+                </XDir>
+                <YDir>
+                    <UVectECF>
+                        <X>0</X>
+                        <Y>0.98480775301220813</Y>
+                        <Z>-0.17364817766693033</Z>
+                    </UVectECF>
+                    <SampleSpacing>0.66641108974957253</SampleSpacing>
+                    <NumSamples>1501</NumSamples>
+                    <FirstSample>0</FirstSample>
+                </YDir>
+            </Plane>
+        </Area>
+    </RadarCollection>
+    <ImageFormation>
+        <RcvChanProc>
+            <NumChanProc>1</NumChanProc>
+            <ChanIndex>1</ChanIndex>
+        </RcvChanProc>
+        <TxRcvPolarizationProc>V:V</TxRcvPolarizationProc>
+        <TStartProc>0.0056816659534327432</TStartProc>
+        <TEndProc>3.4611621345438324</TEndProc>
+        <TxFrequencyProc>
+            <MinProc>9933296178.0950298</MinProc>
+            <MaxProc>10066703821.905016</MaxProc>
+        </TxFrequencyProc>
+        <ImageFormAlgo>PFA</ImageFormAlgo>
+        <STBeamComp>NO</STBeamComp>
+        <ImageBeamComp>NO</ImageBeamComp>
+        <AzAutofocus>NO</AzAutofocus>
+        <RgAutofocus>NO</RgAutofocus>
+        <Processing>
+            <Type>inscription</Type>
+            <Applied>true</Applied>
+            <Parameter name="krange">fixed</Parameter>
+            <Parameter name="kazimuth">fixed</Parameter>
+        </Processing>
+        <Processing>
+            <Type>polar_deterministic_phase</Type>
+            <Applied>true</Applied>
+            <Parameter name="phase_contiguous">true</Parameter>
+            <Parameter name="quadratic_type">none</Parameter>
+            <Parameter name="linear_type">none</Parameter>
+            <Parameter name="constant_type">one_dimensional</Parameter>
+        </Processing>
+    </ImageFormation>
+    <SCPCOA>
+        <SCPTime>1.6800674762530383</SCPTime>
+        <ARPPos>
+            <X>7228710.0595508879</X>
+            <Y>255810.65024467336</Y>
+            <Z>1450851.5901888732</Z>
+        </ARPPos>
+        <ARPVel>
+            <X>340.47184478328006</X>
+            <Y>-7332.8194533174392</Y>
+            <Z>-403.5112050640754</Z>
+        </ARPVel>
+        <ARPAcc>
+            <X>-7.1789158206813477</X>
+            <Y>-0.25403049783428427</Y>
+            <Z>-1.4408563791978921</Z>
+        </ARPAcc>
+        <SideOfTrack>L</SideOfTrack>
+        <SlantRange>1701141.9562064605</SlantRange>
+        <GroundRange>1282320.3392587577</GroundRange>
+        <DopplerConeAng>80.000333057346595</DopplerConeAng>
+        <GrazeAng>30.000080950049</GrazeAng>
+        <IncidenceAng>59.999919049951004</IncidenceAng>
+        <TwistAng>8.9805970546123763</TwistAng>
+        <SlopeAng>31.195125856239255</SlopeAng>
+        <AzimAng>9.9994779614198173</AzimAng>
+        <LayoverAng>352.45909403041333</LayoverAng>
+    </SCPCOA>
+    <Antenna>
+        <Tx>
+            <XAxisPoly>
+                <X order1="5">
+                    <Coef exponent1="0">0.13982986262005959</Coef>
+                    <Coef exponent1="1">-0.0027594341203054122</Coef>
+                    <Coef exponent1="2">-2.642141233211328e-06</Coef>
+                    <Coef exponent1="3">1.4412928975132546e-08</Coef>
+                    <Coef exponent1="4">4.9106827976192821e-11</Coef>
+                    <Coef exponent1="5">-1.1406011989724555e-13</Coef>
+                </X>
+                <Y order1="5">
+                    <Coef exponent1="0">-0.985103968766331</Coef>
+                    <Coef exponent1="1">-0.00072022999981332595</Coef>
+                    <Coef exponent1="2">8.6929909937280073e-06</Coef>
+                    <Coef exponent1="3">1.7419413461433799e-08</Coef>
+                    <Coef exponent1="4">-7.0195266020811239e-11</Coef>
+                    <Coef exponent1="5">-3.1383419971071391e-13</Coef>
+                </Y>
+                <Z order1="5">
+                    <Coef exponent1="0">0.10008886172036295</Coef>
+                    <Coef exponent1="1">-0.0032336279155612555</Coef>
+                    <Coef exponent1="2">-3.6150726160461875e-06</Coef>
+                    <Coef exponent1="3">2.4227194540266762e-08</Coef>
+                    <Coef exponent1="4">6.8535490141060762e-11</Coef>
+                    <Coef exponent1="5">-1.9455706113121084e-13</Coef>
+                </Z>
+            </XAxisPoly>
+            <YAxisPoly>
+                <X order1="5">
+                    <Coef exponent1="0">-0.85523535607199153</Coef>
+                    <Coef exponent1="1">-0.00010473716447760117</Coef>
+                    <Coef exponent1="2">1.0612386361416289e-06</Coef>
+                    <Coef exponent1="3">1.2191988789775561e-10</Coef>
+                    <Coef exponent1="4">-6.5342561715559025e-13</Coef>
+                    <Coef exponent1="5">3.2519400278010645e-16</Coef>
+                </X>
+                <Y order1="5">
+                    <Coef exponent1="0">-0.06921308838843146</Coef>
+                    <Coef exponent1="1">0.00073787526119144643</Coef>
+                    <Coef exponent1="2">7.399077245060788e-08</Coef>
+                    <Coef exponent1="3">-1.0525875572605681e-09</Coef>
+                    <Coef exponent1="4">-3.3788216228145983e-14</Coef>
+                    <Coef exponent1="5">7.6241787500235205e-16</Coef>
+                </Y>
+                <Z order1="5">
+                    <Coef exponent1="0">0.51359715158881925</Coef>
+                    <Coef exponent1="1">-7.4969848184029868e-05</Coef>
+                    <Coef exponent1="2">1.2309351838082699e-06</Coef>
+                    <Coef exponent1="3">3.5096979204331667e-10</Coef>
+                    <Coef exponent1="4">-2.0820927565561895e-12</Coef>
+                    <Coef exponent1="5">-5.4913780628865013e-16</Coef>
+                </Z>
+            </YAxisPoly>
+            <FreqZero>10000000000</FreqZero>
+            <EB>
+                <DCXPoly order1="0">
+                    <Coef exponent1="0">0</Coef>
+                </DCXPoly>
+                <DCYPoly order1="0">
+                    <Coef exponent1="0">0</Coef>
+                </DCYPoly>
+            </EB>
+            <Array>
+                <GainPoly order1="8" order2="8">
+                    <Coef exponent1="0" exponent2="0">0</Coef>
+                    <Coef exponent1="0" exponent2="1">-4.1430777012935061e-12</Coef>
+                    <Coef exponent1="0" exponent2="2">-25810177.686242383</Coef>
+                    <Coef exponent1="0" exponent2="3">-0.00014382609695309318</Coef>
+                    <Coef exponent1="0" exponent2="4">-13687592749336.885</Coef>
+                    <Coef exponent1="0" exponent2="5">292.19947867443852</Coef>
+                    <Coef exponent1="0" exponent2="6">-4.2115648774405212e+18</Coef>
+                    <Coef exponent1="0" exponent2="7">-1442527537.8580344</Coef>
+                    <Coef exponent1="0" exponent2="8">-4.4559066869820204e+25</Coef>
+                    <Coef exponent1="1" exponent2="0">-4.1430777012935061e-12</Coef>
+                    <Coef exponent1="1" exponent2="1">0</Coef>
+                    <Coef exponent1="1" exponent2="2">0</Coef>
+                    <Coef exponent1="1" exponent2="3">0</Coef>
+                    <Coef exponent1="1" exponent2="4">0</Coef>
+                    <Coef exponent1="1" exponent2="5">0</Coef>
+                    <Coef exponent1="1" exponent2="6">0</Coef>
+                    <Coef exponent1="1" exponent2="7">0</Coef>
+                    <Coef exponent1="1" exponent2="8">0</Coef>
+                    <Coef exponent1="2" exponent2="0">-25810177.686242383</Coef>
+                    <Coef exponent1="2" exponent2="1">0</Coef>
+                    <Coef exponent1="2" exponent2="2">0</Coef>
+                    <Coef exponent1="2" exponent2="3">0</Coef>
+                    <Coef exponent1="2" exponent2="4">0</Coef>
+                    <Coef exponent1="2" exponent2="5">0</Coef>
+                    <Coef exponent1="2" exponent2="6">0</Coef>
+                    <Coef exponent1="2" exponent2="7">0</Coef>
+                    <Coef exponent1="2" exponent2="8">0</Coef>
+                    <Coef exponent1="3" exponent2="0">-0.00014382609695309318</Coef>
+                    <Coef exponent1="3" exponent2="1">0</Coef>
+                    <Coef exponent1="3" exponent2="2">0</Coef>
+                    <Coef exponent1="3" exponent2="3">0</Coef>
+                    <Coef exponent1="3" exponent2="4">0</Coef>
+                    <Coef exponent1="3" exponent2="5">0</Coef>
+                    <Coef exponent1="3" exponent2="6">0</Coef>
+                    <Coef exponent1="3" exponent2="7">0</Coef>
+                    <Coef exponent1="3" exponent2="8">0</Coef>
+                    <Coef exponent1="4" exponent2="0">-13687592749336.885</Coef>
+                    <Coef exponent1="4" exponent2="1">0</Coef>
+                    <Coef exponent1="4" exponent2="2">0</Coef>
+                    <Coef exponent1="4" exponent2="3">0</Coef>
+                    <Coef exponent1="4" exponent2="4">0</Coef>
+                    <Coef exponent1="4" exponent2="5">0</Coef>
+                    <Coef exponent1="4" exponent2="6">0</Coef>
+                    <Coef exponent1="4" exponent2="7">0</Coef>
+                    <Coef exponent1="4" exponent2="8">0</Coef>
+                    <Coef exponent1="5" exponent2="0">292.19947867443852</Coef>
+                    <Coef exponent1="5" exponent2="1">0</Coef>
+                    <Coef exponent1="5" exponent2="2">0</Coef>
+                    <Coef exponent1="5" exponent2="3">0</Coef>
+                    <Coef exponent1="5" exponent2="4">0</Coef>
+                    <Coef exponent1="5" exponent2="5">0</Coef>
+                    <Coef exponent1="5" exponent2="6">0</Coef>
+                    <Coef exponent1="5" exponent2="7">0</Coef>
+                    <Coef exponent1="5" exponent2="8">0</Coef>
+                    <Coef exponent1="6" exponent2="0">-4.2115648774405212e+18</Coef>
+                    <Coef exponent1="6" exponent2="1">0</Coef>
+                    <Coef exponent1="6" exponent2="2">0</Coef>
+                    <Coef exponent1="6" exponent2="3">0</Coef>
+                    <Coef exponent1="6" exponent2="4">0</Coef>
+                    <Coef exponent1="6" exponent2="5">0</Coef>
+                    <Coef exponent1="6" exponent2="6">0</Coef>
+                    <Coef exponent1="6" exponent2="7">0</Coef>
+                    <Coef exponent1="6" exponent2="8">0</Coef>
+                    <Coef exponent1="7" exponent2="0">-1442527537.8580344</Coef>
+                    <Coef exponent1="7" exponent2="1">0</Coef>
+                    <Coef exponent1="7" exponent2="2">0</Coef>
+                    <Coef exponent1="7" exponent2="3">0</Coef>
+                    <Coef exponent1="7" exponent2="4">0</Coef>
+                    <Coef exponent1="7" exponent2="5">0</Coef>
+                    <Coef exponent1="7" exponent2="6">0</Coef>
+                    <Coef exponent1="7" exponent2="7">0</Coef>
+                    <Coef exponent1="7" exponent2="8">0</Coef>
+                    <Coef exponent1="8" exponent2="0">-4.4559066869820204e+25</Coef>
+                    <Coef exponent1="8" exponent2="1">0</Coef>
+                    <Coef exponent1="8" exponent2="2">0</Coef>
+                    <Coef exponent1="8" exponent2="3">0</Coef>
+                    <Coef exponent1="8" exponent2="4">0</Coef>
+                    <Coef exponent1="8" exponent2="5">0</Coef>
+                    <Coef exponent1="8" exponent2="6">0</Coef>
+                    <Coef exponent1="8" exponent2="7">0</Coef>
+                    <Coef exponent1="8" exponent2="8">0</Coef>
+                </GainPoly>
+                <PhasePoly order1="0" order2="0">
+                    <Coef exponent1="0" exponent2="0">0</Coef>
+                </PhasePoly>
+            </Array>
+            <Elem>
+                <GainPoly order1="0" order2="0">
+                    <Coef exponent1="0" exponent2="0">0</Coef>
+                </GainPoly>
+                <PhasePoly order1="0" order2="0">
+                    <Coef exponent1="0" exponent2="0">0</Coef>
+                </PhasePoly>
+            </Elem>
+            <GainBSPoly order1="0">
+                <Coef exponent1="0">0</Coef>
+            </GainBSPoly>
+            <MLFreqDilation>false</MLFreqDilation>
+        </Tx>
+        <Rcv>
+            <XAxisPoly>
+                <X order1="5">
+                    <Coef exponent1="0">0.13982986262005959</Coef>
+                    <Coef exponent1="1">-0.0027594341203054122</Coef>
+                    <Coef exponent1="2">-2.642141233211328e-06</Coef>
+                    <Coef exponent1="3">1.4412928975132546e-08</Coef>
+                    <Coef exponent1="4">4.9106827976192821e-11</Coef>
+                    <Coef exponent1="5">-1.1406011989724555e-13</Coef>
+                </X>
+                <Y order1="5">
+                    <Coef exponent1="0">-0.985103968766331</Coef>
+                    <Coef exponent1="1">-0.00072022999981332595</Coef>
+                    <Coef exponent1="2">8.6929909937280073e-06</Coef>
+                    <Coef exponent1="3">1.7419413461433799e-08</Coef>
+                    <Coef exponent1="4">-7.0195266020811239e-11</Coef>
+                    <Coef exponent1="5">-3.1383419971071391e-13</Coef>
+                </Y>
+                <Z order1="5">
+                    <Coef exponent1="0">0.10008886172036295</Coef>
+                    <Coef exponent1="1">-0.0032336279155612555</Coef>
+                    <Coef exponent1="2">-3.6150726160461875e-06</Coef>
+                    <Coef exponent1="3">2.4227194540266762e-08</Coef>
+                    <Coef exponent1="4">6.8535490141060762e-11</Coef>
+                    <Coef exponent1="5">-1.9455706113121084e-13</Coef>
+                </Z>
+            </XAxisPoly>
+            <YAxisPoly>
+                <X order1="5">
+                    <Coef exponent1="0">-0.85523535607199153</Coef>
+                    <Coef exponent1="1">-0.00010473716447760117</Coef>
+                    <Coef exponent1="2">1.0612386361416289e-06</Coef>
+                    <Coef exponent1="3">1.2191988789775561e-10</Coef>
+                    <Coef exponent1="4">-6.5342561715559025e-13</Coef>
+                    <Coef exponent1="5">3.2519400278010645e-16</Coef>
+                </X>
+                <Y order1="5">
+                    <Coef exponent1="0">-0.06921308838843146</Coef>
+                    <Coef exponent1="1">0.00073787526119144643</Coef>
+                    <Coef exponent1="2">7.399077245060788e-08</Coef>
+                    <Coef exponent1="3">-1.0525875572605681e-09</Coef>
+                    <Coef exponent1="4">-3.3788216228145983e-14</Coef>
+                    <Coef exponent1="5">7.6241787500235205e-16</Coef>
+                </Y>
+                <Z order1="5">
+                    <Coef exponent1="0">0.51359715158881925</Coef>
+                    <Coef exponent1="1">-7.4969848184029868e-05</Coef>
+                    <Coef exponent1="2">1.2309351838082699e-06</Coef>
+                    <Coef exponent1="3">3.5096979204331667e-10</Coef>
+                    <Coef exponent1="4">-2.0820927565561895e-12</Coef>
+                    <Coef exponent1="5">-5.4913780628865013e-16</Coef>
+                </Z>
+            </YAxisPoly>
+            <FreqZero>10000000000</FreqZero>
+            <EB>
+                <DCXPoly order1="0">
+                    <Coef exponent1="0">0</Coef>
+                </DCXPoly>
+                <DCYPoly order1="0">
+                    <Coef exponent1="0">0</Coef>
+                </DCYPoly>
+            </EB>
+            <Array>
+                <GainPoly order1="8" order2="8">
+                    <Coef exponent1="0" exponent2="0">0</Coef>
+                    <Coef exponent1="0" exponent2="1">-4.1430777012935061e-12</Coef>
+                    <Coef exponent1="0" exponent2="2">-25810177.686242383</Coef>
+                    <Coef exponent1="0" exponent2="3">-0.00014382609695309318</Coef>
+                    <Coef exponent1="0" exponent2="4">-13687592749336.885</Coef>
+                    <Coef exponent1="0" exponent2="5">292.19947867443852</Coef>
+                    <Coef exponent1="0" exponent2="6">-4.2115648774405212e+18</Coef>
+                    <Coef exponent1="0" exponent2="7">-1442527537.8580344</Coef>
+                    <Coef exponent1="0" exponent2="8">-4.4559066869820204e+25</Coef>
+                    <Coef exponent1="1" exponent2="0">-4.1430777012935061e-12</Coef>
+                    <Coef exponent1="1" exponent2="1">0</Coef>
+                    <Coef exponent1="1" exponent2="2">0</Coef>
+                    <Coef exponent1="1" exponent2="3">0</Coef>
+                    <Coef exponent1="1" exponent2="4">0</Coef>
+                    <Coef exponent1="1" exponent2="5">0</Coef>
+                    <Coef exponent1="1" exponent2="6">0</Coef>
+                    <Coef exponent1="1" exponent2="7">0</Coef>
+                    <Coef exponent1="1" exponent2="8">0</Coef>
+                    <Coef exponent1="2" exponent2="0">-25810177.686242383</Coef>
+                    <Coef exponent1="2" exponent2="1">0</Coef>
+                    <Coef exponent1="2" exponent2="2">0</Coef>
+                    <Coef exponent1="2" exponent2="3">0</Coef>
+                    <Coef exponent1="2" exponent2="4">0</Coef>
+                    <Coef exponent1="2" exponent2="5">0</Coef>
+                    <Coef exponent1="2" exponent2="6">0</Coef>
+                    <Coef exponent1="2" exponent2="7">0</Coef>
+                    <Coef exponent1="2" exponent2="8">0</Coef>
+                    <Coef exponent1="3" exponent2="0">-0.00014382609695309318</Coef>
+                    <Coef exponent1="3" exponent2="1">0</Coef>
+                    <Coef exponent1="3" exponent2="2">0</Coef>
+                    <Coef exponent1="3" exponent2="3">0</Coef>
+                    <Coef exponent1="3" exponent2="4">0</Coef>
+                    <Coef exponent1="3" exponent2="5">0</Coef>
+                    <Coef exponent1="3" exponent2="6">0</Coef>
+                    <Coef exponent1="3" exponent2="7">0</Coef>
+                    <Coef exponent1="3" exponent2="8">0</Coef>
+                    <Coef exponent1="4" exponent2="0">-13687592749336.885</Coef>
+                    <Coef exponent1="4" exponent2="1">0</Coef>
+                    <Coef exponent1="4" exponent2="2">0</Coef>
+                    <Coef exponent1="4" exponent2="3">0</Coef>
+                    <Coef exponent1="4" exponent2="4">0</Coef>
+                    <Coef exponent1="4" exponent2="5">0</Coef>
+                    <Coef exponent1="4" exponent2="6">0</Coef>
+                    <Coef exponent1="4" exponent2="7">0</Coef>
+                    <Coef exponent1="4" exponent2="8">0</Coef>
+                    <Coef exponent1="5" exponent2="0">292.19947867443852</Coef>
+                    <Coef exponent1="5" exponent2="1">0</Coef>
+                    <Coef exponent1="5" exponent2="2">0</Coef>
+                    <Coef exponent1="5" exponent2="3">0</Coef>
+                    <Coef exponent1="5" exponent2="4">0</Coef>
+                    <Coef exponent1="5" exponent2="5">0</Coef>
+                    <Coef exponent1="5" exponent2="6">0</Coef>
+                    <Coef exponent1="5" exponent2="7">0</Coef>
+                    <Coef exponent1="5" exponent2="8">0</Coef>
+                    <Coef exponent1="6" exponent2="0">-4.2115648774405212e+18</Coef>
+                    <Coef exponent1="6" exponent2="1">0</Coef>
+                    <Coef exponent1="6" exponent2="2">0</Coef>
+                    <Coef exponent1="6" exponent2="3">0</Coef>
+                    <Coef exponent1="6" exponent2="4">0</Coef>
+                    <Coef exponent1="6" exponent2="5">0</Coef>
+                    <Coef exponent1="6" exponent2="6">0</Coef>
+                    <Coef exponent1="6" exponent2="7">0</Coef>
+                    <Coef exponent1="6" exponent2="8">0</Coef>
+                    <Coef exponent1="7" exponent2="0">-1442527537.8580344</Coef>
+                    <Coef exponent1="7" exponent2="1">0</Coef>
+                    <Coef exponent1="7" exponent2="2">0</Coef>
+                    <Coef exponent1="7" exponent2="3">0</Coef>
+                    <Coef exponent1="7" exponent2="4">0</Coef>
+                    <Coef exponent1="7" exponent2="5">0</Coef>
+                    <Coef exponent1="7" exponent2="6">0</Coef>
+                    <Coef exponent1="7" exponent2="7">0</Coef>
+                    <Coef exponent1="7" exponent2="8">0</Coef>
+                    <Coef exponent1="8" exponent2="0">-4.4559066869820204e+25</Coef>
+                    <Coef exponent1="8" exponent2="1">0</Coef>
+                    <Coef exponent1="8" exponent2="2">0</Coef>
+                    <Coef exponent1="8" exponent2="3">0</Coef>
+                    <Coef exponent1="8" exponent2="4">0</Coef>
+                    <Coef exponent1="8" exponent2="5">0</Coef>
+                    <Coef exponent1="8" exponent2="6">0</Coef>
+                    <Coef exponent1="8" exponent2="7">0</Coef>
+                    <Coef exponent1="8" exponent2="8">0</Coef>
+                </GainPoly>
+                <PhasePoly order1="0" order2="0">
+                    <Coef exponent1="0" exponent2="0">0</Coef>
+                </PhasePoly>
+            </Array>
+            <Elem>
+                <GainPoly order1="0" order2="0">
+                    <Coef exponent1="0" exponent2="0">0</Coef>
+                </GainPoly>
+                <PhasePoly order1="0" order2="0">
+                    <Coef exponent1="0" exponent2="0">0</Coef>
+                </PhasePoly>
+            </Elem>
+            <GainBSPoly order1="0">
+                <Coef exponent1="0">0</Coef>
+            </GainBSPoly>
+            <MLFreqDilation>false</MLFreqDilation>
+        </Rcv>
+    </Antenna>
+    <PFA>
+        <FPN>
+            <X>1</X>
+            <Y>0</Y>
+            <Z>0</Z>
+        </FPN>
+        <IPN>
+            <X>0.85540832579135895</X>
+            <Y>0.067973204303252321</Y>
+            <Z>-0.51347467325894713</Z>
+        </IPN>
+        <PolarAngRefTime>1.6800674762530463</PolarAngRefTime>
+        <PolarAngPoly order1="9">
+            <Coef exponent1="0">-0.0071413060968959627</Coef>
+            <Coef exponent1="1">0.004245118151048095</Coef>
+            <Coef exponent1="2">3.303261280436797e-06</Coef>
+            <Coef exponent1="3">-2.152475729568344e-08</Coef>
+            <Coef exponent1="4">-5.5340201006749593e-11</Coef>
+            <Coef exponent1="5">1.6174039129702326e-13</Coef>
+            <Coef exponent1="6">1.2038148814517427e-15</Coef>
+            <Coef exponent1="7">-1.0008410326624715e-16</Coef>
+            <Coef exponent1="8">1.6819824323114349e-17</Coef>
+            <Coef exponent1="9">-1.1931290667377136e-18</Coef>
+        </PolarAngPoly>
+        <SpatialFreqSFPoly order1="8">
+            <Coef exponent1="0">0.99999143699142279</Coef>
+            <Coef exponent1="1">2.1389170906735031e-05</Coef>
+            <Coef exponent1="2">0.051388964320644458</Coef>
+            <Coef exponent1="3">0.0048322065140747042</Coef>
+            <Coef exponent1="4">-0.020014437732713723</Coef>
+            <Coef exponent1="5">0.0023716850734943114</Coef>
+            <Coef exponent1="6">0.14153200650672734</Coef>
+            <Coef exponent1="7">4.5834686287659396</Coef>
+            <Coef exponent1="8">-1395.0901983623608</Coef>
+        </SpatialFreqSFPoly>
+        <Krg1>66.268165205464854</Krg1>
+        <Krg2>67.156149288980856</Krg2>
+        <Kaz1>-0.44524655663963569</Kaz1>
+        <Kaz2>0.44524655663963569</Kaz2>
+    </PFA>
+</SICD>

--- a/tests/data/example.sidd.xml
+++ b/tests/data/example.sidd.xml
@@ -1,0 +1,482 @@
+<SIDD xmlns="urn:SIDD:2.0.0" xmlns:si="urn:SICommon:1.0" xmlns:sfa="urn:SFA:1.2.0" xmlns:ism="urn:us:gov:ic:ism:13">
+    <ProductCreation>
+        <ProcessorInformation>
+            <Application>Valkyrie Systems Sage | sar_common_kit 1.9.0.0</Application>
+            <ProcessingDateTime>2022-12-06T19:27:39.012794Z</ProcessingDateTime>
+            <Site>None</Site>
+        </ProcessorInformation>
+        <Classification ism:DESVersion="13" ism:ISMCATCESVersion="1" ism:resourceElement="true" ism:createDate="2022-12-06" ism:compliesWith="USGov" ism:classification="U" ism:ownerProducer="USA"/>
+        <ProductName>unknown</ProductName>
+        <ProductClass>unknown</ProductClass>
+    </ProductCreation>
+    <Display>
+        <PixelType>MONO8I</PixelType>
+        <NumBands>1</NumBands>
+        <NonInteractiveProcessing band="1">
+            <ProductGenerationOptions>
+                <DataRemapping>
+                    <LUTName>UNKNOWN</LUTName>
+                    <Predefined>
+                        <DatabaseName>UNKNOWN</DatabaseName>
+                    </Predefined>
+                </DataRemapping>
+            </ProductGenerationOptions>
+            <RRDS>
+                <DownsamplingMethod>AVERAGE</DownsamplingMethod>
+                <AntiAlias>
+                    <FilterName>PLACEHOLDER</FilterName>
+                    <FilterKernel>
+                        <Predefined>
+                            <DatabaseName>BILINEAR</DatabaseName>
+                        </Predefined>
+                    </FilterKernel>
+                    <Operation>CONVOLUTION</Operation>
+                </AntiAlias>
+                <Interpolation>
+                    <FilterName>PLACEHOLDER</FilterName>
+                    <FilterKernel>
+                        <Predefined>
+                            <DatabaseName>BILINEAR</DatabaseName>
+                        </Predefined>
+                    </FilterKernel>
+                    <Operation>CORRELATION</Operation>
+                </Interpolation>
+            </RRDS>
+        </NonInteractiveProcessing>
+        <InteractiveProcessing band="1">
+            <GeometricTransform>
+                <Scaling>
+                    <AntiAlias>
+                        <FilterName>PLACEHOLDER</FilterName>
+                        <FilterKernel>
+                            <Predefined>
+                                <DatabaseName>BILINEAR</DatabaseName>
+                            </Predefined>
+                        </FilterKernel>
+                        <Operation>CONVOLUTION</Operation>
+                    </AntiAlias>
+                    <Interpolation>
+                        <FilterName>PLACEHOLDER</FilterName>
+                        <FilterKernel>
+                            <Predefined>
+                                <DatabaseName>BILINEAR</DatabaseName>
+                            </Predefined>
+                        </FilterKernel>
+                        <Operation>CORRELATION</Operation>
+                    </Interpolation>
+                </Scaling>
+                <Orientation>
+                    <ShadowDirection>DOWN</ShadowDirection>
+                </Orientation>
+            </GeometricTransform>
+            <SharpnessEnhancement>
+                <ModularTransferFunctionCompensation>
+                    <FilterName>PLACEHOLDER</FilterName>
+                    <FilterKernel>
+                        <Predefined>
+                            <DatabaseName>BILINEAR</DatabaseName>
+                        </Predefined>
+                    </FilterKernel>
+                    <Operation>CONVOLUTION</Operation>
+                </ModularTransferFunctionCompensation>
+            </SharpnessEnhancement>
+            <DynamicRangeAdjustment>
+                <AlgorithmType>NONE</AlgorithmType>
+                <BandStatsSource>1</BandStatsSource>
+            </DynamicRangeAdjustment>
+        </InteractiveProcessing>
+    </Display>
+    <GeoData>
+        <EarthModel>WGS_84</EarthModel>
+        <ImageCorners>
+            <ICP index="1:FRFC">
+                <si:Lat>0.005246355578488418</si:Lat>
+                <si:Lon>-0.0036493547329483943</si:Lon>
+            </ICP>
+            <ICP index="2:FRLC">
+                <si:Lat>0.0036744434203674343</si:Lat>
+                <si:Lon>0.0052057233514495619</si:Lon>
+            </ICP>
+            <ICP index="3:LRLC">
+                <si:Lat>-0.0052384529583787203</si:Lat>
+                <si:Lon>0.0036446600262143069</si:Lon>
+            </ICP>
+            <ICP index="4:LRFC">
+                <si:Lat>-0.0036665408001853718</si:Lat>
+                <si:Lon>-0.0052104180581638796</si:Lon>
+            </ICP>
+        </ImageCorners>
+        <ValidData size="32">
+            <Vertex index="1">
+                <si:Lat>0.0052417900105372808</si:Lat>
+                <si:Lon>-0.0036459553496886836</si:Lon>
+            </Vertex>
+            <Vertex index="2">
+                <si:Lat>0.0050444842018397343</si:Lat>
+                <si:Lon>-0.0025363384075982212</si:Lon>
+            </Vertex>
+            <Vertex index="3">
+                <si:Lat>0.0048486757434716759</si:Lat>
+                <si:Lon>-0.001434596445097429</si:Lon>
+            </Vertex>
+            <Vertex index="4">
+                <si:Lat>0.0046515673660827116</si:Lat>
+                <si:Lon>-0.00032499029180123643</si:Lon>
+            </Vertex>
+            <Vertex index="5">
+                <si:Lat>0.0044559549275893515</si:Lat>
+                <si:Lon>0.00077674095741102334</si:Lon>
+            </Vertex>
+            <Vertex index="6">
+                <si:Lat>0.0042590439589258646</si:Lat>
+                <si:Lon>0.0018863363198758478</si:Lon>
+            </Vertex>
+            <Vertex index="7">
+                <si:Lat>0.0040636275178796534</si:Lat>
+                <si:Lon>0.0029880568537745465</si:Lon>
+            </Vertex>
+            <Vertex index="8">
+                <si:Lat>0.003866913935362671</si:Lat>
+                <si:Lon>0.0040976414233672362</si:Lon>
+            </Vertex>
+            <Vertex index="9">
+                <si:Lat>0.0036702993886366239</si:Lat>
+                <si:Lon>0.0052072205765488133</si:Lon>
+            </Vertex>
+            <Vertex index="10">
+                <si:Lat>0.0025553150338214902</si:Lat>
+                <si:Lon>0.0050052475888817836</si:Lon>
+            </Vertex>
+            <Vertex index="11">
+                <si:Lat>0.0014389632791401541</si:Lat>
+                <si:Lon>0.0048111315417230724</si:Lon>
+            </Vertex>
+            <Vertex index="12">
+                <si:Lat>0.00033183860376480165</si:Lat>
+                <si:Lon>0.0046178775326278648</si:Lon>
+            </Vertex>
+            <Vertex index="13">
+                <si:Lat>-0.00078446001436127883</si:Lat>
+                <si:Lon>0.0044237367501572542</si:Lon>
+            </Vertex>
+            <Vertex index="14">
+                <si:Lat>-0.0019007319678390417</si:Lat>
+                <si:Lon>0.0042295835726184373</si:Lon>
+            </Vertex>
+            <Vertex index="15">
+                <si:Lat>-0.0030077774831168518</si:Lat>
+                <si:Lon>0.0040362926017025865</si:Lon>
+            </Vertex>
+            <Vertex index="16">
+                <si:Lat>-0.0041239963322973966</si:Lat>
+                <si:Lon>0.0038421146909401456</si:Lon>
+            </Vertex>
+            <Vertex index="17">
+                <si:Lat>-0.0052387937410512155</si:Lat>
+                <si:Lon>0.0036400510404809056</si:Lon>
+            </Vertex>
+            <Vertex index="18">
+                <si:Lat>-0.0050434736841941169</si:Lat>
+                <si:Lon>0.0025377799564379345</si:Lon>
+            </Vertex>
+            <Vertex index="19">
+                <si:Lat>-0.0048466597625732291</si:Lat>
+                <si:Lon>0.0014276301096644208</si:Lon>
+            </Vertex>
+            <Vertex index="20">
+                <si:Lat>-0.0046511436574296038</si:Lat>
+                <si:Lon>0.00032534830699847101</si:Lon>
+            </Vertex>
+            <Vertex index="21">
+                <si:Lat>-0.0044555298686204201</si:Lat>
+                <si:Lon>-0.0007769388351615994</si:Lon>
+            </Vertex>
+            <Vertex index="22">
+                <si:Lat>-0.0042584201000616089</si:Lat>
+                <si:Lon>-0.0018871048532465076</si:Lon>
+            </Vertex>
+            <Vertex index="23">
+                <si:Lat>-0.0040626102293912746</si:Lat>
+                <si:Lon>-0.0029894027110379043</si:Lon>
+            </Vertex>
+            <Vertex index="24">
+                <si:Lat>-0.0038653029670940925</si:Lat>
+                <si:Lon>-0.0040995795202901798</si:Lon>
+            </Vertex>
+            <Vertex index="25">
+                <si:Lat>-0.0036692969921356972</si:Lat>
+                <si:Lon>-0.0052018880917231412</si:Lon>
+            </Vertex>
+            <Vertex index="26">
+                <si:Lat>-0.0025532042843858503</si:Lat>
+                <si:Lon>-0.0050071334090955244</si:Lon>
+            </Vertex>
+            <Vertex index="27">
+                <si:Lat>-0.0014370849164168662</si:Lat>
+                <si:Lon>-0.0048123911209361154</si:Lon>
+            </Vertex>
+            <Vertex index="28">
+                <si:Lat>-0.00033013856287731594</si:Lat>
+                <si:Lon>-0.0046185403341168722</si:Lon>
+            </Vertex>
+            <Vertex index="29">
+                <si:Lat>0.00078603393283521012</si:Lat>
+                <si:Lon>-0.0044238227800681706</si:Lon>
+            </Vertex>
+            <Vertex index="30">
+                <si:Lat>0.0019022331049687996</si:Lat>
+                <si:Lon>-0.0042291176215286976</si:Lon>
+            </Vertex>
+            <Vertex index="31">
+                <si:Lat>0.0030092586536039634</si:Lat>
+                <si:Lon>-0.0040353037978433726</si:Lon>
+            </Vertex>
+            <Vertex index="32">
+                <si:Lat>0.0041255109857561032</si:Lat>
+                <si:Lon>-0.0038406233754897695</si:Lon>
+            </Vertex>
+        </ValidData>
+    </GeoData>
+    <Measurement>
+        <PlaneProjection>
+            <ReferencePoint>
+                <si:ECEF>
+                    <si:X>6378137</si:X>
+                    <si:Y>0</si:Y>
+                    <si:Z>0</si:Z>
+                </si:ECEF>
+                <si:Point>
+                    <si:Row>650</si:Row>
+                    <si:Col>751</si:Col>
+                </si:Point>
+            </ReferencePoint>
+            <SampleSpacing>
+                <si:Row>0.76980043496519579</si:Row>
+                <si:Col>0.66641108974957253</si:Col>
+            </SampleSpacing>
+            <TimeCOAPoly order1="0" order2="0">
+                <si:Coef exponent1="0" exponent2="0">1.6800674762530357</si:Coef>
+            </TimeCOAPoly>
+            <ProductPlane>
+                <RowUnitVector>
+                    <si:X>0</si:X>
+                    <si:Y>-0.17364817766693033</si:Y>
+                    <si:Z>-0.98480775301220813</si:Z>
+                </RowUnitVector>
+                <ColUnitVector>
+                    <si:X>0</si:X>
+                    <si:Y>0.98480775301220813</si:Y>
+                    <si:Z>-0.17364817766693033</si:Z>
+                </ColUnitVector>
+            </ProductPlane>
+        </PlaneProjection>
+        <PixelFootprint>
+            <si:Row>1300</si:Row>
+            <si:Col>1502</si:Col>
+        </PixelFootprint>
+        <ARPPoly>
+            <si:X order1="5">
+                <si:Coef exponent1="0">7228127.9124448663</si:Coef>
+                <si:Coef exponent1="1">352.53242998756502</si:Coef>
+                <si:Coef exponent1="2">-3.5891719134975157</si:Coef>
+                <si:Coef exponent1="3">-5.7694198643316104e-05</si:Coef>
+                <si:Coef exponent1="4">2.7699968593303768e-07</si:Coef>
+                <si:Coef exponent1="5">2.1592636134572539e-09</si:Coef>
+            </si:X>
+            <si:Y order1="5">
+                <si:Coef exponent1="0">268129.91744542622</si:Coef>
+                <si:Coef exponent1="1">-7332.3823879634392</si:Coef>
+                <si:Coef exponent1="2">-0.13313219332893028</si:Coef>
+                <si:Coef exponent1="3">0.0012135963117010783</si:Coef>
+                <si:Coef exponent1="4">1.0196690368353028e-08</si:Coef>
+                <si:Coef exponent1="5">1.3607911396273635e-11</si:Coef>
+            </si:Y>
+            <si:Z order1="5">
+                <si:Coef exponent1="0">1451527.4824241539</si:Coef>
+                <si:Coef exponent1="1">-401.08990372640221</si:Coef>
+                <si:Coef exponent1="2">-0.72076439428225647</si:Coef>
+                <si:Coef exponent1="3">6.6511087447480695e-05</si:Coef>
+                <si:Coef exponent1="4">5.6690990559856781e-08</si:Coef>
+                <si:Coef exponent1="5">3.2123861103114586e-10</si:Coef>
+            </si:Z>
+        </ARPPoly>
+        <ValidData size="32">
+            <Vertex index="1">
+                <si:Row>0</si:Row>
+                <si:Col>0</si:Col>
+            </Vertex>
+            <Vertex index="2">
+                <si:Row>0</si:Row>
+                <si:Col>188</si:Col>
+            </Vertex>
+            <Vertex index="3">
+                <si:Row>0</si:Row>
+                <si:Col>375</si:Col>
+            </Vertex>
+            <Vertex index="4">
+                <si:Row>0</si:Row>
+                <si:Col>564</si:Col>
+            </Vertex>
+            <Vertex index="5">
+                <si:Row>0</si:Row>
+                <si:Col>750</si:Col>
+            </Vertex>
+            <Vertex index="6">
+                <si:Row>0</si:Row>
+                <si:Col>939</si:Col>
+            </Vertex>
+            <Vertex index="7">
+                <si:Row>0</si:Row>
+                <si:Col>1125</si:Col>
+            </Vertex>
+            <Vertex index="8">
+                <si:Row>0</si:Row>
+                <si:Col>1314</si:Col>
+            </Vertex>
+            <Vertex index="9">
+                <si:Row>0</si:Row>
+                <si:Col>1502</si:Col>
+            </Vertex>
+            <Vertex index="10">
+                <si:Row>163</si:Row>
+                <si:Col>1501</si:Col>
+            </Vertex>
+            <Vertex index="11">
+                <si:Row>326</si:Row>
+                <si:Col>1501</si:Col>
+            </Vertex>
+            <Vertex index="12">
+                <si:Row>487</si:Row>
+                <si:Col>1501</si:Col>
+            </Vertex>
+            <Vertex index="13">
+                <si:Row>650</si:Row>
+                <si:Col>1501</si:Col>
+            </Vertex>
+            <Vertex index="14">
+                <si:Row>813</si:Row>
+                <si:Col>1502</si:Col>
+            </Vertex>
+            <Vertex index="15">
+                <si:Row>974</si:Row>
+                <si:Col>1502</si:Col>
+            </Vertex>
+            <Vertex index="16">
+                <si:Row>1137</si:Row>
+                <si:Col>1502</si:Col>
+            </Vertex>
+            <Vertex index="17">
+                <si:Row>1300</si:Row>
+                <si:Col>1501</si:Col>
+            </Vertex>
+            <Vertex index="18">
+                <si:Row>1300</si:Row>
+                <si:Col>1314</si:Col>
+            </Vertex>
+            <Vertex index="19">
+                <si:Row>1300</si:Row>
+                <si:Col>1125</si:Col>
+            </Vertex>
+            <Vertex index="20">
+                <si:Row>1300</si:Row>
+                <si:Col>939</si:Col>
+            </Vertex>
+            <Vertex index="21">
+                <si:Row>1300</si:Row>
+                <si:Col>752</si:Col>
+            </Vertex>
+            <Vertex index="22">
+                <si:Row>1300</si:Row>
+                <si:Col>563</si:Col>
+            </Vertex>
+            <Vertex index="23">
+                <si:Row>1300</si:Row>
+                <si:Col>376</si:Col>
+            </Vertex>
+            <Vertex index="24">
+                <si:Row>1300</si:Row>
+                <si:Col>188</si:Col>
+            </Vertex>
+            <Vertex index="25">
+                <si:Row>1300</si:Row>
+                <si:Col>1</si:Col>
+            </Vertex>
+            <Vertex index="26">
+                <si:Row>1137</si:Row>
+                <si:Col>1</si:Col>
+            </Vertex>
+            <Vertex index="27">
+                <si:Row>974</si:Row>
+                <si:Col>1</si:Col>
+            </Vertex>
+            <Vertex index="28">
+                <si:Row>813</si:Row>
+                <si:Col>1</si:Col>
+            </Vertex>
+            <Vertex index="29">
+                <si:Row>650</si:Row>
+                <si:Col>1</si:Col>
+            </Vertex>
+            <Vertex index="30">
+                <si:Row>487</si:Row>
+                <si:Col>0</si:Col>
+            </Vertex>
+            <Vertex index="31">
+                <si:Row>326</si:Row>
+                <si:Col>0</si:Col>
+            </Vertex>
+            <Vertex index="32">
+                <si:Row>163</si:Row>
+                <si:Col>0</si:Col>
+            </Vertex>
+        </ValidData>
+    </Measurement>
+    <ExploitationFeatures>
+        <Collection identifier="SyntheticCore">
+            <Information>
+                <SensorName>Synthetic</SensorName>
+                <RadarMode>
+                    <si:ModeType>SPOTLIGHT</si:ModeType>
+                </RadarMode>
+                <CollectionDateTime>2022-12-05T18:41:24.051402Z</CollectionDateTime>
+                <CollectionDuration>3.4668291025146964</CollectionDuration>
+                <Resolution>
+                    <si:Range>0.99856649779218243</si:Range>
+                    <si:Azimuth>0.99775493302366314</si:Azimuth>
+                </Resolution>
+            </Information>
+            <Geometry>
+                <Azimuth>9.9994779614198173</Azimuth>
+                <Slope>31.195125856239255</Slope>
+                <Squint>80.00038705324377</Squint>
+                <Graze>30.000080950049007</Graze>
+                <Tilt>8.9805970546123763</Tilt>
+                <DopplerConeAngle>80.000333057346595</DopplerConeAngle>
+            </Geometry>
+            <Phenomenology>
+                <Shadow>
+                    <si:Angle>0.0005220385801805148</si:Angle>
+                    <si:Magnitude>1.7320451562031676</si:Magnitude>
+                </Shadow>
+                <Layover>
+                    <si:Angle>-162.45909403041333</si:Angle>
+                    <si:Magnitude>0.60550526142149752</si:Magnitude>
+                </Layover>
+                <MultiPath>-175.48141915233586</MultiPath>
+                <GroundTrack>-76.850298101271562</GroundTrack>
+            </Phenomenology>
+        </Collection>
+        <Product>
+            <Resolution>
+                <si:Row>1.1530455089381841</si:Row>
+                <si:Col>1.0138677668646643</si:Col>
+            </Resolution>
+            <Ellipticity>1.1698668287683203</Ellipticity>
+            <Polarization>
+                <TxPolarizationProc>V</TxPolarizationProc>
+                <RcvPolarizationProc>V</RcvPolarizationProc>
+            </Polarization>
+            <North>-170</North>
+        </Product>
+    </ExploitationFeatures>
+</SIDD>

--- a/tests/geometry/test_point_projection.py
+++ b/tests/geometry/test_point_projection.py
@@ -1,0 +1,252 @@
+#
+# Copyright 2023 Valkyrie Systems Corporation
+#
+# Licensed under MIT License.  See LICENSE.
+#
+import pathlib
+
+import numpy as np
+import pytest
+
+from sarpy.geometry import point_projection
+from sarpy.io.complex.sicd_elements.SICD import SICDType
+from sarpy.io.product.sidd2_elements.SIDD import SIDDType
+from sarpy.io.DEM.DEM import DEMInterpolator
+TOLERANCE = 1e-8
+
+@pytest.fixture(scope='module')
+def sicd():
+    xml_file = pathlib.Path(pathlib.Path.cwd(), 'tests/data/example.sicd.xml')
+    structure = SICDType().from_xml_file(xml_file)
+    scp_pixel = [structure.ImageData.SCPPixel.Row,
+                 structure.ImageData.SCPPixel.Col]
+    scp_ecf = [structure.GeoData.SCP.ECF.X,
+               structure.GeoData.SCP.ECF.Y,
+               structure.GeoData.SCP.ECF.Z]
+    scp_llh = [structure.GeoData.SCP.LLH.Lat,
+               structure.GeoData.SCP.LLH.Lon,
+               structure.GeoData.SCP.LLH.HAE]
+
+    return {'structure': structure,'scp_pixel': scp_pixel,'scp_ecf': scp_ecf,'scp_llh': scp_llh}
+
+@pytest.fixture(scope='module')
+def sidd():
+    xml_file = pathlib.Path(pathlib.Path.cwd(), 'tests/data/example.sidd.xml')
+    return SIDDType().from_xml_file(xml_file)
+
+
+def test_image_to_ground_plane(sicd):
+    # project scp pixel (PLANE)
+    scp_ecef1 = point_projection.image_to_ground(sicd['scp_pixel'],
+                                                 sicd['structure'],
+                                                 projection_type='PLANE')
+    assert scp_ecef1 == pytest.approx(sicd['scp_ecf'], abs=TOLERANCE)
+
+    scp_ecef2 = point_projection.image_to_ground([sicd['scp_pixel'], sicd['scp_pixel']],
+                                                 sicd['structure'],
+                                                 block_size=1,
+                                                 projection_type='PLANE')
+    assert np.all(np.abs(scp_ecef2[0] - scp_ecef1) < TOLERANCE)
+    assert np.all(np.abs(scp_ecef2[1] - scp_ecef1) < TOLERANCE)
+
+    # 2-dim gref
+    gref = np.array([[sicd['structure'].GeoData.SCP.ECF.X],
+                     [sicd['structure'].GeoData.SCP.ECF.Y],
+                     [sicd['structure'].GeoData.SCP.ECF.Z]])
+    scp_ecef3 = point_projection.image_to_ground(sicd['scp_pixel'],
+                                                 sicd['structure'],
+                                                 gref=gref,
+                                                 projection_type='PLANE')
+    assert scp_ecef3 == pytest.approx(sicd['scp_ecf'], abs=TOLERANCE)
+
+    # 2-dim ugpn
+    ugpn = gref
+    scp_ecef4 = point_projection.image_to_ground(sicd['scp_pixel'],
+                                                 sicd['structure'],
+                                                 ugpn=ugpn,
+                                                 projection_type='PLANE')
+    assert scp_ecef4 == pytest.approx(sicd['scp_ecf'], abs=TOLERANCE)
+
+
+def test_image_to_ground_hae(sicd, caplog):
+    # project scp pixel (HAE)
+    scp_ecef1 = point_projection.image_to_ground(sicd['scp_pixel'],
+                                                 sicd['structure'],
+                                                 projection_type='HAE')
+    assert scp_ecef1 == pytest.approx(sicd['scp_ecf'], abs=TOLERANCE)
+
+    scp_ecef2 = point_projection.image_to_ground([sicd['scp_pixel'], sicd['scp_pixel']],
+                                                 sicd['structure'],
+                                                 block_size=1,
+                                                 projection_type='HAE')
+    assert np.all(np.abs(scp_ecef2[0] - scp_ecef1) < TOLERANCE)
+    assert np.all(np.abs(scp_ecef2[1] - scp_ecef1) < TOLERANCE)
+
+    # error max_iterations < 1
+    point_projection.image_to_ground(sicd['scp_pixel'],
+                                     sicd['structure'],
+                                     projection_type='HAE',
+                                     max_iterations=0)
+    assert 'max_iterations must be a positive integer' in caplog.text
+    # error max_iterations > 100
+    point_projection.image_to_ground(sicd['scp_pixel'],
+                                     sicd['structure'],
+                                     projection_type='HAE',
+                                     max_iterations=101)
+    assert 'maximum allowed max_iterations is 100' in caplog.text
+
+
+def test_image_to_ground_errors(sicd):
+    # invalid im_points (empty)
+    with pytest.raises(ValueError, match="final dimension of im_points must have length 2"):
+        point_projection.image_to_ground([], sicd['structure'], projection_type='PLANE')
+
+    # invalid im_points (None)
+    with pytest.raises(ValueError, match="The argument cannot be None"):
+        point_projection.image_to_ground(None, sicd['structure'], projection_type='PLANE')
+
+    # invalid projection_type
+    with pytest.raises(ValueError, match="Got unrecognized projection type INVALID_PLANE"):
+        point_projection.image_to_ground(sicd['scp_pixel'], sicd['structure'], projection_type='INVALID_PLANE')
+
+    # invalid gref
+    with pytest.raises(ValueError, match="gref must have three elements"):
+        point_projection.image_to_ground(sicd['scp_pixel'], sicd['structure'], gref=[0.0, 0.0], projection_type='PLANE')
+
+    # invalid ugpn
+    with pytest.raises(ValueError, match="ugpn must have three elements"):
+        point_projection.image_to_ground(sicd['scp_pixel'], sicd['structure'], ugpn=[0.0, 0.0], projection_type='PLANE')
+
+    # dem_interpolator is none
+    with pytest.raises(ValueError, match="dem_interpolator is None"):
+        point_projection.image_to_ground(sicd['scp_pixel'], sicd['structure'], projection_type='DEM')
+
+    # dem_interpolator is not DEMInterpolator type
+    with pytest.raises(TypeError, match="dem_interpolator is of unsupported type"):
+        point_projection.image_to_ground(sicd['scp_pixel'], sicd['structure'], projection_type='DEM', dem_interpolator=sicd['scp_pixel'])
+
+
+def test_image_to_ground_geo(sicd):
+    # project scp pixel to geodetic
+    scp_geo = point_projection.image_to_ground_geo(sicd['scp_pixel'], sicd['structure'])
+    assert scp_geo == pytest.approx(sicd['scp_llh'], abs=TOLERANCE)
+
+
+def test_image_to_ground_dem(sicd):
+    interp = DEMInterpolator()
+    with pytest.raises(NotImplementedError):
+        point_projection.image_to_ground(sicd['scp_pixel'],
+                                         sicd['structure'],
+                                         projection_type='DEM',
+                                         dem_interpolator=interp)
+
+
+def test_ground_to_image(sicd):
+    # project scp ecef to pixel
+    scp_pixel1 = point_projection.ground_to_image(sicd['scp_ecf'], sicd['structure'])
+    assert scp_pixel1[0] == pytest.approx(sicd['scp_pixel'], abs=TOLERANCE)
+    assert scp_pixel1[1] == pytest.approx(0.0, abs=TOLERANCE)
+
+    scp_pixel2 = point_projection.ground_to_image([sicd['scp_ecf'], sicd['scp_ecf']], sicd['structure'], block_size=1)
+    assert np.all(np.abs(scp_pixel2[0][0] - scp_pixel1[0]) < TOLERANCE)
+    assert np.all(np.abs(scp_pixel2[0][1] - scp_pixel1[0]) < TOLERANCE)
+
+
+def test_ground_to_image_geo(sicd):
+    # project scp pixel to geodetic
+    scp_pixel1 = point_projection.ground_to_image_geo(sicd['scp_llh'], sicd['structure'])
+    assert scp_pixel1[0] == pytest.approx(sicd['scp_pixel'], abs=TOLERANCE)
+    assert scp_pixel1[1] == pytest.approx(0.0, abs=TOLERANCE)
+
+
+def test_image_to_ground_sidd(sidd, caplog):
+    # project SIDD reference point pixel
+    ref_point = [sidd.Measurement.PlaneProjection.ReferencePoint.Point.Row,
+                 sidd.Measurement.PlaneProjection.ReferencePoint.Point.Col]
+    scp_ecef1 = point_projection.image_to_ground(ref_point, sidd)
+
+    sidd_ecef = sidd.Measurement.PlaneProjection.ReferencePoint.ECEF
+    assert sidd_ecef.X == pytest.approx(scp_ecef1[0], abs=TOLERANCE)
+    assert sidd_ecef.Y == pytest.approx(scp_ecef1[1], abs=TOLERANCE)
+    assert sidd_ecef.Z == pytest.approx(scp_ecef1[2], abs=TOLERANCE)
+
+    # force path through _get_outward_norm
+    scp_ecef2 = point_projection.image_to_ground(ref_point, sidd, projection_type='PLANE', ugpn=None)
+    assert scp_ecef2[0] == pytest.approx(sidd_ecef.X, abs=TOLERANCE)
+    assert scp_ecef2[1] == pytest.approx(sidd_ecef.Y, abs=TOLERANCE)
+    assert scp_ecef2[2] == pytest.approx(sidd_ecef.Z, abs=TOLERANCE)
+
+    point_projection.image_to_ground(ref_point, sidd, tolerance=1e-13)
+    assert 'minimum allowed tolerance is 1e-12' in caplog.text
+
+
+def test_ground_to_image_sidd(sidd, caplog):
+    # project reference point ecef to pixel
+    ref_point = [sidd.Measurement.PlaneProjection.ReferencePoint.ECEF.X,
+                 sidd.Measurement.PlaneProjection.ReferencePoint.ECEF.Y,
+                 sidd.Measurement.PlaneProjection.ReferencePoint.ECEF.Z]
+    scp_pixel1 = point_projection.ground_to_image(ref_point, sidd)
+
+    sidd_rowcol = sidd.Measurement.PlaneProjection.ReferencePoint.Point
+    assert sidd_rowcol.Row == pytest.approx(scp_pixel1[0][0], abs=TOLERANCE)
+    assert sidd_rowcol.Col == pytest.approx(scp_pixel1[0][1], abs=TOLERANCE)
+    assert scp_pixel1[1] == pytest.approx(0.0, abs=TOLERANCE)
+
+    point_projection.ground_to_image(ref_point, sidd, tolerance=1e-13)
+    assert 'minimum allowed tolerance is 1e-12' in caplog.text
+
+
+def test_coa_projection(sicd, sidd):
+    # smoke test
+    proj = point_projection.COAProjection.from_sicd(sicd['structure'])
+    assert proj.delta_arp is not None
+    assert proj.delta_varp is not None
+    assert proj.range_bias is not None
+    assert proj.delta_range is not None
+
+    # force path through RIC_ECF code (SICD)
+    proj = point_projection.COAProjection.from_sicd(sicd['structure'], adj_params_frame='RIC_ECF')
+    assert proj.delta_arp is not None
+
+    # force path through RIC_ECF code (SIDD)
+    proj = point_projection.COAProjection.from_sidd(sidd, adj_params_frame='RIC_ECF')
+    assert proj.delta_arp is not None
+
+    method_projection = point_projection._get_sicd_type_specific_projection(sicd['structure'])
+    with pytest.raises(TypeError, match="time_coa_poly must be a Poly2DType instance"):
+        point_projection.COAProjection(sicd['structure'].Position.ARPPoly,
+                                       sicd['structure'].Position.ARPPoly,
+                                       method_projection)
+    with pytest.raises(TypeError, match="arp_poly must be an XYZPolyType instance"):
+        point_projection.COAProjection(sicd['structure'].Grid.TimeCOAPoly,
+                                       sicd['structure'].Grid.TimeCOAPoly,
+                                       method_projection)
+    with pytest.raises(TypeError, match="method_projection must be callable"):
+        point_projection.COAProjection(sicd['structure'].Grid.TimeCOAPoly,
+                                       sicd['structure'].Position.ARPPoly,
+                                       'WRONG')
+
+
+def test_validate_coords_error(sicd):
+    # ECF coordinates must have length 3
+    coords = np.array([[sicd['structure'].GeoData.SCP.ECF.X],
+                      [sicd['structure'].GeoData.SCP.ECF.Y],
+                      [sicd['structure'].GeoData.SCP.ECF.Z],
+                      [sicd['structure'].GeoData.SCP.ECF.Z]])
+    with pytest.raises(ValueError, match="final dimension of coords must have length 3"):
+        point_projection._validate_coords(coords)
+
+
+def test_validate_adjustment_param_error(sicd):
+    # ECF coordinates must have length 3 and passed as an array
+    coords = [[sicd['structure'].GeoData.SCP.ECF.X],
+              [sicd['structure'].GeoData.SCP.ECF.Y],
+              [sicd['structure'].GeoData.SCP.ECF.Z],
+              [sicd['structure'].GeoData.SCP.ECF.Z]]
+    with pytest.raises(ValueError, match=r"position must have shape \(3, \). Got \(4, 1\)"):
+        point_projection._validate_adj_param(coords, 'position')
+
+    coords = np.array(coords)
+    with pytest.raises(ValueError, match=r"position must have shape \(3, \). Got \(4, 1\)"):
+        point_projection._validate_adj_param(coords, 'position')
+


### PR DESCRIPTION
**This PR introduces `test_point_projection.py` to increase coverage from the current 9%.**

**_Change Log_**
- Added `test_point_projection.py`
- Added `sarpy/tests/data` directory
- Added 1 SICD and 1 SIDD xml example to be used to create SICDType and SIDDType objects

**Current coverage**

|Name|Stmts|Miss|Cover|Missing|
|----|-----|----|-----|-------|
|sarpy/geometry/point_projection.py|642|584|9%|115-121, 145-154, 171-337, 361-373, 390-444, 468-491, 554-574, 582, 590, 598, 606, 637-654, 686-690, 713-719, 747-753, 773-784, 803-815, 832-856, 880-934, 941-953, 1002-1030, 1074-1131, 1167, 1187-1202, 1240-1251, 1292, 1326-1352, 1374-1376, 1415-1457, 1496-1528, 1559-1561, 1608-1653, 1664-1670, 1701-1744, 1775-1803, 1859-1956|
|TOTAL|642|584|9%||

**Coverage with this branch improved to 77%.**

|Name|Stmts|Miss|Cover|Missing|
|----|-----|----|-----|-------|
|sarpy/geometry/point_projection.py|642|148|77%|224-252, 255-292, 295-321, 328-337, 365, 439, 444, 472, 490, 638, 643-644, 778, 784, 812, 815, 840, 844, 853, 856, 912, 929, 934, 1664-1670, 1701-1744, 1778-1803, 1865-1886, 1893, 1895, 1909-1910, 1933-1934, 1943-1956|
|TOTAL|642|148|77%||

**For what it's worth, the remaining lines are uncovered either due to the fact that `DEMInterpolation` is not implemented (99) or require a unique custom XML to force the path through the code (49).**

|LOC|Reason for missing|
|----|-----|
|224-252|_get_sicd_type_specific_projection, RgAzComp projection (requires modified SICD XML)|
|255-292|_get_sicd_type_specific_projection, Inca projection (requires modified SICD XML)|
|295-321|_get_sicd_type_specific_projection (requires modified SICD XML)|
|328-337|_get_sicd_type_specific_projection (requires modified SICD XML)|
|365|_get_sicd_adjustment_params (requires modified SICD XML)|
|439|_get_sidd_type_projection (requires modified SICD XML)|
|444|_get_sidd_type_projection (requires modified SICD XML)|
|472|_get_sidd_adjustment_params (not SIDD1 or SIDD2)(requires modified SICD XML)|
|490|_get_sidd_adjustment_params (requires modified SICD XML)|
|638|COAProjection.from_sicd (requires modified SICD XML)|
|643-644|COAProjection.from_sicd, warning (requires modified SICD XML)|
|778|_get_coa_projection (requires modified SICD XML)|
|784|_get_coa_projection, SIDD Type2 (requires modified SICD XML)|
|812|_get_reference_point (requires modified SICD XML)|
|815|_get_reference_point (requires modified SICD XML)|
|840|_get_outward_norm (requires modified SICD XML)|
|844|_get_outward_norm (requires modified SICD XML)|
|853|_get_outward_norm (requires modified SICD XML)|
|856|_get_outward_norm (requires modified SICD XML)|
|912|_extract_plane_params, with SIDD (requires modified SICD XML)|
|929|_extract_plane_params, (requires modified SICD XML)|
|934|_extract_plane_params, (requires modified SICD XML)|
|1664-1670|_do_dem_iteration|
|1701-1744|_image_to_ground_dem|
|1778-1803|dem_interpolator.get_elevation_hae|
|1865-1886|image_to_ground_dem.append_grid_elements|
|1893|image_to_ground_dem|
|1895|image_to_ground_dem|
|1909-1910|image_to_ground_dem|
|1933-1934|image_to_ground_dem|
|1943-1956|image_to_ground_dem|