### PR TITLE
Add Additional sicd_elements Tests

### DIFF
--- a/sarpy/io/complex/sicd_elements/ImageData.py
+++ b/sarpy/io/complex/sicd_elements/ImageData.py
@@ -28,10 +28,10 @@ class FullImageType(Serializable, Arrayable):
     _required = _fields
     # descriptors
     NumRows = IntegerDescriptor(
-        'NumRows', _required, strict=True,
+        'NumRows', _required, strict=DEFAULT_STRICT,
         docstring='Number of rows in the original full image product. May include zero pixels.')  # type: int
     NumCols = IntegerDescriptor(
-        'NumCols', _required, strict=True,
+        'NumCols', _required, strict=DEFAULT_STRICT,
         docstring='Number of columns in the original full image product. May include zero pixels.')  # type: int
 
     def __init__(
@@ -88,7 +88,7 @@ class FullImageType(Serializable, Arrayable):
 
         if isinstance(array, (numpy.ndarray, list, tuple)):
             if len(array) < 2:
-                raise ValueError('Expected array to be of length 2, and received {}'.format(array))
+                raise ValueError('Expected array to be of length 2, and received {}'.format(len(array)))
             return cls(NumRows=array[0], NumCols=array[1])
         raise ValueError('Expected array to be numpy.ndarray, list, or tuple, got {}'.format(type(array)))
 

--- a/sarpy/io/complex/sicd_elements/RadarCollection.py
+++ b/sarpy/io/complex/sicd_elements/RadarCollection.py
@@ -65,7 +65,11 @@ def get_band_name(freq: float) -> str:
         return 'K'
     elif 2.7e10 <= freq < 4e10:
         return 'KA'
-    elif 4e10 <= freq < 3e20:
+    elif 4e10 <= freq < 7.5e10:
+        return 'V'
+    elif 7.5e10 <= freq < 1.1e11:
+        return 'W'
+    elif 1.1e11 <= freq < 3e11:
         return 'MM'
     else:
         return 'UN'
@@ -180,7 +184,7 @@ class TxFrequencyType(Serializable, Arrayable):
             return None
         if isinstance(array, (numpy.ndarray, list, tuple)):
             if len(array) < 2:
-                raise ValueError('Expected array to be of length 2, and received {}'.format(array))
+                raise ValueError('Expected array to be of length 2, and received {}'.format(len(array)))
             return cls(Min=array[0], Max=array[1])
         raise ValueError('Expected array to be numpy.ndarray, list, or tuple, got {}'.format(type(array)))
 
@@ -235,7 +239,7 @@ class WaveformParametersType(Serializable):
             TxRFBandwidth: Optional[float] = None,
             TxFreqStart: Optional[float] = None,
             TxFMRate: Optional[float] = None,
-            RcvDemodType: Optional[float] = None,
+            RcvDemodType: Optional[str] = None,
             RcvWindowLength: Optional[float] = None,
             ADCSampleRate: Optional[float] = None,
             RcvIFBandwidth: Optional[float] = None,
@@ -275,8 +279,10 @@ class WaveformParametersType(Serializable):
         # NB: self.RcvDemodType is read only.
         if RcvDemodType == 'CHIRP' and RcvFMRate is None:
             self.RcvFMRate = 0.0
-        else:
+        elif RcvDemodType == 'STRETCH' and RcvFMRate is not None:
             self.RcvFMRate = RcvFMRate
+        else:
+            self.RcvFMRate = None
         self.index = index
         super(WaveformParametersType, self).__init__(**kwargs)
 

--- a/tests/data/example.sicd.rma.xml
+++ b/tests/data/example.sicd.rma.xml
@@ -938,6 +938,22 @@
   <Timeline>
     <CollectStart>2022-12-05T18:41:24.051402Z</CollectStart>
     <CollectDuration>3.4668291025146964</CollectDuration>
+    <IPP size="1">
+      <Set index="1">
+        <TStart>0.0056816659534297907</TStart>
+        <TEnd>3.4628234234795321</TEnd>
+        <IPPStart>0</IPPStart>
+        <IPPEnd>2080</IPPEnd>
+        <IPPPoly order1="5">
+          <Coef exponent1="0">-3.4200358124461596</Coef>
+          <Coef exponent1="1">601.94243049797956</Coef>
+          <Coef exponent1="2">-2.5957560931224679e-05</Coef>
+          <Coef exponent1="3">-2.0559365748016132e-08</Coef>
+          <Coef exponent1="4">8.5465035653447778e-11</Coef>
+          <Coef exponent1="5">1.5613913034987107e-13</Coef>
+        </IPPPoly>
+      </Set>
+    </IPP>
   </Timeline>
   <Position>
     <ARPPoly>
@@ -1161,6 +1177,58 @@
     <AzimAng>9.999477966137635</AzimAng>
     <LayoverAng>352.4590940290721</LayoverAng>
   </SCPCOA>
+    <Radiometric>
+        <NoiseLevel>
+            <NoiseLevelType>ABSOLUTE</NoiseLevelType>
+            <NoisePoly order1="0" order2="0">
+                <Coef exponent1="0" exponent2="0">1</Coef>
+            </NoisePoly>
+        </NoiseLevel>
+        <RCSSFPoly order1="5" order2="6">
+            <Coef exponent1="0" exponent2="0">234.567891</Coef>
+            <Coef exponent1="0" exponent2="1">0.0123456789</Coef>
+            <Coef exponent1="0" exponent2="2">3.45678912e-05</Coef>
+            <Coef exponent1="0" exponent2="3">1.23456789e-09</Coef>
+            <Coef exponent1="0" exponent2="4">2.34567891e-12</Coef>
+            <Coef exponent1="0" exponent2="5">1.23456789e-16</Coef>
+            <Coef exponent1="0" exponent2="6">1.23456789e-19</Coef>
+            <Coef exponent1="1" exponent2="0">-0.023456789</Coef>
+            <Coef exponent1="1" exponent2="1">-5.67891234e-06</Coef>
+            <Coef exponent1="1" exponent2="2">-4.56789123e-09</Coef>
+            <Coef exponent1="1" exponent2="3">-8.91234567e-13</Coef>
+            <Coef exponent1="1" exponent2="4">-4.56789123e-16</Coef>
+            <Coef exponent1="1" exponent2="5">-9.12345678e-20</Coef>
+            <Coef exponent1="1" exponent2="6">-3.45678912e-23</Coef>
+            <Coef exponent1="2" exponent2="0">5.67891234e-05</Coef>
+            <Coef exponent1="2" exponent2="1">3.45678912e-09</Coef>
+            <Coef exponent1="2" exponent2="2">7.89123456e-12</Coef>
+            <Coef exponent1="2" exponent2="3">4.56789123e-16</Coef>
+            <Coef exponent1="2" exponent2="4">5.67891234e-19</Coef>
+            <Coef exponent1="2" exponent2="5">6.78912345e-23</Coef>
+            <Coef exponent1="2" exponent2="6">5.67891234e-26</Coef>
+            <Coef exponent1="3" exponent2="0">-6.78912345e-09</Coef>
+            <Coef exponent1="3" exponent2="1">-1.23456789e-12</Coef>
+            <Coef exponent1="3" exponent2="2">-1.23456789e-15</Coef>
+            <Coef exponent1="3" exponent2="3">-7.89123456e-20</Coef>
+            <Coef exponent1="3" exponent2="4">-6.78912345e-23</Coef>
+            <Coef exponent1="3" exponent2="5">-5.67891234e-26</Coef>
+            <Coef exponent1="3" exponent2="6">-1.23456789e-29</Coef>
+            <Coef exponent1="4" exponent2="0">7.89123456e-12</Coef>
+            <Coef exponent1="4" exponent2="1">5.67891234e-16</Coef>
+            <Coef exponent1="4" exponent2="2">1.23456789e-18</Coef>
+            <Coef exponent1="4" exponent2="3">1.23456789e-22</Coef>
+            <Coef exponent1="4" exponent2="4">1.23456789e-25</Coef>
+            <Coef exponent1="4" exponent2="5">1.23456789e-29</Coef>
+            <Coef exponent1="4" exponent2="6">6.78912345e-33</Coef>
+            <Coef exponent1="5" exponent2="0">-1.23456789e-15</Coef>
+            <Coef exponent1="5" exponent2="1">-1.23456789e-19</Coef>
+            <Coef exponent1="5" exponent2="2">-1.23456789e-22</Coef>
+            <Coef exponent1="5" exponent2="3">-8.91234567e-26</Coef>
+            <Coef exponent1="5" exponent2="4">-4.56789123e-29</Coef>
+            <Coef exponent1="5" exponent2="5">9.12345678e-33</Coef>
+            <Coef exponent1="5" exponent2="6">2.34567891e-36</Coef>
+        </RCSSFPoly>
+    </Radiometric>
   <Antenna>
     <Tx>
       <XAxisPoly>

--- a/tests/data/example.sicd.xml
+++ b/tests/data/example.sicd.xml
@@ -393,11 +393,25 @@
     <Timeline>
         <CollectStart>2022-12-05T18:41:24.051402Z</CollectStart>
         <CollectDuration>3.4668291025146964</CollectDuration>
-        <IPP size="1">
+        <IPP size="2">
             <Set index="1">
                 <TStart>0.0056816659534297907</TStart>
-                <TEnd>3.4628234234795321</TEnd>
+                <TEnd>1.734252544716481</TEnd>
                 <IPPStart>0</IPPStart>
+                <IPPEnd>1040</IPPEnd>
+                <IPPPoly order1="5">
+                    <Coef exponent1="0">-3.4200358124461596</Coef>
+                    <Coef exponent1="1">601.94243049797956</Coef>
+                    <Coef exponent1="2">-2.5957560931224679e-05</Coef>
+                    <Coef exponent1="3">-2.0559365748016132e-08</Coef>
+                    <Coef exponent1="4">8.5465035653447778e-11</Coef>
+                    <Coef exponent1="5">1.5613913034987107e-13</Coef>
+                </IPPPoly>
+            </Set>
+            <Set index="2">
+                <TStart>1.734252544716481</TStart>
+                <TEnd>3.4628234234795321</TEnd>
+                <IPPStart>1041</IPPStart>
                 <IPPEnd>2080</IPPEnd>
                 <IPPPoly order1="5">
                     <Coef exponent1="0">-3.4200358124461596</Coef>
@@ -646,6 +660,58 @@
         <AzimAng>9.9994779614198173</AzimAng>
         <LayoverAng>352.45909403041333</LayoverAng>
     </SCPCOA>
+    <Radiometric>
+        <NoiseLevel>
+            <NoiseLevelType>ABSOLUTE</NoiseLevelType>
+            <NoisePoly order1="0" order2="0">
+                <Coef exponent1="0" exponent2="0">-47.698407849729996</Coef>
+            </NoisePoly>
+        </NoiseLevel>
+        <RCSSFPoly order1="5" order2="6">
+            <Coef exponent1="0" exponent2="0">234.567891</Coef>
+            <Coef exponent1="0" exponent2="1">0.0123456789</Coef>
+            <Coef exponent1="0" exponent2="2">3.45678912e-05</Coef>
+            <Coef exponent1="0" exponent2="3">1.23456789e-09</Coef>
+            <Coef exponent1="0" exponent2="4">2.34567891e-12</Coef>
+            <Coef exponent1="0" exponent2="5">1.23456789e-16</Coef>
+            <Coef exponent1="0" exponent2="6">1.23456789e-19</Coef>
+            <Coef exponent1="1" exponent2="0">-0.023456789</Coef>
+            <Coef exponent1="1" exponent2="1">-5.67891234e-06</Coef>
+            <Coef exponent1="1" exponent2="2">-4.56789123e-09</Coef>
+            <Coef exponent1="1" exponent2="3">-8.91234567e-13</Coef>
+            <Coef exponent1="1" exponent2="4">-4.56789123e-16</Coef>
+            <Coef exponent1="1" exponent2="5">-9.12345678e-20</Coef>
+            <Coef exponent1="1" exponent2="6">-3.45678912e-23</Coef>
+            <Coef exponent1="2" exponent2="0">5.67891234e-05</Coef>
+            <Coef exponent1="2" exponent2="1">3.45678912e-09</Coef>
+            <Coef exponent1="2" exponent2="2">7.89123456e-12</Coef>
+            <Coef exponent1="2" exponent2="3">4.56789123e-16</Coef>
+            <Coef exponent1="2" exponent2="4">5.67891234e-19</Coef>
+            <Coef exponent1="2" exponent2="5">6.78912345e-23</Coef>
+            <Coef exponent1="2" exponent2="6">5.67891234e-26</Coef>
+            <Coef exponent1="3" exponent2="0">-6.78912345e-09</Coef>
+            <Coef exponent1="3" exponent2="1">-1.23456789e-12</Coef>
+            <Coef exponent1="3" exponent2="2">-1.23456789e-15</Coef>
+            <Coef exponent1="3" exponent2="3">-7.89123456e-20</Coef>
+            <Coef exponent1="3" exponent2="4">-6.78912345e-23</Coef>
+            <Coef exponent1="3" exponent2="5">-5.67891234e-26</Coef>
+            <Coef exponent1="3" exponent2="6">-1.23456789e-29</Coef>
+            <Coef exponent1="4" exponent2="0">7.89123456e-12</Coef>
+            <Coef exponent1="4" exponent2="1">5.67891234e-16</Coef>
+            <Coef exponent1="4" exponent2="2">1.23456789e-18</Coef>
+            <Coef exponent1="4" exponent2="3">1.23456789e-22</Coef>
+            <Coef exponent1="4" exponent2="4">1.23456789e-25</Coef>
+            <Coef exponent1="4" exponent2="5">1.23456789e-29</Coef>
+            <Coef exponent1="4" exponent2="6">6.78912345e-33</Coef>
+            <Coef exponent1="5" exponent2="0">-1.23456789e-15</Coef>
+            <Coef exponent1="5" exponent2="1">-1.23456789e-19</Coef>
+            <Coef exponent1="5" exponent2="2">-1.23456789e-22</Coef>
+            <Coef exponent1="5" exponent2="3">-8.91234567e-26</Coef>
+            <Coef exponent1="5" exponent2="4">-4.56789123e-29</Coef>
+            <Coef exponent1="5" exponent2="5">9.12345678e-33</Coef>
+            <Coef exponent1="5" exponent2="6">2.34567891e-36</Coef>
+        </RCSSFPoly>
+    </Radiometric>
     <Antenna>
         <Tx>
             <XAxisPoly>

--- a/tests/io/complex/sicd_elements/test_sicd_elements.py
+++ b/tests/io/complex/sicd_elements/test_sicd_elements.py
@@ -11,13 +11,18 @@ import pytest
 
 from sarpy.io.complex.sicd_elements import blocks
 from sarpy.io.complex.sicd_elements import Grid
+from sarpy.io.complex.sicd_elements import ImageData
 from sarpy.io.complex.sicd_elements import PFA
+from sarpy.io.complex.sicd_elements import RadarCollection
+from sarpy.io.complex.sicd_elements import Radiometric
+from sarpy.io.complex.sicd_elements import RgAzComp
+from sarpy.io.complex.sicd_elements import Timeline
 from sarpy.io.complex.sicd_elements import utils
 from sarpy.io.complex.sicd_elements import validation_checks
 from sarpy.io.complex.sicd_elements.SICD import SICDType
 from sarpy.io.xml.base import parse_xml_from_string
 TOLERANCE = 1e-8
-
+KWARGS = {'_xml_ns': 'ns', '_xml_ns_key': 'key'}
 
 @pytest.fixture(scope='module')
 def sicd():
@@ -113,18 +118,17 @@ def test_pfa(sicd):
     stdeskew = PFA.STDeskewType()
     assert isinstance(stdeskew, PFA.STDeskewType)
 
-    kwargs = {'_xml_ns': 'ns', '_xml_ns_key': 'key'}
     made_up_poly = blocks.Poly2DType([[10, 5], [8, 3], [1, 0.5]])
-    stdeskew = PFA.STDeskewType(False, made_up_poly, **kwargs)
+    stdeskew = PFA.STDeskewType(False, made_up_poly, **KWARGS)
     assert stdeskew.Applied is False
     assert stdeskew.STDSPhasePoly == made_up_poly
-    assert stdeskew._xml_ns == 'ns'
-    assert stdeskew._xml_ns_key == 'key'
+    assert stdeskew._xml_ns == KWARGS['_xml_ns']
+    assert stdeskew._xml_ns_key == KWARGS['_xml_ns_key']
 
     #Nominal instantiation
     pfa_nom = PFA.PFAType(sicd.PFA.FPN,
                           sicd.PFA.IPN,
-                          sicd.PFA.PolarAngRefTime,
+                          sicd.PFA.PolarAngRefTime, 
                           sicd.PFA.PolarAngPoly,
                           sicd.PFA.SpatialFreqSFPoly,
                           sicd.PFA.Krg1,
@@ -132,10 +136,10 @@ def test_pfa(sicd):
                           sicd.PFA.Kaz1,
                           sicd.PFA.Kaz2,
                           stdeskew,
-                          **kwargs)
+                          **KWARGS)
     assert isinstance(pfa_nom, PFA.PFAType)
