### PR TITLE
Bugfix: SIDD XML namespace handling

### DIFF
--- a/tests/io/product/test_reader.py
+++ b/tests/io/product/test_reader.py
@@ -1,10 +1,14 @@
-import logging
-import os
 import json
+import logging
+import lxml.etree
+import os
+import pathlib
 import unittest
 
 from sarpy.io.product.converter import open_product
 from sarpy.io.product.sidd import SIDDReader
+import sarpy.io.product.sidd
+import sarpy.io.product.sidd2_elements.SIDD as sarpy_sidd2
 
 from tests import parse_file_entry
 
@@ -88,3 +92,16 @@ class TestSIDD(unittest.TestCase):
     def test_sidd_reader(self):
         for test_file in product_file_types['SIDD']:
             generic_reader_test(self, test_file, 'SIDD', SIDDReader)
+
+    def test_from_xml(self):
+        sidd_meta = sarpy_sidd2.SIDDType.from_xml_file(pathlib.Path(__file__).parents[2] / 'data/example.sidd.xml')
+        sarpy.io.product.sidd.validate_sidd_for_writing(sidd_meta)
+
+    def test_from_xml_no_sfa(self):
+        sidd_etree = lxml.etree.parse(str(pathlib.Path(__file__).parents[2] / 'data/example.sidd.xml'))
+        pre_nsmap = sidd_etree.getroot().nsmap
+        lxml.etree.cleanup_namespaces(sidd_etree)
+        post_nsmap = sidd_etree.getroot().nsmap
+        assert 'sfa' in set(pre_nsmap).difference(post_nsmap)
+        sidd_meta = sarpy_sidd2.SIDDType.from_xml_string(lxml.etree.tostring(sidd_etree))
+        sarpy.io.product.sidd.validate_sidd_for_writing(sidd_meta)

--- a/tests/io/product/test_sidd_schema.py
+++ b/tests/io/product/test_sidd_schema.py
@@ -1,0 +1,67 @@
+#
+# Copyright 2023 Valkyrie Systems Corporation
+#
+# Licensed under MIT License.  See LICENSE.
+#
+import re
+
+import lxml.etree
+import pytest
+
+import sarpy.io.product.sidd_schema as sarpy_sidd
+
+
+@pytest.mark.parametrize('sidd_version', sarpy_sidd.get_versions())
+def test_validate_xml_ns(sidd_version):
+    xml_ns, ns_key = get_sidd_nsmap(sidd_version)
+    assert sarpy_sidd.validate_xml_ns(xml_ns, ns_key)
+
+
+def get_sidd_nsmap(sidd_version):
+    schema_root = lxml.etree.parse(sarpy_sidd.get_schema_path(sidd_version)).getroot()
+    reverse_nsmap = {v: k for k, v in schema_root.nsmap.items()}
+    return schema_root.nsmap, reverse_nsmap[schema_root.get('targetNamespace')]
+
+
+@pytest.fixture
+def sidd_nsmap():
+    return get_sidd_nsmap(sarpy_sidd.get_versions()[-1])
+
+
+def test_validate_xml_ns_no_ns_key(sidd_nsmap):
+    xml_ns, ns_key = sidd_nsmap
+    del xml_ns[ns_key]
+    with pytest.raises(ValueError):
+        sarpy_sidd.validate_xml_ns(xml_ns, ns_key)
+
+
+def test_validate_xml_ns_unmapped(sidd_nsmap):
+    xml_ns, _ = sidd_nsmap
+    xml_ns['bad'] = 'urn:SIDD:9.9.9'
+    assert not sarpy_sidd.validate_xml_ns(xml_ns, 'bad')
+
+
+def test_validate_xml_change_keys(sidd_nsmap):
+    xml_ns, ns_key = sidd_nsmap
+    xml_ns_changed_keys = {f'{k}_changed': v for k, v in xml_ns.items()}
+    assert sarpy_sidd.validate_xml_ns(xml_ns_changed_keys, f'{ns_key}_changed')
+
+
+def test_validate_xml_mismatched_ns(sidd_nsmap, caplog):
+    xml_ns, ns_key = sidd_nsmap
+    xml_ns['ism'] += '_make_bad'
+    assert not sarpy_sidd.validate_xml_ns(xml_ns, ns_key)
+    assert re.search(r'namespace urn is expected to be.*but we got', caplog.text)
+
+
+def test_validate_xml_missing_required_ns(sidd_nsmap, caplog):
+    xml_ns, ns_key = sidd_nsmap
+    del xml_ns['ism']
+    assert not sarpy_sidd.validate_xml_ns(xml_ns, ns_key)
+    assert re.search(r'No.* namespace defined.', caplog.text)
+
+
+def test_validate_xml_missing_optional_ns(sidd_nsmap):
+    xml_ns, ns_key = sidd_nsmap
+    del xml_ns['sfa']
+    assert sarpy_sidd.validate_xml_ns(xml_ns, ns_key)


