### PR TITLE
Geotiff dem

### DIFF
--- a/docs/io/DEM/geotiff1deg.rst
+++ b/docs/io/DEM/geotiff1deg.rst
@@ -1,0 +1,7 @@
+GeoTIFF reading objects (sarpy.io.DEM.geotiff1deg)
+==================================================
+
+.. automodule:: sarpy.io.DEM.geotiff1deg
+    :members:
+    :show-inheritance:
+    :inherited-members:

--- a/sarpy/io/DEM/geotiff1deg.py
+++ b/sarpy/io/DEM/geotiff1deg.py
@@ -1,0 +1,584 @@
+"""
+Classes and methods for parsing and using digital elevation models in GeoTIFF format.
+
+This code makes the following assumptions.
+    1. The GeoTIFF files tile the earth with one degree offsets in both latitude and longitude.
+    2. There is one pixel of overlap between adjacent tiles.
+    3. The south-west corner of each tile is at an integer (degrees) latitude and longitude.
+    4. The latitude and longitude of south-west corner point is encoded in the GeoTIFF filename.
+    5. The antimerdian is at W180 rather than at E180 so that valid longitude values are (-180 <= lon < 180) degrees.
+    6. The GeoTIFF tag 34737 (GeoAsciiParamsTag) indicates the reference surface (EGM2008 or WGS84).
+"""
+
+import logging
+import os.path
+import warnings
+from PIL import Image, TiffTags
+from scipy.interpolate import RegularGridInterpolator
+
+import numpy as np
+from sarpy.io.DEM.DEM import DEMList
+from sarpy.io.DEM.DEM import DEMInterpolator
+from sarpy.io.DEM.geoid import GeoidHeight
+
+logger = logging.getLogger(__name__)
+
+__classification__ = "UNCLASSIFIED"
+__author__ = "Valkyrie Systems Corporation"
+
+Image.MAX_IMAGE_PIXELS = None  # get rid of decompression bomb checking
+
+
+class GeoTIFF1DegInterpolator(DEMInterpolator):
+    """
+     This class contains methods used to read DEM data from GeoTIFF files and interpolate the height values, as needed.
+
+     Args
+     ----
+     root_dir: str | pathlib.Path
+         The root directory of the GeoTIFF DEM data.
+    filename_format: str | list[str]
+        format string used to construct GeoTIFF filename from a Lat/Lon pair (see the GeoTIFF1DegList docstring).
+     geoid_dir: str or pathlib.Path
+        Directory containing the geoid files in PGM format.
+     missing_error: bool (default: False)
+         Optional flag indicating whether an exception will be raised when missing DEM data files are encountered.
+         If True then a ValueError will be raised when a needed data file does not exist in the root_dir.
+         If False then a DEM value of zero will be silently used when a needed data file does not exist in the root_dir.
+     interp_method: str (default: "linear")
+         Optional interpolation method. Any scipy.interpolate.RegularGridInterpolator method is valid here.
+
+     """
+    __slots__ = ('_root_dir', '_geod_file', '_interp_method', '_ref_surface',
+                 '_geotiff_list_obj', "_bounding_box_cache")
+
+    def __init__(self, root_dir,  filename_format, geoid_dir='', *, missing_error=False, interp_method="linear"):
+        self._root_dir = str(root_dir)
+        self._geoid_dir = str(geoid_dir)
+        self._interp_method = interp_method
+        self._ref_surface = "Unknown"
+        self._geotiff_list_obj = GeoTIFF1DegList(root_dir, filename_format, missing_error=missing_error)
+        self._bounding_box_cache = {}
+
+        # get the geoid object - we prefer egm2008*.pgm files, but in reality, it makes very little difference.
+        self._geoid_obj = None
+        if self._geoid_dir and os.path.isdir(self._geoid_dir):
+            search_files = ('egm2008-1.pgm', 'egm2008-2_5.pgm', 'egm2008-5.pgm',
+                            'egm96-5.pgm', 'egm96-15.pgm', 'egm84-15.pgm', 'egm84-30.pgm')
+            self._geoid_obj = GeoidHeight.from_directory(geoid_dir, search_files=search_files)
+
+    @property
+    def interp_method(self):
+        return self._interp_method
+
+    @interp_method.setter
+    def interp_method(self, val):
+        self._interp_method = str(val)
+
+    def get_elevation_native(self, lat, lon, block_size=50000):
+        """
+        Get the elevation value relative to the reference surface specified in the GeooTIFF GeoAsciiParamsTag tag.
+
+        Parameters
+        ----------
+        lat : numpy.ndarray|list|tuple|int|float
+        lon : numpy.ndarray|list|tuple|int|float
+        block_size : int|None
+            If `None`, then the entire calculation will proceed as a single block.
+            Otherwise, block processing using blocks of the given size will be used.
+            The minimum value used for this is 50,000, and any smaller value will be
+            replaced with 50,000. Default is 50,000.
+
+
+        Returns
+        -------
+        numpy.ndarray
+            the elevation relative to the WGS-84 ellipsoid.
+        """
+        if block_size is not None:
+            warnings.warn("Block processing is not yet implemented.  Full size processing will be used.")
+
+        lat = np.atleast_1d(lat)
+        lon = np.atleast_1d(lon)
+
+        if lat.shape != lon.shape:
+            raise ValueError("The lat and lon arrays are not the same shape.")
+
+        lat_lon_pairs = np.stack([lat.flatten(), lon.flatten()], axis=-1)
+        unique_sw_corners = np.unique(np.floor(lat_lon_pairs), axis=0)
+
+        # Get the list of filenames for the unique SW corners, if they exist.
+        filename_info = []
+        for sw_lat, sw_lon in unique_sw_corners:
+            # Adding a fractional offset to the otherwise integer SW corner Lat/Lon values
+            # will guarantee that no more than one filename will be found.
+            files = self._geotiff_list_obj.find_dem_files(sw_lat + 0.1, sw_lon + 0.1)
+            if files:
+                filename_info.append({"filename": files[0], "sw_lat": sw_lat, "sw_lon": sw_lon})
+
+        height = np.zeros(lat.size)
+        for info in filename_info:
+            filename = info["filename"]
+            tile_sw_lat = info["sw_lat"]
+            tile_sw_lon = info["sw_lon"]
+            tile_ne_lat = tile_sw_lat + 1
+            tile_ne_lon = tile_sw_lon + 1
+
+            # Note: the dem_data must have dtype=np.float64 otherwise the interpolator
+            # created by RegularGridInterpolator will raise a TypeError exception.
+            with Image.open(filename) as img:
+                tiff_tags = {TiffTags.TAGS[key]: val for key, val in img.tag.items()}
+                dem_data = np.asarray(img, dtype=np.float64)
+
+            geo_ascii_params_tag = tiff_tags.get('GeoAsciiParamsTag', ('',))[0]
+            this_ref_surface = ('EGM84' if 'EGM84' in geo_ascii_params_tag else
+                                'EGM96' if 'EGM96' in geo_ascii_params_tag else
+                                'EGM2008' if 'EGM2008' in geo_ascii_params_tag else
+                                'EGM2020' if 'EGM2020' in geo_ascii_params_tag else
+                                'WGS84' if 'WGS84' in geo_ascii_params_tag else
+                                'Unknown')
+            if self._ref_surface == "Unknown":
+                self._ref_surface = this_ref_surface
+            elif self._ref_surface != this_ref_surface:
+                raise ValueError(f'Reference surface missmatch in file {filename}')    # pragma: no cover
+
+            tile_num_lats, tile_num_lons = dem_data.shape
+            tile_lats = np.linspace(tile_ne_lat, tile_sw_lat, tile_num_lats)
+            tile_lons = np.linspace(tile_sw_lon, tile_ne_lon, tile_num_lons)
+
+            # Old versions of scipy.interpolate require that axis samples be in strictly ascending order.
+            # Unfortunately, the tile_lats are in strictly descending order.  To get the interpolator to
+            # work regardless of package version, we will negate tile_lats and the lat-part of lat_lon_pairs.
+            neg_tile_lats = -tile_lats
+            neg_lat_lon_pairs = [(-lat, lon) for lat, lon in lat_lon_pairs]
+
+            interp = RegularGridInterpolator((neg_tile_lats, tile_lons), dem_data, method=self._interp_method,
+                                             bounds_error=False, fill_value=np.nan)
+
+            interp_height = interp(neg_lat_lon_pairs)
+            mask = np.logical_not(np.isnan(interp_height))
+            height[mask] = interp_height[mask]
+
+        return height.reshape(lat.shape)
+
+    def get_elevation_hae(self, lat, lon, block_size=50000):
+        """
+        Get the elevation value relative to the WGS84 ellipsoid.
+
+        Parameters
+        ----------
+        lat : numpy.ndarray|list|tuple|int|float
+        lon : numpy.ndarray|list|tuple|int|float
+        block_size : int|None
+            If `None`, then the entire calculation will proceed as a single block.
+            Otherwise, block processing using blocks of the given size will be used.
+            The minimum value used for this is 50,000, and any smaller value will be
+            replaced with 50,000. Default is 50,000.
+
+        Returns
+        -------
+        numpy.ndarray
+            the elevation relative to the geoid
+        """
+        height_native = self.get_elevation_native(lat, lon, block_size=block_size)
+
+        if self._ref_surface == "WGS84":
+            return height_native
+        elif self._ref_surface.startswith("EGM"):
+            if self._geoid_obj is None:
+                raise ValueError("The geoid_dir parameter was not defined so geoid calculations are disabled.")
+
+            return height_native + self._geoid_obj.get(lat, lon, block_size=block_size)
+        else:
+            raise ValueError(f"The reference surface is {self._ref_surface}, which is not supported")
+
+    def get_elevation_geoid(self, lat, lon, block_size=50000):
+        """
+        Get the elevation value relative to the geoid.
+
+        Parameters
+        ----------
+        lat : numpy.ndarray|list|tuple|int|float
+        lon : numpy.ndarray|list|tuple|int|float
+        block_size : int|None
+            If `None`, then the entire calculation will proceed as a single block.
+            Otherwise, block processing using blocks of the given size will be used.
+            The minimum value used for this is 50,000, and any smaller value will be
+            replaced with 50,000. Default is 50,000.
+
+        Returns
+        -------
+        numpy.ndarray
+            the elevation relative to the geoid
+        """
+        height_native = self.get_elevation_native(lat, lon, block_size)
+
+        if self._ref_surface.startswith("EGM"):
+            return height_native
+        elif self._ref_surface == "WGS84":
+            if self._geoid_obj is None:
+                raise ValueError("The geoid_dir parameter was not defined so geoid calculations are disabled.")
+
+            return height_native - self._geoid_obj.get(lat, lon, block_size=block_size)
+        else:
+            raise ValueError(f"The reference surface is {self._ref_surface}, which is not supported.")
+
+    def get_max_hae(self, lat_lon_box=None):
+        """
+        Get the maximum dem value with respect to HAE, which should be assumed **approximately** correct.
+
+        Parameters
+        ----------
+        lat_lon_box : list | numpy.ndarray
+            Any area of interest of the form `[lat min lat max, lon min, lon max]`.
+
+        Returns
+        -------
+        float
+        """
+        result = self.get_min_max_native(lat_lon_box)
+
+        if result['ref_surface'] == 'ellipsoid':
+            return result['max']['height']
+        else:
+            return self.get_elevation_hae(result['max']['lat'], result['max']['lon'])[0]
+
+    def get_min_hae(self, lat_lon_box=None):
+        """
+        Get the minimum dem value with respect to HAE, which should be assumed **approximately** correct.
+
+        Parameters
+        ----------
+        lat_lon_box : list | numpy.ndarray
+            Any area of interest of the form `[lat min lat max, lon min, lon max]`.
+
+        Returns
+        -------
+        float
+        """
+        result = self.get_min_max_native(lat_lon_box)
+
+        if result['ref_surface'] == 'ellipsoid':
+            return result['min']['height']
+        else:
+            return self.get_elevation_hae(result['min']['lat'], result['min']['lon'])[0]
+
+    def get_max_geoid(self, lat_lon_box=None):
+        """
+        Get the maximum dem value with respect to the geoid, which should be assumed **approximately** correct.
+
+        Parameters
+        ----------
+        lat_lon_box : list | numpy.ndarray
+            Any area of interest of the form `[lat min lat max, lon min, lon max]`.
+
+        Returns
+        -------
+        float
+        """
+        result = self.get_min_max_native(lat_lon_box)
+
+        if result['ref_surface'] == 'geoid':
+            return result['max']['height']
+        else:
+            return self.get_elevation_geoid(result['max']['lat'], result['max']['lon'])[0]
+
+    def get_min_geoid(self, lat_lon_box=None):
+        """
+        Get the minimum dem value with respect to geoid, which should be assumed **approximately** correct.
+
+        Parameters
+        ----------
+        lat_lon_box : list | numpy.ndarray
+            Any area of interest of the form `[lat min lat max, lon min, lon max]`.
+
+        Returns
+        -------
+        float
+        """
+        result = self.get_min_max_native(lat_lon_box)
+
+        if result['ref_surface'] == 'geoid':
+            return result['min']['height']
+        else:
+            return self.get_elevation_geoid(result['min']['lat'], result['min']['lon'])[0]
+
+    def get_min_max_native(self, lat_lon_box):
+        """
+        Get the minimum and maximum dem value with respect to the native reference surface of the DEM.
+
+        Parameters
+        ----------
+        lat_lon_box : List | numpy.ndarray
+            The bounding box to search `[lat min lat max, lon min, lon max]`.
+
+        Returns
+        -------
+        dict: {"box": lat_lon_box,
+               "ref_surface": ref_surface,
+               "min": {"lat": lat_deg, "lon": lon_deg, "height": height},
+               "max": {"lat": lat_deg, "lon": lon_deg, "height": height}
+              }
+        """
+        if self._bounding_box_cache.get("box", []) == lat_lon_box:
+            # If we have already done this calculation, don't do it again.
+            return self._bounding_box_cache
+
+        box_lat_min, box_lat_max, box_lon_min, box_lon_max = lat_lon_box
+
+        filename_info = []
+        for sw_lat in np.arange(np.floor(box_lat_min), np.floor(box_lat_max)+1):
+            for sw_lon in np.arange(np.floor(box_lon_min), np.floor(box_lon_max) + 1):
+                files = self._geotiff_list_obj.find_dem_files(sw_lat + 0.1, sw_lon + 0.1)
+                if files:
+                    filename_info.append({"filename": files[0], "sw_lat": sw_lat, "sw_lon": sw_lon})
+
+        # Initialize so that the global min and max occur at the same lat/lon and have a value of zero.
+        # These values will be returned if the bounding box is completely outside the available DEM tiles.
+        ref_surface = 'geoid'
+        global_min_lat = box_lat_min
+        global_max_lat = box_lat_min
+        global_min_lon = box_lon_min
+        global_max_lon = box_lon_min
+        global_min = np.inf if filename_info else 0
+        global_max = -np.inf if filename_info else 0
+
+        for info in filename_info:
+            filename = info["filename"]
+            tile_sw_lat = info["sw_lat"]
+            tile_sw_lon = info["sw_lon"]
+            tile_ne_lat = tile_sw_lat + 1
+
+            with Image.open(filename) as img:
+                tiff_tags = {TiffTags.TAGS[key]: val for key, val in img.tag.items()}
+                dem_data = np.asarray(img, dtype=np.float64)
+
+            tile_num_lats = tiff_tags['ImageLength'][0]
+            tile_num_lons = tiff_tags['ImageWidth'][0]
+            ref_surface = 'geoid' if 'EGM' in tiff_tags.get('GeoAsciiParamsTag', ('',))[0] else 'ellipsoid'
+
+            # Lat index is in descending order, so calculate the offset from the north edge (lowest index)
+            lat_start_offset = max(0, tile_ne_lat - box_lat_max)
+            lat_stop_offset = min(1, tile_ne_lat - box_lat_min)
+
+            # Lon index is in ascending order, so calculate the offset from the west edge (lowest index)
+            lon_start_offset = max(0, box_lon_min - tile_sw_lon)
+            lon_stop_offset = min(1, box_lon_max - tile_sw_lon)
+
+            # Lat index is in descending order, so start at the north edge (lowest index)
+            row_start = int(np.ceil(lat_start_offset * (tile_num_lats - 1)))
+            row_stop = int(np.floor(lat_stop_offset * (tile_num_lats - 1)))
+
+            # Lon index is in ascending order, so start at the west edge (lowest index)
+            col_start = int(np.ceil(lon_start_offset * (tile_num_lons - 1)))
+            col_stop = int(np.floor(lon_stop_offset * (tile_num_lons - 1)))
+
+            dem_slice = dem_data[row_start:row_stop+1, col_start:col_stop+1]
+            max_index = np.unravel_index(np.argmax(dem_slice), shape=dem_slice.shape)
+            min_index = np.unravel_index(np.argmin(dem_slice), shape=dem_slice.shape)
+
+            if global_max < dem_slice[max_index]:
+                global_max = dem_slice[max_index]
+                global_max_lat = tile_ne_lat - lat_start_offset - max_index[0] / (tile_num_lats - 1)
+                global_max_lon = tile_sw_lon + lon_start_offset + max_index[1] / (tile_num_lons - 1)
+
+            if global_min > dem_slice[min_index]:
+                global_min = dem_slice[min_index]
+                global_min_lat = tile_ne_lat - lat_start_offset - min_index[0] / (tile_num_lats - 1)
+                global_min_lon = tile_sw_lon + lon_start_offset + min_index[1] / (tile_num_lons - 1)
+
+        self._bounding_box_cache = {"box": lat_lon_box,
+                                    "ref_surface": ref_surface,
+                                    "min": {"lat": global_min_lat, "lon": global_min_lon, "height": float(global_min)},
+                                    "max": {"lat": global_max_lat, "lon": global_max_lon, "height": float(global_max)}
+                                    }
+
+        return self._bounding_box_cache
+
+
+# ---------------------------------------------------------------------------------------------------------------------
+# GeoTIFF1DegList
+# ---------------------------------------------------------------------------------------------------------------------
+class GeoTIFF1DegList(DEMList):
+    """
+    GeoTIFF subclass of sarpy.io.DEM.DEMList
+
+    This class contains methods used to determine which GeoTIFF files are needed to cover
+    a specified geodetic bounding box.
+
+    Args
+    ----
+    root_dir: str or pathlib.Path
+        The root directory of the GeoTIFF DEM data.
+    filename_format: str | list[str]
+        format string used to construct GeoTIFF filename from a Lat/Lon pair, as described in the Notes section.
+    missing_error: bool (default: False)
+        Optional flag indicating whether an exception will be raised when missing DEM data files are encountered.
+        If True then a ValueError will be raised when a needed data file does not exist in root_dir.
+        If False then a DEM value of zero will be silently used when a needed data file does not exist in root_dir.
+
+    Notes
+    -----
+    The DEM files must have the SW corner Lat/Lon encoded in their filenames.  The filename_format argument contains a
+    list of format strings that will be joined together by the os.path.join() to produce a path, relative to root_dir,
+    to the desired GeoTIFF DEM file.  The following arguments will be provided to the format string.
+        lat = int(numpy.floor(lat))
+        lon = int(numpy.floor(lon))
+        abslat = int(abs(numpy.floor(lat)))
+        abslon = int(abs(numpy.floor(lon)))
+        ns = 's' if lat < 0 else 'n'
+        NS = 'S' if lat < 0 else 'N'
+        ew = 'w' if lon < 0 else 'e'
+        EW = 'W' if lon < 0 else 'E'
+        ver = optional character string used to specify a version number
+
+    When specifying an f-string argument, a width field and fill character should always be included.
+    For example, "{ns:1s}", "{ew:1s}", "{ver:2s}", "{abslat:02d}", "{abslon:03d}".
+
+    Examples:
+
+        Some high resolution GeoTIFF DEM files have used the following filename format.
+            ["tdt_{ns:1s}{abslat:02}{ew:1s}{abslon:03}_{ver:2s}", "DEM",
+             "TDT_{NS:1s}{abslat:02}{EW:1s}{abslon:03}_{ver:2s}_DEM.tif"]
+
+        Some lower resolution GeoTIFF DEM files have used the following filename format.
+            ["TDM1_DEM__30_{NS:1s}{abslat:02}{EW:1s}{abslon:03}_V{ver:2s}_C", "DEM",
+            "TDM1_DEM__30_{NS:1s}{abslat:02}{EW:1s}{abslon:03}_DEM.tif"]
+
+    """
+
+    __slots__ = ('_root_dir', "_filename_format", '_missing_error')
+
+    def __init__(self, root_dir, filename_format, *, missing_error=False):
+        if not os.path.exists(str(root_dir)):
+            raise ValueError(f"The top level directory ({str(root_dir)}) does not exist.")
+
+        if isinstance(filename_format, str):
+            filename_format = [filename_format]    # pragma: no cover
+
+        self._root_dir = str(root_dir)
+        self._filename_format = os.path.join(self._root_dir, *filename_format)
+        self._missing_error = bool(missing_error)
+
+    def filename_from_lat_lon(self, lat, lon, ver=None):
+        """
+        This method will return the filename of the GeoTIFF file that contains the specified
+        latitude/longitude and version number.
+
+        """
+        pars = {
+            "lat": int(np.floor(lat)),
+            "lon": int(np.floor(lon)),
+            "abslat": int(abs(np.floor(lat))),
+            "abslon": int(abs(np.floor(lon))),
+            "ns": 's' if lat < 0 else 'n',
+            "ew": 'w' if lon < 0 else 'e',
+            "NS": 'S' if lat < 0 else 'N',
+            "EW": 'W' if lon < 0 else 'E',
+            "ver": ver,
+        }
+
+        class SkipMissing(dict):
+            def __missing__(self, key):
+                return f'{{{key}}}'
+
+        return self._filename_format.format_map(SkipMissing(**pars))
+
+    def find_dem_files(self, lat, lon):
+        """
+        Return a list of filenames of GeoTIFF files that contain DEM data for the specified Lat/Lon point.
+        Since DEM files overlap, there might be more than one file that contains the specified Lat/Lon point.
+
+        Args
+        ----
+        lat: int | float
+            The latitude in degrees (-90 <= lat <= 90)
+        lon: int | float
+            The longitude in degrees (-180 <= lon < 180)
+
+        Returns
+        -------
+        filenames: list(str)
+            A list of filenames of DEM data files, if they exists, otherwise []
+
+        """
+        msg = [] if -90.0 <= lat <= 90.0 else ["The latitude value must be between [-90, +90]"]
+        msg += [] if -180.0 <= lon < 180.0 else ["The longitude value must be between [-180, +180)"]
+        if msg:
+            raise ValueError('\n'.join(msg))
+
+        sw_lats = [89 if lat == 90 else np.floor(lat)]      # The latitude of the south-west corner in integer degrees
+        sw_lons = [np.floor(lon)]                           # The longitude of the south-west corner in integer degrees
+
+        if lat == np.floor(lat) and np.abs(lat) < 90:
+            # lat is an integer, so it is in the overlap region of at least two files
+            sw_lats.append(np.floor(lat)-1)
+
+        if lon == np.floor(lon):
+            # lon is an integer, so it is in the overlap region of at least two files.
+            sw_lons.append(179 if lon == -180 else np.floor(lon)-1)
+
+        filenames = []
+        for sw_lat in sw_lats:
+            for sw_lon in sw_lons:
+                new_filenames = []
+                for ver in ['01', '02']:
+                    filename = self.filename_from_lat_lon(int(sw_lat), int(sw_lon), ver)
+
+                    if os.path.isfile(filename):
+                        new_filenames.append(filename)
+                filenames.extend(new_filenames)
+
+                if not new_filenames:
+                    msg = f'Missing expected DEM file for tile with lower left lat/lon corner ({sw_lat}, {sw_lon})'
+                    if self._missing_error:
+                        raise ValueError(msg)
+                    else:
+                        logger.warning(
+                            msg + '\n\tThis should result in the assumption that the altitude in\n\t'
+                                  'that section is zero relative to the reference surface.')
+
+        return filenames
+
+    def get_file_list(self, lat_lon_box):
+        """
+        This will return the list of files associated with covering the `lat_lon_box` using a DEM.
+
+        If the bounding box spans the antimeridian (180th meridian), then the maximum longitude
+        will be less than the minimum longitude.
+
+        Args
+        ----
+        lat_lon_box : numpy.ndarray | list | tuple
+            The bounding box of the form `[lat min, lat max, lon min, lon max]` in degrees.
+
+        Returns
+        -------
+        filenames: List[str]
+            A list of filenames, without duplication, of the files needed to cover the bounding box.
+        """
+        filenames = []
+
+        lat_min, lat_max, lon_min, lon_max = lat_lon_box
+
+        msg = ["The minimum latitude value must be between [-90, +90]"] if not (-90.0 <= lat_min <= 90.0) else []
+        msg += ["The maximum latitude value must be between [-90, +90]"] if not (-90.0 <= lat_max <= 90.0) else []
+        msg += ["The minimum longitude value must be between [-180, +180)"] if not (-180.0 <= lon_min < 180.0) else []
+        msg += ["The maximum longitude value must be between [-180, +180)"] if not (-180.0 <= lon_max < 180.0) else []
+        if msg:
+            raise ValueError('\n'.join(msg))
+
+        if lon_max < lon_min:
+            lon_max += 360
+
+        for lat_inc in np.arange(np.ceil(lat_max) - np.floor(lat_min)):
+            lat = lat_min + lat_inc
+
+            for lon_inc in np.arange(np.ceil(lon_max) - np.floor(lon_min)):
+                lon = (lon_min + lon_inc + 180) % 360 - 180
+
+                new_filenames = self.find_dem_files(lat, lon)
+                new_unique_filenames = [file for file in new_filenames if file not in filenames]
+                filenames.extend(new_unique_filenames)
+
+        return filenames