-    assert pfa_nom._xml_ns == 'ns'
-    assert pfa_nom._xml_ns_key == 'key'
+    assert pfa_nom._xml_ns == KWARGS['_xml_ns']
+    assert pfa_nom._xml_ns_key == KWARGS['_xml_ns_key']
     assert pfa_nom._basic_validity_check()
     assert pfa_nom._check_polar_ang_ref()
 
@@ -150,7 +154,7 @@ def test_pfa(sicd):
                              sicd.PFA.Kaz1,
                              sicd.PFA.Kaz2,
                              stdeskew,
-                             **kwargs)
+                             **KWARGS)
     assert pfa_no_pap._check_polar_ang_ref()
 
     # Populate empty PFAType with sicd components after instantiation
@@ -317,12 +321,11 @@ def test_grid_wgttype():
     name = 'UNIFORM'
     params = {'fake_params': 'this_fake_str',
               'fake_params1': 'another_fake_str'}
-    kwargs = {'_xml_ns': 'ns', '_xml_ns_key': 'key'}
 
     # Check basic WgtTypeType instantiation
-    weight = Grid.WgtTypeType(WindowName=name, Parameters=params, **kwargs)
-    assert weight._xml_ns == 'ns'
-    assert weight._xml_ns_key == 'key'
+    weight = Grid.WgtTypeType(WindowName=name, Parameters=params, **KWARGS)
+    assert weight._xml_ns == KWARGS['_xml_ns']
+    assert weight._xml_ns_key == KWARGS['_xml_ns_key']
 
     # get_parameter_value checks
     assert weight.get_parameter_value('fake_params1') == params['fake_params1']