### PR DESCRIPTION
# Description
This PR attempts to fix a bug in SarPy for reading SIDDs that do not declare an XML namespace that they don't use (e.g. `sfa`). Even though these XMLs may be valid according to the schema, a SarPy bug can prevent them from being read and used. This is illustrated in a new test in `tests/io/product/test_reader.py`

<details><summary>running new test in master</summary>

```
============================================================================================= test session starts =============================================================================================
platform linux -- Python 3.6.13, pytest-6.2.4, py-1.11.0, pluggy-0.13.1
rootdir: /home/vscuser/git/glweb/software/third-party/sarpy
collected 3 items                                                                                                                                                                                             

tests/io/product/test_reader.py .Fs                                                                                                                                                                     [100%]

================================================================================================== FAILURES ===================================================================================================
________________________________________________________________________________________ TestSIDD.test_from_xml_no_sfa ________________________________________________________________________________________

self = <tests.io.product.test_reader.TestSIDD testMethod=test_from_xml_no_sfa>

    def test_from_xml_no_sfa(self):
        sidd_etree = lxml.etree.parse(str(pathlib.Path(__file__).parents[2] / 'data/example.sidd.xml'))
        pre_nsmap = sidd_etree.getroot().nsmap
        lxml.etree.cleanup_namespaces(sidd_etree)
        post_nsmap = sidd_etree.getroot().nsmap
        assert 'sfa' in set(pre_nsmap).difference(post_nsmap)
>       sidd_meta = sarpy_sidd2.SIDDType.from_xml_string(lxml.etree.tostring(sidd_etree))

tests/io/product/test_reader.py:106: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
sarpy/io/product/sidd2_elements/SIDD.py:473: in from_xml_string
    return cls.from_node(root_node, xml_ns=xml_ns, ns_key=ns_key)
sarpy/io/product/sidd2_elements/SIDD.py:409: in from_node
    valid_ns = validate_xml_ns(xml_ns, ns_key)
sarpy/io/product/sidd_schema/__init__.py:228: in validate_xml_ns
    valid_ns &= validate_sicommon_urn()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

    def validate_sicommon_urn():
        if 'sicommon' not in xml_ns:
            the_val = None
            for key in xml_ns:
                val = xml_ns[key]
>               if val.lower().startswith('urn:sicommon:'):
E               AttributeError: 'NoneType' object has no attribute 'lower'

sarpy/io/product/sidd_schema/__init__.py:196: AttributeError
---------------------------------------------------------------------------------------------- Captured log call ----------------------------------------------------------------------------------------------
ERROR    validation:__init__.py:187 SIDD: SIDD urn:SIDD:2.0.0 `SFA` namespace urn is expected to be "urn:SFA:1.2.0", but we got "None".
        Differences in standard may lead to deserialization and/or validation errors.
=========================================================================================== short test summary info ===========================================================================================
FAILED tests/io/product/test_reader.py::TestSIDD::test_from_xml_no_sfa - AttributeError: 'NoneType' object has no attribute 'lower'
=================================================================================== 1 failed, 1 passed, 1 skipped in 0.82s ====================================================================================
                                                                                                                                                                                                               

```

