### PR TITLE
Bugfix: dimensionality and rounding in CPHD AmpScaling

### DIFF
--- a/sarpy/io/phase_history/cphd.py
+++ b/sarpy/io/phase_history/cphd.py
@@ -151,7 +151,7 @@ class AmpScalingFunction(ComplexFormatFunction):
         # NB: subscript is in raw coordinates, but we have verified that
         #   the first dimension is unchanged
         if self._amplitude_scaling is not None:
-            out = self._amplitude_scaling[subscript[0]]*out
+            out = self._amplitude_scaling[subscript[0]][:, numpy.newaxis] * out
 
         return out
 
@@ -162,7 +162,7 @@ class AmpScalingFunction(ComplexFormatFunction):
         # NB: subscript is in formatted coordinates, but we have verified that
         #   transpose_axes is None and band_dimension is the final dimension
         if self._amplitude_scaling is not None:
-            data = (1./self._amplitude_scaling[subscript[0]])*data
+            data = numpy.rint((1./self._amplitude_scaling[subscript[0]])[:, numpy.newaxis] * data)
 
         return ComplexFormatFunction._reverse_functional_step(self, data, subscript)
 

--- a/tests/io/phase_history/cphd_file_types.json
+++ b/tests/io/phase_history/cphd_file_types.json
@@ -1,6 +1,7 @@
 {
   "CPHD": [
     {"path":  "cphd/example_0_3.cphd", "path_type":  "relative"},
-    {"path":  "cphd/spotlight_example.cphd", "path_type":  "relative"}
+    {"path":  "cphd/spotlight_example.cphd", "path_type":  "relative"},
+    {"path":  "cphd/dynamic_stripmap_ci2.cphd", "path_type":  "relative"}
   ]
 }


### PR DESCRIPTION
# Description
This PR addresses a bug in SarPy's CPHD AmpScaling function that is encountered when reading CPHD signal arrays with integer types that have an AmpSF PVP.

## To reproduce
Add an offending CPHD to `tests/io/phase_history/cphd_file_types.json` and run `pytest tests/io/phase_history/test_cphd.py`

<details><summary>example output</summary>

```
============================================================================================= test session starts =============================================================================================
platform linux -- Python 3.10.9, pytest-7.1.2, pluggy-1.0.0
rootdir: /home/vscuser/git/glweb/software/third-party/sarpy
plugins: cov-3.0.0
collected 1 item                                                                                                                                                                                              

tests/io/phase_history/test_cphd.py F                                                                                                                                                                   [100%]

================================================================================================== FAILURES ===================================================================================================
____________________________________________________________________________________________ TestCPHD.test_cphd_io ____________________________________________________________________________________________

self = <tests.io.phase_history.test_cphd.TestCPHD testMethod=test_cphd_io>

    @unittest.skipIf(len(cphd_file_types.get('CPHD', [])) == 0, 'No CPHD files specified or found')
    def test_cphd_io(self):
        for test_file in cphd_file_types['CPHD']:
>           generic_io_test(self, test_file, 'CPHD', CPHDReader)

tests/io/phase_history/test_cphd.py:152: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
tests/io/phase_history/test_cphd.py:85: in generic_io_test
    test_data = reader[:, :2, i]
sarpy/io/general/base.py:426: in __getitem__
    return self.__call__(*subscript[:-1], index=subscript[-1], raw=raw, squeeze=squeeze)
sarpy/io/phase_history/cphd.py:833: in __call__
    return BaseReader.__call__(self, *ranges, index=index, raw=raw, squeeze=squeeze)
sarpy/io/general/base.py:411: in __call__
    return ds.read(subscript, squeeze=squeeze)
sarpy/io/general/data_segment.py:624: in read
    return self.format_function(raw_data, raw_subscript, squeeze=squeeze)
sarpy/io/general/format_function.py:295: in __call__
    array = self._forward_functional_step(array, subscript)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <sarpy.io.phase_history.cphd.AmpScalingFunction object at 0x7f9cf460b760>
data = memmap([[[ -3,   5],
         [ 69, -22]],

        [[ -7, -56],
         [-28,   1]],

        [[-29,  11],
         ...      [ 16,  13]],

        [[ 45, -24],
         [ -8, -37]],

        [[ 22, -27],
         [-19, -25]]], dtype=int8)
subscript = (slice(0, 2849, 1), slice(0, 2, 1), slice(0, 2, 1))

    def _forward_functional_step(
            self,
            data: numpy.ndarray,
            subscript: Tuple[slice, ...]) -> numpy.ndarray:
        out = ComplexFormatFunction._forward_functional_step(self, data, subscript)
    
        # NB: subscript is in raw coordinates, but we have verified that
        #   the first dimension is unchanged
        if self._amplitude_scaling is not None:
>           out = self._amplitude_scaling[subscript[0]]*out
E           ValueError: operands could not be broadcast together with shapes (2849,) (2849,2)

sarpy/io/phase_history/cphd.py:154: ValueError
=========================================================================================== short test summary info ===========================================================================================
FAILED tests/io/phase_history/test_cphd.py::TestCPHD::test_cphd_io - ValueError: operands could not be broadcast together with shapes (2849,) (2849,2)
============================================================================================== 1 failed in 1.04s ==============================================================================================
                                                                                                                                                                                                               

```