@@ -351,3 +354,314 @@ def test_grid_wgttype():
     assert weight1.Parameters.get('nbar') == '5'
     assert weight1.Parameters.get('sll_db') == '-35.0'
     assert weight1.Parameters.get('osf') == '1.2763784887678868'
+
+
+def test_radiometric(sicd, rma_sicd):
+    noise_level = Radiometric.NoiseLevelType_()
+    assert noise_level.NoiseLevelType is None
+    assert noise_level.NoisePoly is None
+
+    noise_level = Radiometric.NoiseLevelType_('ABSOLUTE')
+    assert noise_level.NoiseLevelType == 'ABSOLUTE'
+    assert noise_level.NoisePoly is None
+
+    noise_level = Radiometric.NoiseLevelType_(None, rma_sicd.Radiometric.NoiseLevel.NoisePoly, **KWARGS)
+    assert noise_level.NoiseLevelType == 'RELATIVE'
+
+    noise_level = Radiometric.NoiseLevelType_(None, sicd.Radiometric.NoiseLevel.NoisePoly, **KWARGS)
+    assert noise_level._xml_ns == KWARGS['_xml_ns']
+    assert noise_level._xml_ns_key == KWARGS['_xml_ns_key']
+    assert noise_level.NoiseLevelType == 'ABSOLUTE'
+    assert noise_level.NoisePoly == sicd.Radiometric.NoiseLevel.NoisePoly
+
+    radio_type = Radiometric.RadiometricType()
+    assert radio_type.NoiseLevel is None
+    assert radio_type.RCSSFPoly is None
+    assert radio_type.SigmaZeroSFPoly is None
+    assert radio_type.BetaZeroSFPoly is None
+    assert radio_type.GammaZeroSFPoly is None
+
+    radio_type = Radiometric.RadiometricType(noise_level, sicd.Radiometric.RCSSFPoly)
+    assert radio_type.NoiseLevel == noise_level
+    assert radio_type.RCSSFPoly == sicd.Radiometric.RCSSFPoly
+
+    radio_type._derive_parameters(sicd.Grid, sicd.SCPCOA)
+    assert radio_type.SigmaZeroSFPoly is not None
+    assert radio_type.BetaZeroSFPoly is not None
+    assert radio_type.GammaZeroSFPoly is not None
+
+    radio_type = Radiometric.RadiometricType(noise_level)
+    assert radio_type.NoiseLevel == noise_level
+    assert radio_type.RCSSFPoly is None
+    assert radio_type.SigmaZeroSFPoly is None
+    assert radio_type.BetaZeroSFPoly is None
+    assert radio_type.GammaZeroSFPoly is None
+
+    radio_type._derive_parameters(sicd.Grid, sicd.SCPCOA)
+    assert radio_type.NoiseLevel == noise_level
+    assert radio_type.RCSSFPoly is None
+    assert radio_type.SigmaZeroSFPoly is None
+    assert radio_type.BetaZeroSFPoly is None
+    assert radio_type.GammaZeroSFPoly is None
+
+
+def test_rgazcomp(rma_sicd):
+    rg_az = RgAzComp.RgAzCompType(None, None, **KWARGS)
+    rg_az._derive_parameters(rma_sicd.Grid, rma_sicd.Timeline, rma_sicd.SCPCOA)
+    assert rg_az._xml_ns == KWARGS['_xml_ns']
+    assert rg_az._xml_ns_key == KWARGS['_xml_ns_key']
+    assert rg_az.AzSF is not None
+    assert rg_az.KazPoly is not None
+
+
+def test_timeline(sicd):
+    def get_ipp_set(ipp, idx, **kwargs):
+        return Timeline.IPPSetType(ipp.TStart,
+                                   ipp.TEnd,
+                                   ipp.IPPStart,
+                                   ipp.IPPEnd,
+                                   ipp.IPPPoly,
+                                   idx,
+                                   **kwargs)
+
+    ippset1 = get_ipp_set(sicd.Timeline.IPP[0], 1, **KWARGS)
+    assert ippset1.TStart == sicd.Timeline.IPP[0].TStart
+    assert ippset1.TEnd == sicd.Timeline.IPP[0].TEnd
+    assert ippset1.IPPStart == sicd.Timeline.IPP[0].IPPStart
+    assert ippset1.IPPEnd == sicd.Timeline.IPP[0].IPPEnd
+    assert ippset1.IPPPoly == sicd.Timeline.IPP[0].IPPPoly
+    assert ippset1._basic_validity_check()
+
+    ippset2 = get_ipp_set(sicd.Timeline.IPP[1], 2, **KWARGS)
+    ipp_list = [ippset1, ippset2]
+
+    timeline = Timeline.TimelineType(sicd.Timeline.CollectStart,
+                                     sicd.Timeline.CollectDuration,
+                                     ipp_list)
+    assert timeline.CollectStart == sicd.Timeline.CollectStart
+    assert timeline.CollectDuration == sicd.Timeline.CollectDuration
+
+    for idx in np.arange(len(timeline.IPP)):
+        assert timeline.IPP[idx].TStart == ipp_list[idx].TStart
+        assert timeline.IPP[idx].TEnd == ipp_list[idx].TEnd
+        assert timeline.IPP[idx].IPPStart == ipp_list[idx].IPPStart
+        assert timeline.IPP[idx].IPPEnd == ipp_list[idx].IPPEnd
+        assert timeline.IPP[idx].IPPPoly == ipp_list[idx].IPPPoly
+
+    assert timeline.CollectEnd == timeline.CollectStart + np.timedelta64(int(timeline.CollectDuration*1e6), 'us')
+    assert timeline._check_ipp_consecutive()
+    assert timeline._check_ipp_times()
+    assert timeline._basic_validity_check()
+
+    # Check bail out for IPP consecutive with a single IPP set
+    timeline = Timeline.TimelineType(sicd.Timeline.CollectStart,
+                                     sicd.Timeline.CollectDuration,
+                                     ipp_list[0])
+    assert timeline._check_ipp_consecutive()
+
+
+def test_timeline_start_end_mismatches(sicd, caplog):
+    # Swap Tstart and TEnd along with IPPStart and IPPEnd
+    ipp0 = sicd.Timeline.IPP[0]
+    bad_ippset = Timeline.IPPSetType(ipp0.TEnd,
+                                     ipp0.TStart,
+                                     ipp0.IPPEnd,
+                                     ipp0.IPPStart,
+                                     ipp0.IPPPoly,
+                                     1,
+                                     **KWARGS)
+    bad_ippset._basic_validity_check()
+    assert 'TStart ({}) >= TEnd ({})'.format(ipp0.TEnd, ipp0.TStart) in caplog.text
+    assert 'IPPStart ({}) >= IPPEnd ({})'.format(ipp0.IPPEnd, ipp0.IPPStart) in caplog.text
+
+    # CollectEnd is None with no CollectStart
+    bad_timeline = Timeline.TimelineType(None, sicd.Timeline.CollectDuration, bad_ippset)
+    assert bad_timeline.CollectEnd is None
+
+
+def test_timeline_negative_tstart(sicd, caplog):
+    # Negative TStart
+    ipp0 = sicd.Timeline.IPP[0]
+    bad_ippset = Timeline.IPPSetType(-ipp0.TStart,
+                                     ipp0.TEnd,
+                                     ipp0.IPPStart,
+                                     ipp0.IPPEnd,
+                                     ipp0.IPPPoly,
+                                     1,
+                                     **KWARGS)
+    bad_timeline = Timeline.TimelineType(None, sicd.Timeline.CollectDuration, bad_ippset)
+    bad_timeline._check_ipp_times()
+    assert 'IPP entry 0 has negative TStart' in caplog.text
+
+
+def test_timeline_bad_tend(sicd, caplog):
+    # TEnd too large
+    ipp0 = sicd.Timeline.IPP[0]
+    bad_ippset = Timeline.IPPSetType(ipp0.TStart,
+                                     sicd.Timeline.CollectDuration+1,
+                                     ipp0.IPPStart,
+                                     ipp0.IPPEnd,
+                                     ipp0.IPPPoly,
+                                     1,
+                                     **KWARGS)
+    bad_timeline = Timeline.TimelineType(None, sicd.Timeline.CollectDuration, bad_ippset)
+    bad_timeline._check_ipp_times()
+    assert 'appreciably larger than CollectDuration' in caplog.text
+
+
+def test_timeline_unset_ipp(sicd):
+    # Check times is True with no IPP set
+    bad_timeline = Timeline.TimelineType(sicd.Timeline.CollectStart, sicd.Timeline.CollectDuration, None)
+    assert bad_timeline._check_ipp_times()
+
+
+def test_imagedata(sicd, caplog):
+    image_type = ImageData.FullImageType()
+    assert image_type.NumRows is None
+    assert image_type.NumCols is None
+
+    image_type = image_type.from_array([sicd.ImageData.NumRows, sicd.ImageData.NumCols])
+    assert image_type.NumRows == sicd.ImageData.NumRows
+    assert image_type.NumCols == sicd.ImageData.NumCols
+
+    with pytest.raises(ValueError, match='Expected array to be of length 2, and received 1'):
+        image_type.from_array([sicd.ImageData.NumRows])
+    with pytest.raises(ValueError, match='Expected array to be numpy.ndarray, list, or tuple'):
+        image_type.from_array(image_type)
+
+    image_type1 = ImageData.FullImageType(sicd.ImageData.NumRows, sicd.ImageData.NumCols, **KWARGS)
+    assert image_type1._xml_ns == KWARGS['_xml_ns']
+    assert image_type1._xml_ns_key == KWARGS['_xml_ns_key']
+    assert image_type1.NumRows == sicd.ImageData.NumRows
+    assert image_type1.NumCols == sicd.ImageData.NumCols
+
+    image_array = image_type.get_array()
+    assert np.all(image_array == np.array([sicd.ImageData.NumRows, sicd.ImageData.NumCols]))
+
+    amp_table = np.ones((256, 256))
+    image_data = ImageData.ImageDataType('AMP8I_PHS8I',
+                                         None,
+                                         sicd.ImageData.NumRows,
+                                         sicd.ImageData.NumCols,
+                                         sicd.ImageData.FirstRow,
+                                         sicd.ImageData.FirstCol,
+                                         sicd.ImageData.FullImage,
+                                         sicd.ImageData.SCPPixel,
+                                         sicd.ImageData.ValidData,
+                                         **KWARGS)
+    assert image_data._xml_ns == KWARGS['_xml_ns']
+    assert image_data._xml_ns_key == KWARGS['_xml_ns_key']
+    assert image_data.get_pixel_size() == 2
+    assert not image_data._basic_validity_check()
+    assert "We have `PixelType='AMP8I_PHS8I'` and `AmpTable` is not defined for ImageDataType" in caplog.text
+
+    image_data = ImageData.ImageDataType('RE32F_IM32F',
+                                         amp_table,
+                                         sicd.ImageData.NumRows,
+                                         sicd.ImageData.NumCols,
+                                         sicd.ImageData.FirstRow,
+                                         sicd.ImageData.FirstCol,
+                                         sicd.ImageData.FullImage,
+                                         sicd.ImageData.SCPPixel,
+                                         sicd.ImageData.ValidData,
+                                         **KWARGS)
+    assert image_data.get_pixel_size() == 8
+    assert not image_data._basic_validity_check()
+    assert "We have `PixelType != 'AMP8I_PHS8I'` and `AmpTable` is defined for ImageDataType" in caplog.text
+
+    image_data = ImageData.ImageDataType('RE32F_IM32F',
+                                         None,
+                                         sicd.ImageData.NumRows,
+                                         sicd.ImageData.NumCols,
+                                         sicd.ImageData.FirstRow,
+                                         sicd.ImageData.FirstCol,
+                                         sicd.ImageData.FullImage,
+                                         sicd.ImageData.SCPPixel,
+                                         sicd.ImageData.ValidData,
+                                         **KWARGS)
+    assert image_data._basic_validity_check()
+
+    assert image_data._check_valid_data()
+
+    valid_vertex_data = image_data.get_valid_vertex_data()
+    assert len(valid_vertex_data) == len(sicd.ImageData.ValidData)
+
+    full_vertex_data = image_data.get_full_vertex_data()
+    assert np.all(full_vertex_data == np.array([[0, 0],
+                                                [0, image_data.NumCols - 1],
+                                                [image_data.NumRows - 1, image_data.NumCols - 1],
+                                                [image_data.NumRows - 1, 0]]))
+
+    image_data.PixelType = 'RE16I_IM16I'
+    assert image_data.get_pixel_size() == 4
+
+
+def test_radarcollection_getbandname():
+    assert RadarCollection.get_band_name(None) == 'UN'
+    assert RadarCollection.get_band_name(3.5e6) == 'HF'
+    assert RadarCollection.get_band_name(3.5e7) == 'VHF'
+    assert RadarCollection.get_band_name(3.5e8) == 'UHF'
+    assert RadarCollection.get_band_name(1.5e9) == 'L'
+    assert RadarCollection.get_band_name(2.5e9) == 'S'
+    assert RadarCollection.get_band_name(4.5e9) == 'C'
+    assert RadarCollection.get_band_name(8.5e9) == 'X'
+    assert RadarCollection.get_band_name(1.5e10) == 'KU'
+    assert RadarCollection.get_band_name(2.5e10) == 'K'
+    assert RadarCollection.get_band_name(3.0e10) == 'KA'
+    assert RadarCollection.get_band_name(6.0e10) == 'V'
+    assert RadarCollection.get_band_name(1.0e11) == 'W'
+    assert RadarCollection.get_band_name(2.0e11) == 'MM'
+    assert RadarCollection.get_band_name(5.0e11) == 'UN'
+
+
+def test_radarcollection_txfreqtype(sicd, caplog):
+
+    bad_tx_freq = RadarCollection.TxFrequencyType(None,
+                                                  sicd.RadarCollection.TxFrequency.Max,
+                                                  **KWARGS)
+    assert bad_tx_freq.center_frequency is None
+
+    bad_tx_freq = RadarCollection.TxFrequencyType(sicd.RadarCollection.TxFrequency.Max,
+                                                  sicd.RadarCollection.TxFrequency.Min,
+                                                  **KWARGS)
+    assert not bad_tx_freq._basic_validity_check()
+    assert 'Invalid frequency bounds Min ({}) > Max ({})'.format(bad_tx_freq.Min, bad_tx_freq.Max) in caplog.text
+
+    tx_freq = RadarCollection.TxFrequencyType(sicd.RadarCollection.TxFrequency.Min,
+                                              sicd.RadarCollection.TxFrequency.Max,
+                                              **KWARGS)
+    assert tx_freq._xml_ns == KWARGS['_xml_ns']
+    assert tx_freq._xml_ns_key == KWARGS['_xml_ns_key']
+    assert tx_freq.Min == sicd.RadarCollection.TxFrequency.Min
+    assert tx_freq.Max == sicd.RadarCollection.TxFrequency.Max
+    assert tx_freq.center_frequency == 0.5 * (tx_freq.Min + tx_freq.Max)
+
+    tx_freq._apply_reference_frequency(1000)
+    assert tx_freq.Min == sicd.RadarCollection.TxFrequency.Min + 1000
+    assert tx_freq.Max == sicd.RadarCollection.TxFrequency.Max + 1000
+    assert tx_freq._basic_validity_check()
+    assert tx_freq.get_band_abbreviation() == 'X__'
+
+    tx_freq_arr = tx_freq.get_array()
+    assert np.all(tx_freq_arr == np.array([tx_freq.Min, tx_freq.Max]))
+
+    assert tx_freq.from_array(None) is None
+    tx_freq1 = tx_freq.from_array(tx_freq_arr)
+    assert tx_freq1.Min == tx_freq.Min
+    assert tx_freq1.Max == tx_freq.Max
+
+    with pytest.raises(ValueError, match='Expected array to be of length 2, and received 1'):
+        tx_freq.from_array([tx_freq_arr[0]])
+    with pytest.raises(ValueError, match='Expected array to be numpy.ndarray, list, or tuple'):
+        tx_freq.from_array(tx_freq)
+
+
+def test_radarcollection_waveformparamtype():
+    rc = RadarCollection.WaveformParametersType(RcvDemodType='STRETCH', RcvFMRate=1.0)
+    assert rc.RcvFMRate == 1.0
+
+    rc = RadarCollection.WaveformParametersType(RcvDemodType='CHIRP', RcvFMRate=None)
+    assert rc.RcvFMRate == 0.0
+
+    rc = RadarCollection.WaveformParametersType(RcvDemodType='cHiRp', RcvFMRate=None)
+    assert rc.RcvFMRate == None