--- a/sarpy/io/complex/converter.py
+++ b/sarpy/io/complex/converter.py
@@ -4,21 +4,24 @@ read to SICD or SIO format. The same conversion utility can be used to subset da
 """
 
 __classification__ = "UNCLASSIFIED"
-__author__ = ("Wade Schwartzkopf", "Thomas McCullough")
-
+__author__ = ("Wade Schwartzkopf", "Thomas McCullough", "Valkyrie Systems Corporation")
 
 import os
-import numpy
 import logging
 from typing import Union, List, Tuple, Callable, BinaryIO
 
-from sarpy.io.general.base import SarpyIOError, check_for_openers
-from sarpy.io.general.nitf import NITFReader
-from sarpy.io.general.utils import is_file_like
+import numpy
+
+from sarpy.geometry.geocoords import ecf_to_geodetic
+from sarpy.geometry.point_projection import image_to_ground_dem
 from sarpy.io.complex.base import SICDTypeReader
 from sarpy.io.complex.sicd import SICDWriter
 from sarpy.io.complex.sio import SIOWriter
-
+from sarpy.io.DEM.geotiff1deg import GeoTIFF1DegInterpolator
+from sarpy.io.general.base import SarpyIOError
+from sarpy.io.general.base import check_for_openers
+from sarpy.io.general.nitf import NITFReader
+from sarpy.io.general.utils import is_file_like
 
 logger = logging.getLogger(__name__)
 
@@ -266,7 +269,8 @@ class Converter(object):
 def conversion_utility(
         input_file, output_directory, output_files=None, frames=None, output_format='SICD',
         row_limits=None, column_limits=None, max_block_size=None, check_older_version=False,
-        preserve_nitf_information=False, check_existence=True):
+        preserve_nitf_information=False, check_existence=True,
+        dem_filename_pattern=None, dem_type=None, geoid_file=None):
     """
     Copy SAR complex data to a file of the specified format.
 