</details>

## To fix
SarPy already makes sure the PVPs are 1D and that the number of vectors match. The missing piece is a second dimension for the scale factors to satisfy numpy's broadcasting.

## Rounding
While testing this issue, we found that the re-read test was failing (see below). We tracked this to a missing round after undoing the amp scaling, meaning samples were being truncated upon writing.

<details><summary>Click to expand</summary>

```
============================================================================================= test session starts =============================================================================================
platform linux -- Python 3.10.9, pytest-7.1.2, pluggy-1.0.0
rootdir: /home/vscuser/git/glweb/software/third-party/sarpy
plugins: cov-3.0.0
collected 1 item                                                                                                                                                                                              

tests/io/phase_history/test_cphd.py F                                                                                                                                                                   [100%]

================================================================================================== FAILURES ===================================================================================================
____________________________________________________________________________________________ TestCPHD.test_cphd_io ____________________________________________________________________________________________

self = <tests.io.phase_history.test_cphd.TestCPHD testMethod=test_cphd_io>

    @unittest.skipIf(len(cphd_file_types.get('CPHD', [])) == 0, 'No CPHD files specified or found')
    def test_cphd_io(self):
        for test_file in cphd_file_types['CPHD']:
>           generic_io_test(self, test_file, 'CPHD', CPHDReader)

tests/io/phase_history/test_cphd.py:152: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
tests/io/phase_history/test_cphd.py:109: in generic_io_test
    generic_writer_test(reader, temp_directory)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

cphd_reader = <sarpy.io.phase_history.cphd.CPHDReader1 object at 0x7fe7ad712bc0>, the_directory = '/data/tmp/tmpmxj2sd9_'

    def generic_writer_test(cphd_reader, the_directory):
        written_cphd_name = os.path.join(the_directory, 'example_cphd.cphd')
    
        read_support = cphd_reader.read_support_block()
        read_pvp = cphd_reader.read_pvp_block()
        read_signal = cphd_reader.read_signal_block()
    
        # write the cphd file
        with CPHDWriter1(written_cphd_name, cphd_reader.cphd_meta, check_existence=False) as writer:
            writer.write_file(read_pvp, read_signal, read_support)
    
        # reread the newly written data
        rereader = CPHDReader(written_cphd_name)
        reread_support = rereader.read_support_block()
        reread_pvp = rereader.read_pvp_block()
        reread_signal = rereader.read_signal_block()
    
        # byte compare that the original data and re-read data are identical
        assert read_support.keys() == reread_support.keys(), 'Support keys are not identical'
        for support_key in reread_support:
            numpy.testing.assert_array_equal(read_support[support_key], reread_support[support_key])
    
        assert reread_pvp.keys() == read_pvp.keys(), 'PVP keys are not identical'
        for pvp_key in reread_pvp:
            numpy.testing.assert_array_equal(read_pvp[pvp_key], reread_pvp[pvp_key])
    
        assert read_signal.keys() == read_signal.keys(), 'Signal keys are not identical'
        for signal_key in reread_signal:
>           numpy.testing.assert_array_equal(read_signal[signal_key], reread_signal[signal_key])
E           AssertionError: 
E           Arrays are not equal
E           
E           Mismatched elements: 737374 / 3632475 (20.3%)
E           Max absolute difference: 0.07193291
E           Max relative difference: 1.4142137
E            x: array([[-0.062761+0.104602j,  1.443511-0.46025j ,  0.041841-0.146443j,
E                   ...,  0.648534+0.209204j, -0.836818-0.041841j,
E                   -0.230125+0.041841j],...
E            y: array([[-0.062761+0.083682j,  1.422591-0.46025j ,  0.02092 -0.125523j,
E                   ...,  0.627613+0.188284j, -0.815898-0.02092j ,
E                   -0.230125+0.02092j ],...

tests/io/phase_history/test_cphd.py:143: AssertionError
=========================================================================================== short test summary info ===========================================================================================
FAILED tests/io/phase_history/test_cphd.py::TestCPHD::test_cphd_io - AssertionError: 
============================================================================================== 1 failed in 3.06s ==============================================================================================
                                                                                                                                                                                                               

```