### PR DESCRIPTION
Additional unit tests for the `sicd_elements` module

This PR:

1. Minor bugfixes for `sarpy/io/complex/sicd_elements/ImageData.py` 
2. Minor bugfixes for `sarpy/io/complex/sicd_elements/RadarCollection.py`
3. Addition of `Radiometric` and `Timeline.IPP` nodes to `tests/data/example.sicd.xml`
4. Addition of `Radiometric` and `Timeline.IPP` nodes to `tests/data/example.sicd.rma.xml`
5. Additional tests for `Radiometric.py`, `RgAzComp.py`, `Timeline.py`, `ImageData.py`, and parts of `RadarCollection.py` to `tests/io/complex/sicd_elements/test_sicd_elements.py`

Details + Before/After coverage report

<details><summary>Radiometric.py</summary>

**_Coverage from main branch:_**

`pytest tests --cov=sarpy.io.complex.sicd_elements.Radiometric--cov-report term-missing`

|Name|Stmts|Miss|Cover|Missing|
|----|-----|----|-----|-------|
|sarpy/io/complex/sicd_elements/Radiometric.py|78|50|36%|53-60, 63-74, 126-135, 139-146, 162-189|
|TOTAL|78|50|36%||

**_Coverage from this branch:_**

`pytest tests --cov=sarpy.io.complex.sicd_elements.Radiometric--cov-report term-missing`

