### PR TITLE
add microparameter checks to cphd_consistency

### DIFF
--- a/sarpy/consistency/consistency.py
+++ b/sarpy/consistency/consistency.py
@@ -351,7 +351,7 @@ class ConsistencyChecker(object):
 
         indent = 4
         for case, details in to_print.items():
-            print("{}: {}".format(case, details['doc']))
+            print(f"{case}: {str(details['doc']).strip()}")
             if details['details']:
                 for sub in details['details']:
                     lead = in_color(*coloration[sub['severity'], sub['passed']])

--- a/sarpy/io/phase_history/cphd1_elements/Antenna.py
+++ b/sarpy/io/phase_history/cphd1_elements/Antenna.py
@@ -125,7 +125,7 @@ class GainPhaseArrayType(Serializable):
 
     _fields = ('Freq', 'ArrayId', 'ElementId')
     _required = ('Freq', 'ArrayId')
-    _numeric_format = {'Freq', FLOAT_FORMAT}
+    _numeric_format = {'Freq': FLOAT_FORMAT}
     # descriptors
     Freq = FloatDescriptor(
         'Freq', _required, strict=DEFAULT_STRICT, bounds=(0, None),


### PR DESCRIPTION
# Description
This MR updates SarPy's `cphd_consistency` module with additional checks for microparameters (and some semi-related metadata):

* `check_channel_afdop`
* `check_channel_afrr1_afrr2_relative`
* `check_channel_afrr1`
* `check_channel_afrr2`
* `check_channel_identifier_uniqueness`
* `check_channel_rcv_sample_rate`

Many of the new checks are pre-conditioned on optional CPHD fields so updated data may be required for the unit-tests.

## Misc

### Improved `cphd_consistency` result formatting
We've updated `print_result` to strip the whitespace from the SarPy-style docstrings prior to printing:

<details><summary>before</summary>

Note the newlines and odd placement of "for channel..."

```
check_channel_antenna_exist_1: 
        The antenna patterns and phase centers exist if declared.
         for channel 1
    [Pass] Need: AntPhaseCenter node exists with name transmit (for Tx)
    [Pass] Need: AntPattern node exists with name transmit (for Tx)
    [Pass] Need: AntPhaseCenter node exists with name receive (for Rcv)
    [Pass] Need: AntPattern node exists with name receive (for Rcv)
check_channel_dwell_exist_1: 
        The referenced Dwell and COD nodes exist.
         for channel 1
    [Pass] Need: /Dwell/CODTime with Identifier=1 exists for DwellTime in channel=1
    [Pass] Need: /Dwell/DwellTime with Identifier=1 exists for DwellTime in channel=1
```

</details>

<details><summary>after</summary>

the docstrings are now on one-line

```
check_channel_afdop_1: aFDOP PVP is consistent with other PVPs for channel 1.
    [Pass] Want: aFDOP consistent with other PVPs
check_channel_afrr1_1: aFRR1 is consistent with /TxRcv/TxWFParameters/LFMRate for channel 1.
    [Pass] Want: aFRR1 is consistent with /TxRcv/TxWFParameters/LFMRate(s): [2.5e+13]
check_channel_afrr1_afrr2_relative_1: aFRR1 & aFRR2 PVPs are related by fx_C for channel 1.
    [Pass] Want: aFRR1 == (FX1 + FX2) * aFRR2 / 2
check_channel_afrr2_1: aFRR2 is consistent with /TxRcv/TxWFParameters/LFMRate(s) for channel 1.
    [Pass] Want: aFRR2 is consistent with /TxRcv/TxWFParameters/LFMRate(s): [2.5e+13]
```

</details>

### Unrelated bugfix
We've fixed an unrelated bug in `sarpy/io/phase_history/cphd1_elements/Antenna.py` `GainPhaseArrayType._numeric_format`:
  - the definition was incorrectly created as a set rather than a dict due to a typo (`,` instead of `:`)

# Test Plan
I ran SarPy's test suite in a python=3.6 & python=3.10 environments with SARPY_TEST_PATH populated with a CPHD with TxRcv (and Tx/Rcv LFMRates) specified:

<details><summary>3.6</summary>

```
============================================================================================== test session starts ==============================================================================================
platform linux -- Python 3.6.13, pytest-6.2.4, py-1.11.0, pluggy-0.13.1 -- /home/vscuser/miniconda3/envs/sarpy36/bin/python
cachedir: .pytest_cache
rootdir: /home/vscuser/git/glweb/software/third-party/sarpy
collected 156 items

pytests/test_consistency.py::test_all PASSED                                                                                                                                                              [  0%]
pytests/test_consistency.py::test_one PASSED                                                                                                                                                              [  1%]
pytests/test_consistency.py::test_multiple PASSED                                                                                                                                                         [  1%]
pytests/test_consistency.py::test_check_with_ignore_pattern PASSED                                                                                                                                        [  2%]
pytests/test_consistency.py::test_check_with_ignore_specific[True] PASSED                                                                                                                                 [  3%]
pytests/test_consistency.py::test_check_with_ignore_specific[False] PASSED                                                                                                                                [  3%]
pytests/test_consistency.py::test_invalid PASSED                                                                                                                                                          [  4%]
pytests/test_consistency.py::test_approx PASSED                                                                                                                                                           [  5%]
pytests/test_cphd_consistency.py::test_from_file_cphd PASSED                                                                                                                                              [  5%]
pytests/test_cphd_consistency.py::test_from_file_xml PASSED                                                                                                                                               [  6%]
pytests/test_cphd_consistency.py::test_main PASSED                                                                                                                                                        [  7%]
pytests/test_cphd_consistency.py::test_main_with_ignore PASSED                                                                                                                                            [  7%]
pytests/test_cphd_consistency.py::test_main_schema_args PASSED                                                                                                                                            [  8%]
pytests/test_cphd_consistency.py::test_main_each_file[/data/sarpy_test/cphd/spotlight_example.cphd] PASSED                                                                                                [  8%]
pytests/test_cphd_consistency.py::test_main_each_file[/data/sarpy_test/cphd/bistatic.cphd] PASSED                                                                                                         [  9%]
pytests/test_cphd_consistency.py::test_check_file_type_header PASSED                                                                                                                                      [ 10%]
pytests/test_cphd_consistency.py::test_schema_available PASSED                                                                                                                                            [ 10%]
pytests/test_cphd_consistency.py::test_xml_schema_error PASSED                                                                                                                                            [ 11%]
pytests/test_cphd_consistency.py::test_check_unconnected_ids_severed_node PASSED                                                                                                                          [ 12%]
pytests/test_cphd_consistency.py::test_check_unconnected_ids_extra_node PASSED                                                                                                                            [ 12%]
pytests/test_cphd_consistency.py::test_check_classification_and_release_info_error PASSED                                                                                                                 [ 13%]
pytests/test_cphd_consistency.py::test_error_in_check PASSED                                                                                                                                              [ 14%]
pytests/test_cphd_consistency.py::test_polygon_size_error PASSED                                                                                                                                          [ 14%]
pytests/test_cphd_consistency.py::test_polygon_winding_error PASSED                                                                                                                                       [ 15%]
pytests/test_cphd_consistency.py::test_signalnormal PASSED                                                                                                                                                [ 16%]
pytests/test_cphd_consistency.py::test_signalnormal_bad_pvp PASSED                                                                                                                                        [ 16%]
pytests/test_cphd_consistency.py::test_fxfixed PASSED                                                                                                                                                     [ 17%]
pytests/test_cphd_consistency.py::test_channel_toafixed PASSED                                                                                                                                            [ 17%]
pytests/test_cphd_consistency.py::test_channel_srpfixed PASSED                                                                                                                                            [ 18%]
pytests/test_cphd_consistency.py::test_txrcv PASSED                                                                                                                                                       [ 19%]
pytests/test_cphd_consistency.py::test_txrcv_bad_txwfid PASSED                                                                                                                                            [ 19%]
pytests/test_cphd_consistency.py::test_antenna_bad_acf_count PASSED                                                                                                                                       [ 20%]
pytests/test_cphd_consistency.py::test_antenna_bad_apc_count PASSED                                                                                                                                       [ 21%]
pytests/test_cphd_consistency.py::test_antenna_bad_antpats_count PASSED                                                                                                                                   [ 21%]
pytests/test_cphd_consistency.py::test_antenna_non_matching_acfids PASSED                                                                                                                                 [ 22%]
pytests/test_cphd_consistency.py::test_txrcv_bad_rcvid PASSED                                                                                                                                             [ 23%]
pytests/test_cphd_consistency.py::test_txrcv_missing_channel_node PASSED                                                                                                                                  [ 23%]
pytests/test_cphd_consistency.py::test_fxbwnoise PASSED                                                                                                                                                   [ 24%]
pytests/test_cphd_consistency.py::test_fxbwnoise_bad_domain PASSED                                                                                                                                        [ 25%]
pytests/test_cphd_consistency.py::test_fxbwnoise_bad_value PASSED                                                                                                                                         [ 25%]
pytests/test_cphd_consistency.py::test_geoinfo_polygons PASSED                                                                                                                                            [ 26%]
pytests/test_cphd_consistency.py::test_geoinfo_polygons_bad_order PASSED                                                                                                                                  [ 26%]
pytests/test_cphd_consistency.py::test_channel_image_area PASSED                                                                                                                                          [ 27%]
pytests/test_cphd_consistency.py::test_extended_imagearea PASSED                                                                                                                                          [ 28%]
pytests/test_cphd_consistency.py::test_extended_imagearea_polygon_bad_extent PASSED                                                                                                                       [ 28%]
pytests/test_cphd_consistency.py::test_antenna_missing_channel_node PASSED                                                                                                                                [ 29%]
pytests/test_cphd_consistency.py::test_refgeom_bad_root PASSED                                                                                                                                            [ 30%]
pytests/test_cphd_consistency.py::test_refgeom_bad_monostatic PASSED                                                                                                                                      [ 30%]
pytests/test_cphd_consistency.py::test_refgeom_bad_bistatic PASSED                                                                                                                                        [ 31%]
pytests/test_cphd_consistency.py::test_check_identifier_uniqueness PASSED                                                                                                                                 [ 32%]
pytests/test_cphd_consistency.py::test_check_polynomials[_invalidate_order] PASSED                                                                                                                        [ 32%]
pytests/test_cphd_consistency.py::test_check_polynomials[_invalidate_coef_uniqueness] PASSED                                                                                                              [ 33%]
pytests/test_cphd_consistency.py::test_check_channel_normal_signal_pvp PASSED                                                                                                                             [ 33%]
pytests/test_cphd_consistency.py::test_check_optional_pvps_fx[_fxn_with_toa_domain] PASSED                                                                                                                [ 34%]
pytests/test_cphd_consistency.py::test_check_optional_pvps_fx[_fxn1_only] PASSED                                                                                                                          [ 35%]
pytests/test_cphd_consistency.py::test_check_optional_pvps_toa PASSED                                                                                                                                     [ 35%]
pytests/test_cphd_consistency.py::test_check_channel_toaextsaved PASSED                                                                                                                                   [ 36%]
pytests/test_cphd_consistency.py::test_check_channel_toaextsaved_no_toae1 PASSED                                                                                                                          [ 37%]
pytests/test_cphd_consistency.py::test_check_channel_afdop PASSED                                                                                                                                         [ 37%]
pytests/test_cphd_consistency.py::test_check_channel_afrr1_afrr2_relative PASSED                                                                                                                          [ 38%]
pytests/test_cphd_consistency.py::test_check_channel_afrrs[aFRR1] PASSED                                                                                                                                  [ 39%]
pytests/test_cphd_consistency.py::test_check_channel_afrrs[aFRR2] PASSED                                                                                                                                  [ 39%]
pytests/test_cphd_consistency.py::test_check_channel_identifier_uniqueness PASSED                                                                                                                         [ 40%]
pytests/test_cphd_consistency.py::test_check_channel_rcv_sample_rate PASSED                                                                                                                               [ 41%]
tests/test_class_string.py::TestClassString::test_class_str PASSED                                                                                                                                        [ 41%]
tests/geometry/test_geocoords.py::test_ecf_to_geodetic PASSED                                                                                                                                             [ 42%]
tests/geometry/test_geocoords.py::test_geodetic_to_ecf PASSED                                                                                                                                             [ 42%]
tests/geometry/test_geocoords.py::test_values_both_ways PASSED                                                                                                                                            [ 43%]
tests/geometry/test_geocoords.py::test_ecf_to_ned PASSED                                                                                                                                                  [ 44%]
tests/geometry/test_geocoords.py::test_ned_to_ecf PASSED                                                                                                                                                  [ 44%]
tests/geometry/test_geocoords.py::test_ecf_to_ned_roundtrip PASSED                                                                                                                                        [ 45%]
tests/geometry/test_geocoords.py::test_ecf_to_enu PASSED                                                                                                                                                  [ 46%]
tests/geometry/test_geocoords.py::test_enu_to_ecf PASSED                                                                                                                                                  [ 46%]
tests/geometry/test_geocoords.py::test_ecf_to_enu_roundtrip PASSED                                                                                                                                        [ 47%]
tests/geometry/test_geocoords.py::test_wgs84_norm PASSED                                                                                                                                                  [ 48%]
tests/geometry/test_geometry_elements.py::test_line_string PASSED                                                                                                                                         [ 48%]
tests/geometry/test_geometry_elements.py::test_multi_line_string PASSED                                                                                                                                   [ 49%]
tests/geometry/test_geometry_elements.py::test_polygon PASSED                                                                                                                                             [ 50%]
tests/geometry/test_geometry_elements.py::test_multi_polygon PASSED                                                                                                                                       [ 50%]
tests/geometry/test_latlon.py::test_string PASSED                                                                                                                                                         [ 51%]
tests/geometry/test_latlon.py::test_dms PASSED                                                                                                                                                            [ 51%]
tests/geometry/test_latlon.py::test_num PASSED                                                                                                                                                            [ 52%]
tests/geometry/test_point_projection.py::test_image_to_ground_plane PASSED                                                                                                                                [ 53%]
tests/geometry/test_point_projection.py::test_image_to_ground_hae PASSED                                                                                                                                  [ 53%]
tests/geometry/test_point_projection.py::test_image_to_ground_errors PASSED                                                                                                                               [ 54%]
tests/geometry/test_point_projection.py::test_image_to_ground_geo PASSED                                                                                                                                  [ 55%]
tests/geometry/test_point_projection.py::test_image_to_ground_dem PASSED                                                                                                                                  [ 55%]
tests/geometry/test_point_projection.py::test_ground_to_image PASSED                                                                                                                                      [ 56%]
tests/geometry/test_point_projection.py::test_ground_to_image_geo PASSED                                                                                                                                  [ 57%]
tests/geometry/test_point_projection.py::test_image_to_ground_sidd PASSED                                                                                                                                 [ 57%]
tests/geometry/test_point_projection.py::test_ground_to_image_sidd PASSED                                                                                                                                 [ 58%]
tests/geometry/test_point_projection.py::test_coa_projection PASSED                                                                                                                                       [ 58%]
tests/geometry/test_point_projection.py::test_validate_coords_error PASSED                                                                                                                                [ 59%]
tests/geometry/test_point_projection.py::test_validate_adjustment_param_error PASSED                                                                                                                      [ 60%]
tests/io/DEM/test_geoid.py::TestGeoidHeight::test_geoid_height SKIPPED (No test file or geoid files found)                                                                                                [ 60%]
tests/io/complex/test_reader.py::TestSICD::test_sicd_reader SKIPPED (No SICD files specified or found)                                                                                                    [ 61%]
tests/io/complex/test_reader.py::TestRCM::test_rcm_reader SKIPPED (No RCM files specified or found)                                                                                                       [ 62%]
tests/io/complex/test_reader.py::TestRCM_NITF::test_rcm_nitf_reader SKIPPED (No RCM_NITF files specified or found)                                                                                        [ 62%]
tests/io/complex/test_reader.py::TestRS2::test_rs2_reader SKIPPED (No RadarSat-2 files specified or found)                                                                                                [ 63%]
tests/io/complex/test_reader.py::TestSentinel::test_sentinel_reader SKIPPED (No Sentinel-1 files specified or found)                                                                                      [ 64%]
tests/io/complex/test_reader.py::TestTerraSAR::test_terrasarx_reader SKIPPED (No TerraSAR-X files specified or found)                                                                                     [ 64%]
tests/io/complex/test_reader.py::TestCosmoSkymed::test_csk_reader SKIPPED (No CosmoSkymed files specified or found)                                                                                       [ 65%]
tests/io/complex/test_reader.py::TestKompSat5::test_kompsat_reader SKIPPED (No KompSat-5 files specified or found)                                                                                        [ 66%]
tests/io/complex/test_reader.py::TestICEYE::test_iceye_reader SKIPPED (No ICEYE files specified or found)                                                                                                 [ 66%]
tests/io/complex/test_reader.py::TestPALSAR::test_palsar_reader SKIPPED (No PALSAR files specified or found)                                                                                              [ 67%]
tests/io/complex/test_reader.py::TestCapella::test_capella_reader SKIPPED (No Capella files specified or found)                                                                                           [ 67%]
tests/io/complex/test_remote.py::TestRemoteSICD::test_remote_reader PASSED                                                                                                                                [ 68%]
tests/io/complex/test_sicd.py::TestSICDWriting::test_sicd_creation SKIPPED (No sicd files found)                                                                                                          [ 69%]
tests/io/complex/test_utils.py::TestRadarSatUtils::test_two_dim_poly_fit PASSED                                                                                                                           [ 69%]
tests/io/general/test_base.py::TestBaseReader::test_read PASSED                                                                                                                                           [ 70%]
tests/io/general/test_base.py::TestBaseReader::test_read_with_symmetry PASSED                                                                                                                             [ 71%]
tests/io/general/test_base.py::TestBaseWriter::test_write PASSED                                                                                                                                          [ 71%]
tests/io/general/test_data_segment.py::TestNumpyArraySegment::test_basic_read PASSED                                                                                                                      [ 72%]
tests/io/general/test_data_segment.py::TestNumpyArraySegment::test_basic_write PASSED                                                                                                                     [ 73%]
tests/io/general/test_data_segment.py::TestNumpyArraySegment::test_read_with_transpose_and_reverse PASSED                                                                                                 [ 73%]
tests/io/general/test_data_segment.py::TestSubsetSegment::test_read PASSED                                                                                                                                [ 74%]
tests/io/general/test_data_segment.py::TestSubsetSegment::test_write PASSED                                                                                                                               [ 75%]
tests/io/general/test_data_segment.py::TestBandAggregateSegment::test_read PASSED                                                                                                                         [ 75%]
tests/io/general/test_data_segment.py::TestBandAggregateSegment::test_write PASSED                                                                                                                        [ 76%]
tests/io/general/test_data_segment.py::TestBlockAggregateSegment::test_read PASSED                                                                                                                        [ 76%]
tests/io/general/test_data_segment.py::TestBlockAggregateSegment::test_write PASSED                                                                                                                       [ 77%]
tests/io/general/test_data_segment.py::TestFileReadSegment::test_read PASSED                                                                                                                              [ 78%]
tests/io/general/test_format_function.py::TestIdentityFunction::test_combined PASSED                                                                                                                      [ 78%]
tests/io/general/test_format_function.py::TestIdentityFunction::test_reverse PASSED                                                                                                                       [ 79%]
tests/io/general/test_format_function.py::TestIdentityFunction::test_transpose PASSED                                                                                                                     [ 80%]
tests/io/general/test_format_function.py::TestComplexFunction::test_bad_typing PASSED                                                                                                                     [ 80%]
tests/io/general/test_format_function.py::TestComplexFunction::test_float PASSED                                                                                                                          [ 81%]
tests/io/general/test_format_function.py::TestComplexFunction::test_int PASSED                                                                                                                            [ 82%]
tests/io/general/test_format_function.py::TestComplexFunction::test_uint PASSED                                                                                                                           [ 82%]
tests/io/general/test_nitf_headers.py::TestNITFHeader::test_nitf_header SKIPPED (No nitf files identified for testing)                                                                                    [ 83%]
tests/io/general/test_tre.py::TestTreRegistry::test_find_tre PASSED                                                                                                                                       [ 83%]
tests/io/phase_history/test_cphd.py::TestCPHD::test_cphd_io PASSED                                                                                                                                        [ 84%]
tests/io/phase_history/cphd1_elements/test_utils.py::TestCphd1Utils::test_binary_format_to_dtype PASSED                                                                                                   [ 85%]
tests/io/product/test_reader.py::TestSIDD::test_sidd_reader SKIPPED (No SIDD files specified or found)                                                                                                    [ 85%]
tests/io/product/test_sidd_writing.py::TestSIDDWriting::test_sidd_creation SKIPPED (No sicd files found)                                                                                                  [ 86%]
tests/io/received/test_crsd.py::TestCRSD::test_crsd_io SKIPPED (No CRSD files specified or found)                                                                                                         [ 87%]
tests/visualization/test_remap.py::TestRemap::test_Density PASSED                                                                                                                                         [ 87%]
tests/visualization/test_remap.py::TestRemap::test_LUTRemap PASSED                                                                                                                                        [ 88%]
tests/visualization/test_remap.py::TestRemap::test_LUTRemap_matplotlib PASSED                                                                                                                             [ 89%]
tests/visualization/test_remap.py::TestRemap::test_Linear PASSED                                                                                                                                          [ 89%]
tests/visualization/test_remap.py::TestRemap::test_Logarithmic PASSED                                                                                                                                     [ 90%]
tests/visualization/test_remap.py::TestRemap::test_Logarithmic_const PASSED                                                                                                                               [ 91%]
tests/visualization/test_remap.py::TestRemap::test_MonoRemaps PASSED                                                                                                                                      [ 91%]
tests/visualization/test_remap.py::TestRemap::test_MonochromaticRemap PASSED                                                                                                                              [ 92%]
tests/visualization/test_remap.py::TestRemap::test_NRL PASSED                                                                                                                                             [ 92%]
tests/visualization/test_remap.py::TestRemap::test_NRL_inf PASSED                                                                                                                                         [ 93%]
tests/visualization/test_remap.py::TestRemap::test_NRL_near_const PASSED                                                                                                                                  [ 94%]
tests/visualization/test_remap.py::TestRemap::test_PEDF PASSED                                                                                                                                            [ 94%]
tests/visualization/test_remap.py::TestRemap::test_RemapFunction PASSED                                                                                                                                   [ 95%]
tests/visualization/test_remap.py::TestRemap::test_amplitude_to_density PASSED                                                                                                                            [ 96%]
tests/visualization/test_remap.py::TestRemap::test_amplitude_to_density_zeros PASSED                                                                                                                      [ 96%]
tests/visualization/test_remap.py::TestRemap::test_clip_cast PASSED                                                                                                                                       [ 97%]
tests/visualization/test_remap.py::TestRemap::test_flat_interface PASSED                                                                                                                                  [ 98%]
tests/visualization/test_remap.py::TestRemap::test_get_registered_remap PASSED                                                                                                                            [ 98%]
tests/visualization/test_remap.py::TestRemap::test_get_remap_list PASSED                                                                                                                                  [ 99%]
tests/visualization/test_remap.py::TestRemap::test_remap_names PASSED                                                                                                                                     [100%]

================================================================================= 139 passed, 17 skipped, 2 warnings in 19.77s ==================================================================================

```

</details>

<details><summary>3.10</summary>

```
============================================================================================== test session starts ==============================================================================================
platform linux -- Python 3.10.9, pytest-7.1.2, pluggy-1.0.0 -- /home/vscuser/miniconda3/envs/sarpy/bin/python
cachedir: .pytest_cache
rootdir: /home/vscuser/git/glweb/software/third-party/sarpy
plugins: cov-3.0.0
collected 156 items

pytests/test_consistency.py::test_all PASSED                                                                                                                                                              [  0%]
pytests/test_consistency.py::test_one PASSED                                                                                                                                                              [  1%]
pytests/test_consistency.py::test_multiple PASSED                                                                                                                                                         [  1%]
pytests/test_consistency.py::test_check_with_ignore_pattern PASSED                                                                                                                                        [  2%]
pytests/test_consistency.py::test_check_with_ignore_specific[True] PASSED                                                                                                                                 [  3%]
pytests/test_consistency.py::test_check_with_ignore_specific[False] PASSED                                                                                                                                [  3%]
pytests/test_consistency.py::test_invalid PASSED                                                                                                                                                          [  4%]
pytests/test_consistency.py::test_approx PASSED                                                                                                                                                           [  5%]
pytests/test_cphd_consistency.py::test_from_file_cphd PASSED                                                                                                                                              [  5%]
pytests/test_cphd_consistency.py::test_from_file_xml PASSED                                                                                                                                               [  6%]
pytests/test_cphd_consistency.py::test_main PASSED                                                                                                                                                        [  7%]
pytests/test_cphd_consistency.py::test_main_with_ignore PASSED                                                                                                                                            [  7%]
pytests/test_cphd_consistency.py::test_main_schema_args PASSED                                                                                                                                            [  8%]
pytests/test_cphd_consistency.py::test_main_each_file[/data/sarpy_test/cphd/spotlight_example.cphd] PASSED                                                                                                [  8%]
pytests/test_cphd_consistency.py::test_main_each_file[/data/sarpy_test/cphd/bistatic.cphd] PASSED                                                                                                         [  9%]
pytests/test_cphd_consistency.py::test_check_file_type_header PASSED                                                                                                                                      [ 10%]
pytests/test_cphd_consistency.py::test_schema_available PASSED                                                                                                                                            [ 10%]
pytests/test_cphd_consistency.py::test_xml_schema_error PASSED                                                                                                                                            [ 11%]
pytests/test_cphd_consistency.py::test_check_unconnected_ids_severed_node PASSED                                                                                                                          [ 12%]
pytests/test_cphd_consistency.py::test_check_unconnected_ids_extra_node PASSED                                                                                                                            [ 12%]
pytests/test_cphd_consistency.py::test_check_classification_and_release_info_error PASSED                                                                                                                 [ 13%]
pytests/test_cphd_consistency.py::test_error_in_check PASSED                                                                                                                                              [ 14%]
pytests/test_cphd_consistency.py::test_polygon_size_error PASSED                                                                                                                                          [ 14%]
pytests/test_cphd_consistency.py::test_polygon_winding_error PASSED                                                                                                                                       [ 15%]
pytests/test_cphd_consistency.py::test_signalnormal PASSED                                                                                                                                                [ 16%]
pytests/test_cphd_consistency.py::test_signalnormal_bad_pvp PASSED                                                                                                                                        [ 16%]
pytests/test_cphd_consistency.py::test_fxfixed PASSED                                                                                                                                                     [ 17%]
pytests/test_cphd_consistency.py::test_channel_toafixed PASSED                                                                                                                                            [ 17%]
pytests/test_cphd_consistency.py::test_channel_srpfixed PASSED                                                                                                                                            [ 18%]
pytests/test_cphd_consistency.py::test_txrcv PASSED                                                                                                                                                       [ 19%]
pytests/test_cphd_consistency.py::test_txrcv_bad_txwfid PASSED                                                                                                                                            [ 19%]
pytests/test_cphd_consistency.py::test_antenna_bad_acf_count PASSED                                                                                                                                       [ 20%]
pytests/test_cphd_consistency.py::test_antenna_bad_apc_count PASSED                                                                                                                                       [ 21%]
pytests/test_cphd_consistency.py::test_antenna_bad_antpats_count PASSED                                                                                                                                   [ 21%]
pytests/test_cphd_consistency.py::test_antenna_non_matching_acfids PASSED                                                                                                                                 [ 22%]
pytests/test_cphd_consistency.py::test_txrcv_bad_rcvid PASSED                                                                                                                                             [ 23%]
pytests/test_cphd_consistency.py::test_txrcv_missing_channel_node PASSED                                                                                                                                  [ 23%]
pytests/test_cphd_consistency.py::test_fxbwnoise PASSED                                                                                                                                                   [ 24%]
pytests/test_cphd_consistency.py::test_fxbwnoise_bad_domain PASSED                                                                                                                                        [ 25%]
pytests/test_cphd_consistency.py::test_fxbwnoise_bad_value PASSED                                                                                                                                         [ 25%]
pytests/test_cphd_consistency.py::test_geoinfo_polygons PASSED                                                                                                                                            [ 26%]
pytests/test_cphd_consistency.py::test_geoinfo_polygons_bad_order PASSED                                                                                                                                  [ 26%]
pytests/test_cphd_consistency.py::test_channel_image_area PASSED                                                                                                                                          [ 27%]
pytests/test_cphd_consistency.py::test_extended_imagearea PASSED                                                                                                                                          [ 28%]
pytests/test_cphd_consistency.py::test_extended_imagearea_polygon_bad_extent PASSED                                                                                                                       [ 28%]
pytests/test_cphd_consistency.py::test_antenna_missing_channel_node PASSED                                                                                                                                [ 29%]
pytests/test_cphd_consistency.py::test_refgeom_bad_root PASSED                                                                                                                                            [ 30%]
pytests/test_cphd_consistency.py::test_refgeom_bad_monostatic PASSED                                                                                                                                      [ 30%]
pytests/test_cphd_consistency.py::test_refgeom_bad_bistatic PASSED                                                                                                                                        [ 31%]
pytests/test_cphd_consistency.py::test_check_identifier_uniqueness PASSED                                                                                                                                 [ 32%]
pytests/test_cphd_consistency.py::test_check_polynomials[_invalidate_order] PASSED                                                                                                                        [ 32%]
pytests/test_cphd_consistency.py::test_check_polynomials[_invalidate_coef_uniqueness] PASSED                                                                                                              [ 33%]
pytests/test_cphd_consistency.py::test_check_channel_normal_signal_pvp PASSED                                                                                                                             [ 33%]
pytests/test_cphd_consistency.py::test_check_optional_pvps_fx[_fxn_with_toa_domain] PASSED                                                                                                                [ 34%]
pytests/test_cphd_consistency.py::test_check_optional_pvps_fx[_fxn1_only] PASSED                                                                                                                          [ 35%]
pytests/test_cphd_consistency.py::test_check_optional_pvps_toa PASSED                                                                                                                                     [ 35%]
pytests/test_cphd_consistency.py::test_check_channel_toaextsaved PASSED                                                                                                                                   [ 36%]
pytests/test_cphd_consistency.py::test_check_channel_toaextsaved_no_toae1 PASSED                                                                                                                          [ 37%]
pytests/test_cphd_consistency.py::test_check_channel_afdop PASSED                                                                                                                                         [ 37%]
pytests/test_cphd_consistency.py::test_check_channel_afrr1_afrr2_relative PASSED                                                                                                                          [ 38%]
pytests/test_cphd_consistency.py::test_check_channel_afrrs[aFRR1] PASSED                                                                                                                                  [ 39%]
pytests/test_cphd_consistency.py::test_check_channel_afrrs[aFRR2] PASSED                                                                                                                                  [ 39%]
pytests/test_cphd_consistency.py::test_check_channel_identifier_uniqueness PASSED                                                                                                                         [ 40%]
pytests/test_cphd_consistency.py::test_check_channel_rcv_sample_rate PASSED                                                                                                                               [ 41%]
... truncated due to github limitation ...
tests/visualization/test_remap.py::TestRemap::test_LUTRemap_matplotlib PASSED                                                                                                                             [ 89%]
tests/visualization/test_remap.py::TestRemap::test_Linear PASSED                                                                                                                                          [ 89%]
tests/visualization/test_remap.py::TestRemap::test_Logarithmic PASSED                                                                                                                                     [ 90%]
tests/visualization/test_remap.py::TestRemap::test_Logarithmic_const PASSED                                                                                                                               [ 91%]
tests/visualization/test_remap.py::TestRemap::test_MonoRemaps PASSED                                                                                                                                      [ 91%]
tests/visualization/test_remap.py::TestRemap::test_MonochromaticRemap PASSED                                                                                                                              [ 92%]
tests/visualization/test_remap.py::TestRemap::test_NRL PASSED                                                                                                                                             [ 92%]
tests/visualization/test_remap.py::TestRemap::test_NRL_inf PASSED                                                                                                                                         [ 93%]
tests/visualization/test_remap.py::TestRemap::test_NRL_near_const PASSED                                                                                                                                  [ 94%]
tests/visualization/test_remap.py::TestRemap::test_PEDF PASSED                                                                                                                                            [ 94%]
tests/visualization/test_remap.py::TestRemap::test_RemapFunction PASSED                                                                                                                                   [ 95%]
tests/visualization/test_remap.py::TestRemap::test_amplitude_to_density PASSED                                                                                                                            [ 96%]
tests/visualization/test_remap.py::TestRemap::test_amplitude_to_density_zeros PASSED                                                                                                                      [ 96%]
tests/visualization/test_remap.py::TestRemap::test_clip_cast PASSED                                                                                                                                       [ 97%]
tests/visualization/test_remap.py::TestRemap::test_flat_interface PASSED                                                                                                                                  [ 98%]
tests/visualization/test_remap.py::TestRemap::test_get_registered_remap PASSED                                                                                                                            [ 98%]
tests/visualization/test_remap.py::TestRemap::test_get_remap_list PASSED                                                                                                                                  [ 99%]
tests/visualization/test_remap.py::TestRemap::test_remap_names PASSED                                                                                                                                     [100%]

================================================================================= 139 passed, 17 skipped, 7 warnings in 19.87s ==================================================================================

```

</details>