</details>

# Test Plan
After adding a new CI2-valued CPHD (with AmpSF PVP) to SARPY_TEST_PATH, we ran the unittests in python 3.6 and python 3.10:

<details><summary>3.6</summary>

```
============================================================================================= test session starts =============================================================================================
platform linux -- Python 3.6.13, pytest-6.2.4, py-1.11.0, pluggy-0.13.1
rootdir: /home/vscuser/git/glweb/software/third-party/sarpy
collected 162 items                                                                                                                                                                                           

tests/test_class_string.py .                                                                                                                                                                            [  0%]
tests/geometry/test_geocoords.py ..........                                                                                                                                                             [  6%]
tests/geometry/test_geometry_elements.py ..........                                                                                                                                                     [ 12%]
tests/geometry/test_latlon.py ...                                                                                                                                                                       [ 14%]
tests/geometry/test_point_projection.py ............                                                                                                                                                    [ 22%]
tests/io/DEM/test_geoid.py s                                                                                                                                                                            [ 22%]
tests/io/complex/test_reader.py sssssssssss                                                                                                                                                             [ 29%]
tests/io/complex/test_remote.py .                                                                                                                                                                       [ 30%]
tests/io/complex/test_sicd.py s                                                                                                                                                                         [ 30%]
tests/io/complex/test_utils.py .                                                                                                                                                                        [ 31%]
tests/io/general/test_base.py ...                                                                                                                                                                       [ 33%]
tests/io/general/test_data_segment.py ..........                                                                                                                                                        [ 39%]
tests/io/general/test_format_function.py .......                                                                                                                                                        [ 43%]
tests/io/general/test_nitf_headers.py s                                                                                                                                                                 [ 44%]
tests/io/general/test_tre.py .                                                                                                                                                                          [ 45%]
tests/io/phase_history/test_cphd.py .                                                                                                                                                                   [ 45%]
tests/io/phase_history/cphd1_elements/test_utils.py .                                                                                                                                                   [ 46%]
tests/io/product/test_reader.py s                                                                                                                                                                       [ 46%]
tests/io/product/test_sidd_writing.py s                                                                                                                                                                 [ 47%]
tests/io/received/test_crsd.py s                                                                                                                                                                        [ 48%]
tests/visualization/test_remap.py ....................                                                                                                                                                  [ 60%]
pytests/test_consistency.py ........                                                                                                                                                                    [ 65%]
pytests/test_cphd_consistency.py ........................................................                                                                                                               [100%]

============================================================================================== warnings summary ===============================================================================================
tests/geometry/test_point_projection.py::test_image_to_ground_errors
tests/geometry/test_point_projection.py::test_image_to_ground_dem
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/geometry/point_projection.py:1903: RuntimeWarning: divide by zero encountered in double_scalars
    lon_grid_size = min(10, lat_grid_size/numpy.sin(numpy.deg2rad(ref_llh[0])))

-- Docs: https://docs.pytest.org/en/stable/warnings.html
================================================================================ 145 passed, 17 skipped, 2 warnings in 18.22s =================================================================================

```