|Name|Stmts|Miss|Cover|Missing|
|----|-----|----|-----|-------|
|sarpy/io/complex/sicd_elements/Radiometric.py|78|6|92%|140, 145, 163, 174, 177, 184|
|TOTAL|78|6|92%||


</details>

<details><summary>RgAzComp.py</summary>

**_Coverage from main branch:_**

`pytest tests --cov=sarpy.io.complex.sicd_elements.RgAzComp--cov-report term-missing`

|Name|Stmts|Miss|Cover|Missing|
|----|-----|----|-----|-------|
|sarpy/io/complex/sicd_elements/RgAzComp.py|40|21|48%|59-65, 82-105|
|TOTAL|40|21|48%||

**_Coverage from this branch:_**

`pytest tests --cov=sarpy.io.complex.sicd_elements.RgAzComp--cov-report term-missing`

|Name|Stmts|Miss|Cover|Missing|
|----|-----|----|-----|-------|
|sarpy/io/complex/sicd_elements/RgAzComp.py|40|2|95%|86-87|
|TOTAL|40|2|95%||

</details>

<details><summary>Timeline.py</summary>

**_Coverage from main branch:_**

`pytest tests --cov=sarpy.io.complex.sicd_elements.Timeline--cov-report term-missing`

|Name|Stmts|Miss|Cover|Missing|
|----|-----|----|-----|-------|
|sarpy/io/complex/sicd_elements/Timeline.py|105|52|50%|84-105, 160-163, 166-180, 183-206, 209-212|
|TOTAL|105|52|50%||