@@ -296,6 +300,16 @@ def conversion_utility(
         is actually a NITF file.
     check_existence : bool
         Check for the existence of any possibly overwritten file?
+    dem_filename_pattern : str | None
+        Optional string specifying a Digital Elevation Model (DEM) filename pattern.
+        This is a format string that specifies a glob pattern that will
+        uniquely specify a DEM file from the Lat/Lon of the SW corner of
+        the DEM tile.  See the utils/convert_to_sicd help text for more details.
+    dem_type : str | None
+        Optional DEM type ('GeoTIFF', etc.).
+        This parameter is required when dem_filename_pattern is specified.
+    geoid_file : str | None
+        Optional Geoid file which might be needed when dem_filename_pattern is specified.
 
     Returns
     -------
@@ -362,6 +376,46 @@ def conversion_utility(
 
     sicds = reader.get_sicds_as_tuple()
     sizes = reader.get_data_size_as_tuple()
+
+    if dem_filename_pattern is not None:
+        # Update the SICD metadata base on a projection of the SCP to a DEM.
+        if dem_type.upper() == 'GEOTIFF':
+            dem_interpolator = GeoTIFF1DegInterpolator(dem_filename_pattern, geoid_path=geoid_file)
+        else:
+            raise NotImplementedError(f'DEM type ({dem_type}) is not implemented.')
+
+        for sicd in sicds:
+            # project SCP and corner points to DEM
+            scp = (sicd.ImageData.SCPPixel.Row, sicd.ImageData.SCPPixel.Col)
+            frfc = (sicd.ImageData.FirstRow, sicd.ImageData.FirstCol)
+            frlc = (sicd.ImageData.FirstRow, sicd.ImageData.FirstCol + sicd.ImageData.NumCols - 1)
+            lrfc = (sicd.ImageData.FirstRow + sicd.ImageData.NumRows - 1, sicd.ImageData.FirstCol)
+            lrlc = (sicd.ImageData.FirstRow + sicd.ImageData.NumRows - 1,
+                    sicd.ImageData.FirstCol + sicd.ImageData.NumCols - 1)
+
+            img_points = [scp, frfc, frlc, lrfc, lrlc]
+            ecf_points = image_to_ground_dem(img_points, sicd,
+                                             block_size=None,
+                                             dem_interpolator=dem_interpolator,
+                                             pad_value=0.2,
+                                             vertical_step_size=1.0,
+                                             use_structure_coa=True,
+                                             )
+
+            llh_points = ecf_to_geodetic(ecf_points)
+
+            sicd.GeoData.SCP.LLH.Lat = llh_points[0][0]
+            sicd.GeoData.SCP.LLH.Lon = llh_points[0][1]
+            sicd.GeoData.SCP.LLH.HAE = llh_points[0][2]
+
+            sicd.GeoData.SCP.ECF.X = ecf_points[0][0]
+            sicd.GeoData.SCP.ECF.Y = ecf_points[0][1]
+            sicd.GeoData.SCP.ECF.Z = ecf_points[0][2]
+
+            for i in range(4):
+                index = int(sicd.GeoData.ImageCorners[i].index.split(':')[0])    # index = 1|2|3|4, SCP is index 0
+                sicd.GeoData.ImageCorners[i].Lat = llh_points[index][0]          # FRFC is index 1, FRLC is index 2,
+                sicd.GeoData.ImageCorners[i].Lon = llh_points[index][1]          # LRFC is index 3, LRLC is index 4
 
     # check that frames is valid
     if frames is None:

--- a/tests/io/DEM/test_geotiff1deg_list.py
+++ b/tests/io/DEM/test_geotiff1deg_list.py
@@ -1,0 +1,180 @@
+"""
+These test functions will exercise the GeoTIFF1DegList class which contains methods used to determine
+which GeoTIFF files are needed to cover a specified geodetic bounding box.  These tests create dummy,
+temporary, DEM files on-the-fly, so there is no need to provide any actual DEM files.
+
+"""
+import logging
+import pathlib
+import tempfile
+
+import pytest
+
+from sarpy.io.DEM.geotiff1deg import GeoTIFF1DegList
+
+# SW corner (degrees) of valid DEM pixels
+MIN_LAT = -3
+MIN_LON = -2
+
+# NE corner (degrees) of valid DEM pixels
+MAX_LAT = 2
+MAX_LON = 4
+
+logging.basicConfig(level=logging.WARNING)
+
+dataset_ff = {
+    "high_res": ["tdt_{ns:1s}{abslat:02}{ew:1s}{abslon:03}_{ver:2s}",
+                 "DEM",
+                 "TDT_{NS:1s}{abslat:02}{EW:1s}{abslon:03}_{ver:2s}_DEM.tif"],
+    "low_res": ["TDM1_DEM__30_{NS:1s}{abslat:02}{EW:1s}{abslon:03}_V{ver:2s}_C",
+                "DEM",
+                "TDM1_DEM__30_{NS:1s}{abslat:02}{EW:1s}{abslon:03}_DEM.tif"
+                ]
+}
+
+
+@pytest.fixture(scope='module')
+def dem_file_path():
+    """
+    Create a directory of empty files that satisfy the DEM "high_res" naming convention.
+
+    """
+    ver_choice = ('01', '02')
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = pathlib.Path(temp_dir)
+
+        for lat in range(MIN_LAT, MAX_LAT):
+            ns = 's' if lat < 0 else 'n'
+
+            for lon in range(MIN_LON, MAX_LON):
+                ew = 'w' if lon < 0 else 'e'
+
+                # Make files that span the prime meridian and the equator
+                stem = f"tdt_{ns}{abs(lat):02}{ew}{abs(lon):03}_{ver_choice[0]}"
+                filename = temp_path / f"{stem}" / "DEM" / f"{stem.upper()}_DEM.tif"
+                filename.parent.mkdir(parents=True, exist_ok=True)
+                filename.touch()
+
+                # Make files that span the antimeridian and the equator
+                lon2 = lon + 180
+                lon2 = (lon2 + 180) % 360 - 180
+                ew = 'w' if lon2 < 0 else 'e'
+
+                stem = f"tdt_{ns}{abs(lat):02}{ew}{abs(lon2):03}_{ver_choice[1]}"
+                filename = temp_path / f"{stem}" / "DEM" / f"{stem.upper()}_DEM.tif"
+                filename.parent.mkdir(parents=True, exist_ok=True)
+                filename.touch()
+
+        yield temp_path
+
+
+def test_filename_from_lat_lon():
+    filename_format = "Test_{lat:02d}_{lon:03d}_{abslat:02d}_{abslon:03d}_{ns:1s}{NS:1s}_{ew:1s}{EW:1s}_{ver:2s}"
+    obj = GeoTIFF1DegList('/tmp', filename_format=filename_format)
+    filename = obj.filename_from_lat_lon(-1, -2, 'V1')
+    assert filename == "/tmp/Test_-1_-02_01_002_sS_wW_V1"
+
+    obj = GeoTIFF1DegList('/tmp', filename_format=filename_format+'_{bad}')
+    filename = obj.filename_from_lat_lon(-1, -2, 'V1')
+    assert filename == "/tmp/Test_-1_-02_01_002_sS_wW_V1_{bad}"
+
+    filename_format = "Test_{lat:02d}_{lon:03d}_{abslat:02d}_{abslon:03d}_{ns}{NS}_{ew}{EW}_{ver:2s}"
+    obj = GeoTIFF1DegList('/tmp', filename_format=filename_format)
+    filename = obj.filename_from_lat_lon(-1, -2, 'V1')
+    assert filename == "/tmp/Test_-1_-02_01_002_sS_wW_V1"
+
+
+def test_find_dem_files(dem_file_path):
+    obj = GeoTIFF1DegList(str(dem_file_path), dataset_ff["high_res"])
+
+    filenames = obj.find_dem_files(MIN_LAT - 1, MIN_LON - 1)
+    assert len(filenames) == 0
+
+    filenames = obj.find_dem_files(MIN_LAT, MIN_LON)
+    expected_filename = obj.filename_from_lat_lon(MIN_LAT, MIN_LON, '01')
+    assert len(filenames) == 1 and filenames[0].endswith(expected_filename)
+
+    filenames = obj.find_dem_files(MIN_LAT + 0.5, MIN_LON + 0.5)
+    assert len(filenames) == 1 and filenames[0].endswith(expected_filename)
+
+    filenames = obj.find_dem_files(MAX_LAT, MAX_LON)
+    expected_filename = obj.filename_from_lat_lon(MAX_LAT-1, MAX_LON-1, '01')
+    assert len(filenames) == 1 and filenames[0].endswith(expected_filename)
+
+    filenames = obj.find_dem_files(MIN_LAT+1, MIN_LON)
+    assert len(filenames) == 2
+
+    filenames = obj.find_dem_files(MIN_LAT, MIN_LON+1)
+    assert len(filenames) == 2
+
+    filenames = obj.find_dem_files(MIN_LAT+1, MIN_LON + 1)
+    assert len(filenames) == 4
+
+    # Zero files because the low_res dataset does not exist in dem_file_path
+    obj = GeoTIFF1DegList(str(dem_file_path), dataset_ff["low_res"])
+    filenames = obj.find_dem_files(MIN_LAT, MIN_LON)
+    assert len(filenames) == 0
+
+
+def test_file_list(dem_file_path):
+    obj = GeoTIFF1DegList(str(dem_file_path), dataset_ff["high_res"])
+
+    # Zero files
+    lat_lon_box = [MIN_LAT - 10, MIN_LAT - 9, MIN_LON - 10, MIN_LON - 9]
+    filenames = obj.get_file_list(lat_lon_box)
+    assert len(filenames) == 0
+
+    # Single file
+    lat_lon_box = [MIN_LAT + 0.3, MIN_LAT + 0.6, MIN_LON + 0.2, MIN_LON + 0.5]
+    filenames = obj.get_file_list(lat_lon_box)
+    assert len(filenames) == 1
+
+    # All files near the prime meridian
+    lat_lon_box = [MIN_LAT + 0.3, MAX_LAT - 0.5, MIN_LON + 0.2, MAX_LON - 0.5]
+    filenames = obj.get_file_list(lat_lon_box)
+    assert len(filenames) == 30
+
+    # All files near the Antimeridian
+    lat_lon_box = [MIN_LAT + 0.3, MAX_LAT - 0.5, 180 + MIN_LON + 0.2, MAX_LON - 180 - 0.5]
+    filenames = obj.get_file_list(lat_lon_box)
+    assert len(filenames) == 30
+
+    # 360 degrees of longitude
+    lat_lon_box = [MIN_LAT + 0.3, MAX_LAT - 0.5, 0.1, -0.1]
+    filenames = obj.get_file_list(lat_lon_box)
+    assert len(filenames) == 60
+
+
+def test_exceptions(dem_file_path, caplog):
+    with pytest.raises(ValueError, match="^The top level directory \\(/bad_dir\\) does not exist\\."):
+        GeoTIFF1DegList("/bad_dir", dataset_ff["high_res"])
+
+    obj = GeoTIFF1DegList(str(dem_file_path), dataset_ff["high_res"])
+    with pytest.raises(ValueError) as info:
+        obj.find_dem_files(999, 999)
+
+    msgs = str(info.value).split('\n')
+    assert len(msgs) == 2
+    assert info.match("The latitude value must be between \\[-90, \\+90\\]")
+    assert info.match("The longitude value must be between \\[-180, \\+180\\)")
+
+    with pytest.raises(ValueError) as info:
+        obj.get_file_list([999, 999, 999, 999])
+
+    msgs = str(info.value).split('\n')
+    assert len(msgs) == 4
+    assert info.match("The minimum latitude value must be between \\[-90, \\+90\\]")
+    assert info.match("The maximum latitude value must be between \\[-90, \\+90\\]")
+    assert info.match("The minimum longitude value must be between \\[-180, \\+180\\)")
+    assert info.match("The maximum longitude value must be between \\[-180, \\+180\\)")
+
+    caplog.set_level(logging.WARNING)
+    obj.get_file_list([45.1, 45.3, 90.1, 90.3])
+    assert caplog.text.startswith("WARNING  sarpy.io.DEM.geotiff1deg:geotiff1deg.py")
+    assert "Missing expected DEM file for tile with lower left lat/lon corner (45.0, 90.0)" in caplog.text
+
+    obj = GeoTIFF1DegList(str(dem_file_path), dataset_ff["high_res"], missing_error=True)
+    with pytest.raises(ValueError,
+                       match="^Missing expected DEM file for tile with lower left lat/lon corner \\(45.0, 90.0\\)"):
+        obj.get_file_list([45.1, 45.3, 90.1, 90.3])

--- a/tests/io/DEM/test_geotiff1deg_reader.py
+++ b/tests/io/DEM/test_geotiff1deg_reader.py
@@ -1,0 +1,330 @@
+"""
+These test functions will exercise the GeoTIFF1DegInterpolator class which reads DEM data files and interpolates
+data points as needed.  Most of these tests use fabricated data, so the GeoTIFF1DegInterpolator class is moderately
+well tests without providing external DEM data.  However, when available, real DEM data is used for some tests.
+The location of the real DEM data files and real Geoid data files are defined by the parameters:
+
+    GEOTIFF_ROOT_PATH        - A pathlib.Path to the root directory containing DEM data files in GeoTIFF
+    GEOID_ROOT_PATH          - A pathlib.Path to the root directory containing Geoid data files in PGM format
+    FILENAME_FORMAT_HIGH_RES - A format string for a high-res DEM filenames relative to GEOTIFF_ROOT_PATH
+    FILENAME_FORMAT_LOW_RES  - A format string for a low-res DEM filenames relative to GEOTIFF_ROOT_PATH
+
+    Low resolution GeoTIFF data files can be downloaded from here:
+        https://download.geoservice.dlr.de/TDM90/
+
+    High resolution GeoTIFF data files are typically restricted, but more information can be found here:
+        https://data.europa.eu/data/datasets/5eecdf4c-de57-4624-99e9-60086b032aea?locale=en
+
+    The Geoid model files are available in either ZIP of BZ2 format from here:
+        https://sourceforge.net/projects/geographiclib/files/geoids-distrib/
+
+If real DEM files and/or real Geoid files are not available then tests that require these files will be skipped.
+
+"""
+import os
+import pathlib
+import re
+import tempfile
+
+import numpy as np
+from PIL import Image
+import pytest
+
+from sarpy.io.DEM.geotiff1deg import GeoTIFF1DegInterpolator
+
+GEOTIFF_ROOT_PATH = pathlib.Path(__file__).parent / "dem_data"
+GEOID_ROOT_PATH = pathlib.Path(__file__).parent / "dem"
+
+FILENAME_FORMAT_HIGH_RES = ["tdt_{ns:1s}{abslat:02}{ew:1s}{abslon:03}_{ver:2s}", "DEM",
+                            "TDT_{NS:1s}{abslat:02}{EW:1s}{abslon:03}_{ver:2s}_DEM.tif"]
+FILENAME_FORMAT_LOW_RES = ["TDM1_DEM__30_{NS:1s}{abslat:02}{EW:1s}{abslon:03}_V{ver:2s}_C", "DEM",
+                           "TDM1_DEM__30_{NS:1s}{abslat:02}{EW:1s}{abslon:03}_DEM.tif"]
+FILENAME_FORMAT_DICT = {"high_res": FILENAME_FORMAT_HIGH_RES, "low_res": FILENAME_FORMAT_LOW_RES}
+
+NUM_LATS_DUMMY = 201
+NUM_LONS_DUMMY = 101
+
+
+def lat_lon_to_dummy_height(lat, lon):
+    return lat + 1000 * lon
+
+
+def lat_lon_from_filename(filename):
+    m = re.search('(N|S)([0-8][0-9])(E|W)((0[0-9][0-9])|(1[0-7][0-9])|180)', filename.upper())
+    if m is None:
+        raise ValueError(f"Could not find a Lat/Lon substring in filename ({filename}).")
+
+    lat_sgn = 1 if m.group(1) == 'N' else -1
+    lat_abs = int(m.group(2))
+    lon_sgn = 1 if m.group(3) == 'E' else -1
+    lon_abs = int(m.group(4))
+
+    return lat_sgn * lat_abs, lon_sgn * lon_abs
+
+
+def dummy_pil_image_open(filename, ref_surface):
+    """
+    This function is intended to be a monkeypatch target for PIL.Image.open().  It returns a PIL.Image
+    object of dummy DEM values.  The tile's SW corner Lat/Lon value is extracted from the filename.
+    The DEM height values are a linear function of the Lat/Lon value so that interpolated
+    values of the DEM are predictable and easily compared to the expected result.  The filename
+    is assumed to be in "high_res" format.
+    """
+    lat, lon = lat_lon_from_filename(str(filename))
+
+    lat_values = np.linspace(lat+1, lat, NUM_LATS_DUMMY)    # Increasing axis-0 index is decreasing latitude
+    lon_values = np.linspace(lon, lon+1, NUM_LONS_DUMMY)    # Increasing axis-1 index is increasing longitude
+    lon_mat, lat_mat = np.meshgrid(lon_values, lat_values)
+    heights = lat_lon_to_dummy_height(lat_mat, lon_mat)
+
+    im = Image.fromarray(heights.astype(np.float64))
+    im.tag = {256: (NUM_LONS_DUMMY,),             # ImageWidth
+              257: (NUM_LATS_DUMMY,),             # ImageLength
+              34737: (f"Dummy: {ref_surface}",)}  # GeoAsciiParamsTag
+
+    return im
+
+
+@pytest.fixture(scope='module')
+def dummy_dem_file_path_high_res():
+    dataset = 'high_res'
+    filename_format = FILENAME_FORMAT_HIGH_RES
+    with tempfile.TemporaryDirectory() as temp_dir:
+        root_path = pathlib.Path(temp_dir) / dataset
+        dummy_dem_file_path(root_path, filename_format)
+        yield root_path
+
+
+@pytest.fixture(scope='module')
+def dummy_dem_file_path_low_res():
+    dataset = 'low_res'
+    filename_format = FILENAME_FORMAT_LOW_RES
+    with tempfile.TemporaryDirectory() as temp_dir:
+        root_path = pathlib.Path(temp_dir) / dataset
+        dummy_dem_file_path(root_path, filename_format)
+        yield root_path
+
+
+def dummy_dem_file_path(root_path, filename_format):
+    """
+    Create a directory of empty files that satisfy the DEM naming convention.
+    """
+    min_lat = -1
+    max_lat = +2
+    min_lon = -1
+    max_lon = +2
+    ver_choice = ('01', '02')
+
+    for lat in range(min_lat, max_lat):
+        for lon in range(min_lon, max_lon):
+            anti_lon = (lon + 360) % 360 - 180
+            # Make empty files that span the prime meridian and the equator,
+            # then make more empty files that span the antimeridian and the equator.
+            for xlon, ver in zip([lon, anti_lon], ver_choice):
+                pars = {"abslat": int(abs(np.floor(lat))), "abslon": int(abs(np.floor(xlon))),
+                        "ns": 's' if lat < 0 else 'n', "ew": 'w' if xlon < 0 else 'e',
+                        "NS": 'S' if lat < 0 else 'N', "EW": 'W' if xlon < 0 else 'E', "ver": ver}
+                filename = root_path / os.path.join(*filename_format).format_map(pars)
+                filename.parent.mkdir(parents=True, exist_ok=True)
+                filename.touch()
+
+
+def lat_lon_bounds(root_dir):
+    """
+    Determine the min/max lat/lon covered by DEM files in a specified directory.
+    """
+    filenames = list(pathlib.Path(root_dir).glob("**/*DEM.tif"))
+    lats = np.zeros(len(filenames))
+    lons = np.zeros(len(filenames))
+    for i, filename in enumerate(filenames):
+        lats[i], lons[i] = lat_lon_from_filename(str(filename))
+
+    sw_lat = np.min(lats)
+    ne_lat = np.max(lats) + 1
+    sw_lon = np.min(lons)
+    ne_lon = np.max(lons) + 1
+
+    return [sw_lat, ne_lat, sw_lon, ne_lon]
+
+
+def test_setter_getter(dummy_dem_file_path_high_res):
+    obj = GeoTIFF1DegInterpolator(str(dummy_dem_file_path_high_res), FILENAME_FORMAT_HIGH_RES)
+    obj.interp_method = "dummy"
+    assert obj.interp_method == "dummy"
+
+
+@pytest.mark.parametrize("dataset", [
+    pytest.param("high_res", marks=pytest.mark.skipif(not (GEOTIFF_ROOT_PATH / "high_res").exists(),
+                                                      reason="GeoTIFF test data does not exist.")),
+    pytest.param("low_res", marks=pytest.mark.skipif(not (GEOTIFF_ROOT_PATH / "low_res").exists(),
+                                                     reason="GeoTIFF test data does not exist."))])
+def test_get_elevation_native(dataset):
+    root_dir = str(GEOTIFF_ROOT_PATH / dataset)
+    sw_lat, ne_lat, sw_lon, ne_lon = lat_lon_bounds(root_dir)
+
+    obj = GeoTIFF1DegInterpolator(root_dir, FILENAME_FORMAT_DICT[dataset])
+
+    num_points = 8
+    d_offset = 1 / 18111    # Offset used to avoid exact Lat/Lon samples which occur ever 1/9000
+
+    # All test points are outside valid DEM area
+    lats = np.linspace(sw_lat - 0.9, sw_lat - 0.1, num_points)
+    lons = np.linspace(sw_lon - 0.9, sw_lon - 0.1, num_points)
+    hgts = obj.get_elevation_native(lats, lons)
+    assert np.all(np.equal(hgts, np.zeros(num_points)))
+
+    # All test points are inside valid DEM area and are inside a single tile
+    lats = np.linspace(sw_lat + d_offset, sw_lat + (1 - d_offset), num_points)
+    lons = np.linspace(sw_lon + d_offset, sw_lon + (1 - d_offset), num_points)
+    hgts = obj.get_elevation_native(lats, lons)
+    assert not np.all(np.equal(hgts, np.zeros(num_points)))
+
+    # Test all point are inside valid DEM area and span several tiles
+    lats = np.linspace(sw_lat + d_offset, ne_lat - d_offset, num_points)
+    lons = np.linspace(sw_lon + d_offset, ne_lon - d_offset, num_points)
+    hght = obj.get_elevation_native(lats, lons)
+    assert not np.all(np.equal(hght, np.zeros(num_points)))
+
+    # Test scale lat / lon arguments
+    hght = obj.get_elevation_native(lats[0], lons[0])
+    assert not np.all(np.equal(hght, np.zeros(1)))
+
+
+def test_get_elevation_native_dummy(dummy_dem_file_path_high_res, monkeypatch):
+    monkeypatch.setattr(Image, 'open', lambda filename: dummy_pil_image_open(filename, "EGM2008"))
+
+    sw_lat = -1
+    ne_lat = 2
+    sw_lon = -1
+    ne_lon = 2
+
+    obj = GeoTIFF1DegInterpolator(str(dummy_dem_file_path_high_res), FILENAME_FORMAT_HIGH_RES)
+
+    num_points = 8
+    d_offset = 1 / 18000
+
+    lats = np.linspace(sw_lat + d_offset, ne_lat - d_offset, num_points)
+    lons = np.linspace(sw_lon + d_offset, ne_lon/2 - d_offset, num_points)
+    hght = obj.get_elevation_native(lats, lons)
+    expected_hght = lat_lon_to_dummy_height(lats, lons)
+    assert np.allclose(hght, expected_hght)
+
+
+def test_get_min_max_native_dummy(dummy_dem_file_path_high_res, monkeypatch):
+    monkeypatch.setattr(Image, 'open', lambda filename: dummy_pil_image_open(filename, "EGM2008"))
+
+    sw_lat = -1
+    ne_lat = 2
+    sw_lon = -1
+    ne_lon = 2
+
+    lat_ss = 1 / (NUM_LATS_DUMMY - 1)
+    lon_ss = 1 / (NUM_LONS_DUMMY - 1)
+
+    def assert_result_good(pars, box):
+        def lt_or_close(lower, upper):
+            return lower < upper or np.isclose(lower, upper)
+
+        assert pars['box'] == box
+        assert pars['ref_surface'] == 'geoid'
+
+        assert lt_or_close(box[0], pars['min']['lat']) and lt_or_close(pars['min']['lat'], box[0] + lat_ss)
+        assert lt_or_close(box[2], pars['min']['lon']) and lt_or_close(pars['min']['lon'], box[2] + lon_ss)
+        assert (lt_or_close(lat_lon_to_dummy_height(box[0], box[2]), pars['min']['height']) and
+                lt_or_close(pars['min']['height'], lat_lon_to_dummy_height(box[0] + lat_ss, box[2] + lon_ss)))
+
+        assert lt_or_close(box[1] - lat_ss, pars['max']['lat']) and lt_or_close(pars['max']['lat'], box[1])
+        assert lt_or_close(box[3] - lon_ss, pars['max']['lon']) and lt_or_close(pars['max']['lon'], box[3])
+        assert (lt_or_close(lat_lon_to_dummy_height(box[1] - lat_ss, box[3] - lon_ss), pars['max']['height']) and
+                lt_or_close(pars['max']['height'], lat_lon_to_dummy_height(box[1], box[3] + lon_ss)))
+
+    obj = GeoTIFF1DegInterpolator(str(dummy_dem_file_path_high_res), FILENAME_FORMAT_HIGH_RES, "EGM2008")
+
+    # Test bounding box outside the DEM tiles
+    lat_lon_bounding_box = [sw_lat-10, ne_lat - 10, sw_lon - 10, ne_lon - 10]
+    result = obj.get_min_max_native(lat_lon_bounding_box)
+    expected_result = {'box': lat_lon_bounding_box,
+                       'ref_surface': 'geoid',
+                       'min': {'lat': lat_lon_bounding_box[0], 'lon': lat_lon_bounding_box[2], 'height': 0.0},
+                       'max': {'lat': lat_lon_bounding_box[0], 'lon': lat_lon_bounding_box[2], 'height': 0.0}}
+    assert result == expected_result
+
+    # All test points are inside valid DEM area and are inside a single tile
+    lat_min = sw_lat + 0.111111
+    lat_max = sw_lat + 0.811111
+    lon_min = sw_lon + 0.211111
+    lon_max = sw_lon + 0.711111
+    result = obj.get_min_max_native([lat_min, lat_max, lon_min, lon_max])
+    assert_result_good(result, [lat_min, lat_max, lon_min, lon_max])
+
+    # Test all point are inside valid DEM area and span several tiles
+    lat_min = sw_lat + 0.111
+    lat_max = sw_lat + 1.811
+    lon_min = sw_lon + 0.211
+    lon_max = sw_lon + 1.711
+    result = obj.get_min_max_native([lat_min, lat_max, lon_min, lon_max])
+    assert_result_good(result, [lat_min, lat_max, lon_min, lon_max])
+
+    # Exercise the bounding_box_cache
+    result = obj.get_min_max_native([lat_min, lat_max, lon_min, lon_max])
+    assert_result_good(result, [lat_min, lat_max, lon_min, lon_max])
+
+
+@pytest.mark.parametrize("ref_surface", [
+    pytest.param("egm2008", marks=pytest.mark.skipif(not (GEOID_ROOT_PATH / "geoid" / 'egm2008-1.pgm').exists(),
+                                                     reason="Geoid data does not exist.")),
+    pytest.param("wgs84", marks=pytest.mark.skipif(not (GEOID_ROOT_PATH / "geoid" / 'egm2008-1.pgm').exists(),
+                                                   reason="Geoid data does not exist."))])
+def test_get_elevation_hae_geoid(ref_surface, dummy_dem_file_path_high_res, monkeypatch):
+    if ref_surface == "egm2008":
+        monkeypatch.setattr(Image, 'open', lambda filename: dummy_pil_image_open(filename, "EGM2008"))
+    else:
+        monkeypatch.setattr(Image, 'open', lambda filename: dummy_pil_image_open(filename, "WGS84"))
+
+    sw_lat = -1
+    ne_lat = 2
+    sw_lon = -1
+    ne_lon = 2
+
+    obj = GeoTIFF1DegInterpolator(str(dummy_dem_file_path_high_res), FILENAME_FORMAT_HIGH_RES, str(GEOID_ROOT_PATH))
+
+    num_points = 8
+    d_offset = 1 / 18000
+
+    lats = np.linspace(sw_lat + d_offset, ne_lat - d_offset, num_points)
+    lons = np.linspace(sw_lon + d_offset, ne_lon/2 - d_offset, num_points)
+    hght1 = obj.get_elevation_hae(lats, lons)
+    hght2 = obj.get_elevation_geoid(lats, lons)
+    assert np.all(np.abs(hght1 - hght2) > 0)
+
+    min_hae = obj.get_min_hae([lats[0], lats[-1], lons[0], lons[-1]])
+    max_hae = obj.get_max_hae([lats[0], lats[-1], lons[0], lons[-1]])
+    min_geoid = obj.get_min_geoid([lats[0], lats[-1], lons[0], lons[-1]])
+    max_geoid = obj.get_max_geoid([lats[0], lats[-1], lons[0], lons[-1]])
+    assert np.all(np.abs(min_hae - min_geoid))
+    assert np.all(np.abs(max_hae - max_geoid))
+
+
+def test_exceptions(dummy_dem_file_path_high_res, monkeypatch):
+    obj = GeoTIFF1DegInterpolator(str(dummy_dem_file_path_high_res), FILENAME_FORMAT_HIGH_RES)
+    with pytest.raises(ValueError, match="^The lat and lon arrays are not the same shape\\."):
+        obj.get_elevation_native([1, 2, 3], [1, 2])
+
+    monkeypatch.setattr(Image, 'open', lambda filename: dummy_pil_image_open(filename, "WGS84"))
+    obj = GeoTIFF1DegInterpolator(str(dummy_dem_file_path_high_res), FILENAME_FORMAT_HIGH_RES)
+    with pytest.raises(ValueError,
+                       match="^The geoid_dir parameter was not defined so geoid calculations are disabled\\."):
+        obj.get_elevation_geoid(1, 1)
+
+    monkeypatch.setattr(Image, 'open', lambda filename: dummy_pil_image_open(filename, "EGM2008"))
+    obj = GeoTIFF1DegInterpolator(str(dummy_dem_file_path_high_res), FILENAME_FORMAT_HIGH_RES)
+    with pytest.raises(ValueError,
+                       match="^The geoid_dir parameter was not defined so geoid calculations are disabled\\."):
+        obj.get_elevation_hae(1, 1)
+
+    monkeypatch.setattr(Image, 'open', lambda filename: dummy_pil_image_open(filename, "Unknown"))
+    obj = GeoTIFF1DegInterpolator(str(dummy_dem_file_path_high_res), FILENAME_FORMAT_HIGH_RES)
+    with pytest.raises(ValueError, match="^The reference surface is Unknown, which is not supported"):
+        obj.get_elevation_geoid(1, 1)
+    with pytest.raises(ValueError, match="^The reference surface is Unknown, which is not supported"):
+        obj.get_elevation_hae(1, 1)


### PR DESCRIPTION
This PR adds support for Digital Elevation Models (DEMs) in GeoTIFF file format.  The module called **geotiff1deg.py** is added to **sarpy/io/DEM**.  The code makes the following assumptions.

1. The GeoTIFF files tile the earth with one-degree offsets in both latitude and longitude.
2. There is one pixel of overlap between adjacent tiles.
3. The south-west corner of each tile is at an integer (degrees) latitude and longitude.
4. The latitude and longitude of south-west corner point is encoded in the GeoTIFF filename.
5. The antimerdian is at W180 rather than at E180 so that valid longitude values are (-180 <= lon < 180) degrees.
6. The GeoTIFF tag 34737 (GeoAsciiParamsTag) indicates the reference surface (e.g., EGM2008, WGS84, etc.)

Within **geotiff1deg.py** the class called **GeoTIFF1DegInterpolator** is a child of the **DEMInterpolator** parent class, and the class called **GeoTIFF1DegList** is a child of the **DEMList** parent class.  This is similar to the existing **DTED.py** module.

The **geotiff1deg.py** module has 100% test coverage using the pytest modules called **test_geotiff1deg_list.py** and **test_geotiff1deg_reader.py**.  Real GeoTIFF DEM data files are not needed to run the tests, but, if real DEM data is available the tests will be more robust.  

Also, the **sarpy/utils/convert_to_sicd.py** and the **sarpy/io/complex/converter.py** modules have been modified so that the SCP and image corner coordinates will be projected to a DEM when a GeoTIFF DEM file is provided as a CLI argument to the **convert_to_sicd** program.

This code has been tested in python 3.6, 3.7, 3.8, 3.9, and 3.10 environments.  In addition to the usual **numpy** and **scipy** packages, the **pillow** package is needed to read the GeoTIFF files.  The **pytest** package is needed to run the unit test programs.