</details>

## What is the bug
In `sarpy/io/product/sidd_schema/__init__.py:validate_xml_ns`, if the SFA entry is missing from the namespace dict, SarPy adds an entry valued `None` and then attempts to use string operations which error out in a subsequent validation step (`validate_sicommon_urn`). Therefore, even though sicommon is in the nsmap, due to the order of operations, it cannot be discovered and the reader is unable to parse much of the SIDD metadata.

## What is the fix
We propose simplifying `validate_xml_ns` so that it only updates the namespace dict after searching through all of the expected entries ensuring that modifications only happen after discovery.

In addition, we propose only logging errors for required namespaces that are missing or when specified namespaces do not match their expected values (and not if an optional namespace is not present).

The new unittests should demonstrate the bug and our proposed behavior updates.

# Test Plan
I've tested the changes in this branch using an environment based on python 3.6 and one based on python 3.10

<details><summary>3.6</summary>

```
============================================================================================== test session starts ==============================================================================================
platform linux -- Python 3.6.13, pytest-6.2.4, py-1.11.0, pluggy-0.13.1
rootdir: /home/vscuser/git/glweb/software/third-party/sarpy
collected 172 items                                                                                                                                                                                             

tests/test_class_string.py .                                                                                                                                                                              [  0%]
tests/geometry/test_geocoords.py ..........                                                                                                                                                               [  6%]
tests/geometry/test_geometry_elements.py ..........                                                                                                                                                       [ 12%]
tests/geometry/test_latlon.py ...                                                                                                                                                                         [ 13%]
tests/geometry/test_point_projection.py ............                                                                                                                                                      [ 20%]
tests/io/DEM/test_geoid.py s                                                                                                                                                                              [ 21%]
tests/io/complex/test_reader.py sssssssssss                                                                                                                                                               [ 27%]
tests/io/complex/test_remote.py .                                                                                                                                                                         [ 28%]
tests/io/complex/test_sicd.py s                                                                                                                                                                           [ 29%]
tests/io/complex/test_utils.py .                                                                                                                                                                          [ 29%]
tests/io/general/test_base.py ...                                                                                                                                                                         [ 31%]
tests/io/general/test_data_segment.py ..........                                                                                                                                                          [ 37%]
tests/io/general/test_format_function.py .......                                                                                                                                                          [ 41%]
tests/io/general/test_nitf_headers.py s                                                                                                                                                                   [ 41%]
tests/io/general/test_tre.py .                                                                                                                                                                            [ 42%]
tests/io/phase_history/test_cphd.py .                                                                                                                                                                     [ 43%]
tests/io/phase_history/cphd1_elements/test_utils.py .                                                                                                                                                     [ 43%]
tests/io/product/test_reader.py ..s                                                                                                                                                                       [ 45%]
tests/io/product/test_sidd_schema.py ........                                                                                                                                                             [ 50%]
tests/io/product/test_sidd_writing.py s                                                                                                                                                                   [ 50%]
tests/io/received/test_crsd.py s                                                                                                                                                                          [ 51%]
tests/visualization/test_remap.py ....................                                                                                                                                                    [ 62%]
pytests/test_consistency.py ........                                                                                                                                                                      [ 67%]
pytests/test_cphd_consistency.py ........................................................                                                                                                                 [100%]

=============================================================================================== warnings summary ================================================================================================
tests/geometry/test_point_projection.py::test_image_to_ground_errors
tests/geometry/test_point_projection.py::test_image_to_ground_dem
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/geometry/point_projection.py:1903: RuntimeWarning: divide by zero encountered in double_scalars
    lon_grid_size = min(10, lat_grid_size/numpy.sin(numpy.deg2rad(ref_llh[0])))

-- Docs: https://docs.pytest.org/en/stable/warnings.html
================================================================================= 155 passed, 17 skipped, 2 warnings in 18.76s ==================================================================================
```