**_Coverage from this branch:_**

`pytest tests --cov=sarpy.io.complex.sicd_elements.Timeline--cov-report term-missing`

|Name|Stmts|Miss|Cover|Missing|
|----|-----|----|-----|-------|
|sarpy/io/complex/sicd_elements/Timeline.py|105|4|96%|98, 102, 173-176|
|TOTAL|105|4|96%||

</details>

<details><summary>ImageData.py</summary>

BUGFIX: Changed descriptor details from `strict=True` to `srtict=DEFAULT_STRICT` to bring it in line with other class descriptors

BUGFIX: Corrected a ValueError message to reflect what was being checked

**_Coverage from main branch:_**

`pytest tests --cov=sarpy.io.complex.sicd_elements.ImageData--cov-report term-missing`

|Name|Stmts|Miss|Cover|Missing|
|----|-----|----|-----|-------|
|sarpy/io/complex/sicd_elements/ImageData.py|110|49|55%|72, 89-93, 185-207, 210-224, 243-246, 264, 277-284|
|TOTAL|110|49|55%||

**_Coverage from this branch:_**

`pytest tests --cov=sarpy.io.complex.sicd_elements.ImageData--cov-report term-missing`

|Name|Stmts|Miss|Cover|Missing|
|----|-----|----|-----|-------|
|sarpy/io/complex/sicd_elements/ImageData.py|110|13|88%|186, 188, 195-196, 198-200, 204-206, 220-222, 242, 264, 284|
|TOTAL|110|13|88%||

