### PR TITLE
Fix reading S3 SICD read with stride non-multiple of image size.

### DIFF
--- a/sarpy/io/general/data_segment.py
+++ b/sarpy/io/general/data_segment.py
@@ -2447,7 +2447,7 @@ class FileReadDataSegment(DataSegment):
         row_stride = self.raw_dtype.itemsize*pixel_per_row
 
         start_row = init_slice.start
-        rows = out_shape[0] * init_slice.step
+        rows = init_slice.stop - init_slice.start
 
         # read the whole contiguous chunk from start_row up to the final row
         # seek to the proper start location


### PR DESCRIPTION
When reading the entire image of a S3 SICD that has an odd number of rows with stride of 2, I got an error.  The amount of data to be read was taking the output size and multiplying by the stride, but that's too much if the stride isn't a multiple of the input size.

```python
sl = np.s_[0:101:2]
full_image = np.zeros((101, 100))
sub_image = full_image[sl, sl]
print(sub_image.shape[0] * sl.step)
print(sl.stop - sl.start)
```

```
  File "xxx", line 312, in read_chip
    return reader[r1_start:r1_stop:stride, r2_start:r2_stop:stride]
  File "/home/kjurka/git/kjurka/sarpy/sarpy/io/general/base.py", line 427, in __getitem__
    return self.__call__(*subscript, index=0, raw=raw, squeeze=squeeze)
  File "/home/kjurka/git/kjurka/sarpy/sarpy/io/general/base.py", line 411, in __call__
    return ds.read(subscript, squeeze=squeeze)
  File "/home/kjurka/git/kjurka/sarpy/sarpy/io/general/data_segment.py", line 623, in read
    raw_data = self.read_raw(raw_subscript, squeeze=False)
  File "/home/kjurka/git/kjurka/sarpy/sarpy/io/general/data_segment.py", line 2460, in read_raw
    raise ValueError(
ValueError: Tried to read 513984960 bytes of data, but received 513948456. The most likely reason for this is a malformed chipper, which attempts to read more data than the file contains
```