</details>

<details><summary>3.10</summary>

```
============================================================================================== test session starts ==============================================================================================
platform linux -- Python 3.10.9, pytest-7.1.2, pluggy-1.0.0
rootdir: /home/vscuser/git/glweb/software/third-party/sarpy
plugins: cov-3.0.0
collected 172 items                                                                                                                                                                                             

tests/test_class_string.py .                                                                                                                                                                              [  0%]
tests/geometry/test_geocoords.py ..........                                                                                                                                                               [  6%]
tests/geometry/test_geometry_elements.py ..........                                                                                                                                                       [ 12%]
tests/geometry/test_latlon.py ...                                                                                                                                                                         [ 13%]
tests/geometry/test_point_projection.py ............                                                                                                                                                      [ 20%]
tests/io/DEM/test_geoid.py s                                                                                                                                                                              [ 21%]
tests/io/complex/test_reader.py sssssssssss                                                                                                                                                               [ 27%]
tests/io/complex/test_remote.py .                                                                                                                                                                         [ 28%]
tests/io/complex/test_sicd.py s                                                                                                                                                                           [ 29%]
tests/io/complex/test_utils.py .                                                                                                                                                                          [ 29%]
tests/io/general/test_base.py ...                                                                                                                                                                         [ 31%]
tests/io/general/test_data_segment.py ..........                                                                                                                                                          [ 37%]
tests/io/general/test_format_function.py .......                                                                                                                                                          [ 41%]
tests/io/general/test_nitf_headers.py s                                                                                                                                                                   [ 41%]
tests/io/general/test_tre.py .                                                                                                                                                                            [ 42%]
tests/io/phase_history/test_cphd.py .                                                                                                                                                                     [ 43%]
tests/io/phase_history/cphd1_elements/test_utils.py .                                                                                                                                                     [ 43%]
tests/io/product/test_reader.py ..s                                                                                                                                                                       [ 45%]
tests/io/product/test_sidd_schema.py ........                                                                                                                                                             [ 50%]
tests/io/product/test_sidd_writing.py s                                                                                                                                                                   [ 50%]
tests/io/received/test_crsd.py s                                                                                                                                                                          [ 51%]
tests/visualization/test_remap.py ....................                                                                                                                                                    [ 62%]
pytests/test_consistency.py ........                                                                                                                                                                      [ 67%]
pytests/test_cphd_consistency.py ........................................................                                                                                                                 [100%]

=============================================================================================== warnings summary ================================================================================================
tests/geometry/test_point_projection.py::test_image_to_ground_errors
tests/geometry/test_point_projection.py::test_image_to_ground_dem
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/geometry/point_projection.py:1903: RuntimeWarning: divide by zero encountered in double_scalars
    lon_grid_size = min(10, lat_grid_size/numpy.sin(numpy.deg2rad(ref_llh[0])))

tests/visualization/test_remap.py::TestRemap::test_LUTRemap_matplotlib
tests/visualization/test_remap.py::TestRemap::test_remap_names
tests/visualization/test_remap.py::TestRemap::test_remap_names
tests/visualization/test_remap.py::TestRemap::test_remap_names
tests/visualization/test_remap.py::TestRemap::test_remap_names
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/visualization/remap.py:1562: PendingDeprecationWarning: The get_cmap function will be deprecated in a future version. Use ``matplotlib.colormaps[name]
`` or ``matplotlib.colormaps.get_cmap(obj)`` instead.                                                                                                                                                                cmap = cm.get_cmap(value, max_out_size+1)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================================= 155 passed, 17 skipped, 7 warnings in 17.24s ==================================================================================

```

</summary>