</details>

<details><summary>RadarCollection.py</summary>

BUGFIX: Corrected a ValueError message to reflect what was being checked

BUGFIX: Made setting `RcvFMRate` based on `RcvDemodType` more explicit

BUGFIX: Update `get_band_name` to be more complete and follow IEEE definitions

**_Coverage from main branch:_**

`pytest tests --cov=sarpy.io.complex.sicd_elements.RadarCollection --cov-report term-missing`

|Name|Stmts|Miss|Cover|Missing|
|----|-----|----|-----|-------|
|sarpy/io/complex/sicd_elements/RadarCollection.py|509|288|43%|46-71, 117-119, 122-125, 128-133, 144-145, 162, 179-185, 277, 296-301, 308, 313, 317-322, 325-326, 338, 340, 342, 345-348, 386-393, 441-446, 457, 498-506, 546-554, 594-602, 652-660, 710-718, 730-742, 777-784, 788-793, 806, 903, 912-916, 920-921, 925-941, 945, 949-955, 961, 963, 967, 969, 986-993, 1004-1017, 1022-1030, 1035-1051, 1062-1165, 1168-1172, 1183-1189|
|TOTAL|509|288|43%||

**_Coverage from this branch:_**

`pytest tests --cov=sarpy.io.complex.sicd_elements.RadarCollection --cov-report term-missing`

|Name|Stmts|Miss|Cover|Missing|
|----|-----|----|-----|-------|
|sarpy/io/complex/sicd_elements/RadarCollection.py|511|211|59%|302-305, 321-326, 329-330, 341-346, 349-352, 390-397, 445-450, 461, 656-664, 734-746, 794-797, 905-912, 915-945, 948-959, 964-973, 990-997, 1008-1021, 1026-1034, 1039-1055, 1066-1169, 1172-1176, 1187-1193|
|TOTAL|511|211|59%||

</details>