</details>

<details><summary>3.10</summary>

```
============================================================================================= test session starts =============================================================================================
platform linux -- Python 3.10.9, pytest-7.1.2, pluggy-1.0.0
rootdir: /home/vscuser/git/glweb/software/third-party/sarpy
plugins: cov-3.0.0
collected 162 items                                                                                                                                                                                           

tests/test_class_string.py .                                                                                                                                                                            [  0%]
tests/geometry/test_geocoords.py ..........                                                                                                                                                             [  6%]
tests/geometry/test_geometry_elements.py ..........                                                                                                                                                     [ 12%]
tests/geometry/test_latlon.py ...                                                                                                                                                                       [ 14%]
tests/geometry/test_point_projection.py ............                                                                                                                                                    [ 22%]
tests/io/DEM/test_geoid.py s                                                                                                                                                                            [ 22%]
tests/io/complex/test_reader.py sssssssssss                                                                                                                                                             [ 29%]
tests/io/complex/test_remote.py .                                                                                                                                                                       [ 30%]
tests/io/complex/test_sicd.py s                                                                                                                                                                         [ 30%]
tests/io/complex/test_utils.py .                                                                                                                                                                        [ 31%]
tests/io/general/test_base.py ...                                                                                                                                                                       [ 33%]
tests/io/general/test_data_segment.py ..........                                                                                                                                                        [ 39%]
tests/io/general/test_format_function.py .......                                                                                                                                                        [ 43%]
tests/io/general/test_nitf_headers.py s                                                                                                                                                                 [ 44%]
tests/io/general/test_tre.py .                                                                                                                                                                          [ 45%]
tests/io/phase_history/test_cphd.py .                                                                                                                                                                   [ 45%]
tests/io/phase_history/cphd1_elements/test_utils.py .                                                                                                                                                   [ 46%]
tests/io/product/test_reader.py s                                                                                                                                                                       [ 46%]
tests/io/product/test_sidd_writing.py s                                                                                                                                                                 [ 47%]
tests/io/received/test_crsd.py s                                                                                                                                                                        [ 48%]
tests/visualization/test_remap.py ....................                                                                                                                                                  [ 60%]
pytests/test_consistency.py ........                                                                                                                                                                    [ 65%]
pytests/test_cphd_consistency.py ........................................................                                                                                                               [100%]

============================================================================================== warnings summary ===============================================================================================
tests/geometry/test_point_projection.py::test_image_to_ground_errors
tests/geometry/test_point_projection.py::test_image_to_ground_dem
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/geometry/point_projection.py:1903: RuntimeWarning: divide by zero encountered in double_scalars
    lon_grid_size = min(10, lat_grid_size/numpy.sin(numpy.deg2rad(ref_llh[0])))

tests/visualization/test_remap.py::TestRemap::test_LUTRemap_matplotlib
tests/visualization/test_remap.py::TestRemap::test_remap_names
tests/visualization/test_remap.py::TestRemap::test_remap_names
tests/visualization/test_remap.py::TestRemap::test_remap_names
tests/visualization/test_remap.py::TestRemap::test_remap_names
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/visualization/remap.py:1562: PendingDeprecationWarning: The get_cmap function will be deprecated in a future version. Use ``matplotlib.colormaps[nam
e]`` or ``matplotlib.colormaps.get_cmap(obj)`` instead.                                                                                                                                                            cmap = cm.get_cmap(value, max_out_size+1)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================================ 145 passed, 17 skipped, 7 warnings in 19.36s =================================================================================

```

</details>