### PR TITLE
Pr 393

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ SarPy follows a continuous release process, so there are fairly frequent release
 Since essentially every (squash merge) commit corresponds to a release, specific 
 release points are not being annotated in GitHub.
 
+## [1.3.28] - 2023-04-21
+### Fixed
+- Fixed bug in Sarpy correctly handling negative longitudes when calculating longitude grid size in 
+point_projection.image_to_ground_dem.
+
 ## [1.3.27] - 2023-04-17
 ### Added
 - Tests for utils, validation_checks, PFA, RMA, and Grid

--- a/sarpy/__about__.py
+++ b/sarpy/__about__.py
@@ -27,7 +27,7 @@ __all__ = ['__version__',
            '__license__', '__copyright__']
 
 from sarpy.__details__ import __classification__, _post_identifier
-_version_number = '1.3.27'
+_version_number = '1.3.28'
 
 __version__ = _version_number + _post_identifier
 

--- a/sarpy/geometry/point_projection.py
+++ b/sarpy/geometry/point_projection.py
@@ -1900,7 +1900,7 @@ def image_to_ground_dem(
     ref_hae = ref_llh[2]
     # subgrid size definition
     lat_grid_size = 0.03
-    lon_grid_size = min(10, lat_grid_size/numpy.sin(numpy.deg2rad(ref_llh[0])))
+    lon_grid_size = min(10, lat_grid_size/abs(numpy.sin(numpy.deg2rad(ref_llh[0]))))
 
     # validate the dem_interpolator
     if dem_interpolator is None:


### PR DESCRIPTION
[1.3.28] - 2023-04-21
Fixed
Fixed bug in Sarpy correctly handling negative longitudes when calculating longitude grid size in point_projection.image_to_ground_dem.