### PR TITLE
add X1Y1 vs X2Y2 checks to cphd_consistency

### DIFF
--- a/sarpy/consistency/cphd_consistency.py
+++ b/sarpy/consistency/cphd_consistency.py
@@ -1137,12 +1137,25 @@ class CphdConsistency(con.ConsistencyChecker):
             assert channel_node.find('./ImageArea') is not None
             x1y1 = parsers.parse_xy(channel_node.find('./ImageArea/X1Y1'))
             x2y2 = parsers.parse_xy(channel_node.find('./ImageArea/X2Y2'))
+            with self.need("Channel/Parameters/ImageArea/X1Y1 < Channel/Parameters/ImageArea/X2Y2"):
+                assert x1y1[0] < x2y2[0]
+                assert x1y1[1] < x2y2[1]
             global_x1y1 = parsers.parse_xy(self.xml.find('./SceneCoordinates/ImageArea/X1Y1'))
             global_x2y2 = parsers.parse_xy(self.xml.find('./SceneCoordinates/ImageArea/X2Y2'))
-            with self.need("X1Y1"):
+            with self.need("Channel/Parameters/ImageArea/X1Y1 bounded by SceneCoordinates/ImageArea/X1Y1"):
                 assert x1y1 >= con.Approx(global_x1y1)
-            with self.need("X2Y2"):
+            with self.need("Channel/Parameters/ImageArea/X2Y2 bounded by SceneCoordinates/ImageArea/X2Y2"):
                 assert x2y2 <= con.Approx(global_x2y2)
+
+    def check_imagearea_x1y1_x2y2(self):
+        """
+        SceneCoordinates/ImageArea is self-consistent.
+        """
+        x1, y1 = parsers.parse_xy(self.xml.find('./SceneCoordinates/ImageArea/X1Y1'))
+        x2, y2 = parsers.parse_xy(self.xml.find('./SceneCoordinates/ImageArea/X2Y2'))
+        with self.need("SceneCoordinates/ImageArea/X1Y1 < SceneCoordinates/ImageArea/X2Y2"):
+            assert x1 < x2
+            assert y1 < y2
 
     def check_extended_imagearea_x1y1_x2y2(self):
         """
@@ -1153,6 +1166,9 @@ class CphdConsistency(con.ConsistencyChecker):
             assert self.xml.find('./SceneCoordinates/ExtendedArea') is not None
             extended_x1y1 = parsers.parse_xy(self.xml.find('./SceneCoordinates/ExtendedArea/X1Y1'))
             extended_x2y2 = parsers.parse_xy(self.xml.find('./SceneCoordinates/ExtendedArea/X2Y2'))
+            with self.need("SceneCoordinates/ExtendedArea/X1Y1 < SceneCoordinates/ExtendedArea/X2Y2"):
+                assert extended_x1y1[0] < extended_x2y2[0]
+                assert extended_x1y1[1] < extended_x2y2[1]
             global_x1y1 = parsers.parse_xy(self.xml.find('./SceneCoordinates/ImageArea/X1Y1'))
             global_x2y2 = parsers.parse_xy(self.xml.find('./SceneCoordinates/ImageArea/X2Y2'))
             with self.need("Extended X1Y1 less than image area X1Y1"):

--- a/tests/consistency/test_cphd_consistency.py
+++ b/tests/consistency/test_cphd_consistency.py
@@ -726,6 +726,23 @@ def test_channel_image_area(xml_with_channel_imagearea):
     assert len(cphd_con.failures()) == 0
 
 
+def test_check_imagearea_x1y1_x2y2(good_cphd):
+    cphd_con = CphdConsistency.from_file(str(good_cphd))
+    scene_imagearea = cphd_con.xml.find('./SceneCoordinates/ImageArea')
+    scene_imagearea.find('./X1Y1/X').text = scene_imagearea.findtext('./X2Y2/X')
+    cphd_con.check('check_imagearea_x1y1_x2y2')
+    assert cphd_con.failures()
+
+
+def test_check_channel_imagearea_x1y1(xml_with_channel_imagearea):
+    root, nsmap = xml_with_channel_imagearea
+    channel_imagearea = root.find('./{*}Channel/{*}Parameters/{*}ImageArea')
+    channel_imagearea.find('./{*}X1Y1/{*}Y').text = channel_imagearea.findtext('./{*}X2Y2/{*}Y')
+    cphd_con = CphdConsistency(root, pvps=None, header=None, filename=None)
+    cphd_con.check('check_channel_imagearea_x1y1', allow_prefix=True)
+    assert cphd_con.failures()
+
+
 @pytest.fixture
 def xml_with_extendedarea(good_xml):
     root = copy_xml(good_xml['with_ns'])
@@ -769,6 +786,18 @@ def test_extended_imagearea(xml_with_extendedarea):
 
     cphd_con.check(['check_extended_imagearea_polygon', 'check_extended_imagearea_x1y1_x2y2'])
     assert len(cphd_con.failures()) == 0
+
+
+def test_check_extended_imagearea_x1y1_x2y2(xml_with_extendedarea):
+    root, nsmap = xml_with_extendedarea
+    x1 = root.findtext('./ns:SceneCoordinates/ns:ExtendedArea/ns:X1Y1/ns:X', namespaces=nsmap)
+    root.find('./ns:SceneCoordinates/ns:ExtendedArea/ns:X2Y2/ns:X', namespaces=nsmap).text = x1
+
+    cphd_con = CphdConsistency(
+        root, pvps=None, header=None, filename=None, check_signal_data=False)
+
+    cphd_con.check('check_extended_imagearea_x1y1_x2y2')
+    assert cphd_con.failures()
 
 
 def test_extended_imagearea_polygon_bad_extent(xml_with_extendedarea):


### PR DESCRIPTION
# Description
This PR adds X1Y1 < X2Y2 checks to SarPy's `cphd_consistency` module.

# Demo
Using a hand-modified XML:

<details><summary>modification</summary>

Note that Y2 is negated on the bottom ImageArea (which happens to be inside of `Channel/Parameters`

```
(sarpy) 15:17:55 [sarpy] (1035)$ grep "<X1Y1" -A 7 -B 1 spotlight_example_small.cphd.xml 
    <ImageArea>
      <X1Y1>
        <X>-250.0</X>
        <Y>-250.0</Y>
      </X1Y1>
      <X2Y2>
        <X>250.0</X>
        <Y>250.0</Y>
      </X2Y2>
--
    <ExtendedArea>
      <X1Y1>
        <X>-250.0</X>
        <Y>-250.0</Y>
      </X1Y1>
      <X2Y2>
        <X>250.0</X>
        <Y>250.0</Y>
      </X2Y2>
--
      <ImageArea>
        <X1Y1>
          <X>-250.0</X>
          <Y>-250.0</Y>
        </X1Y1>
        <X2Y2>
          <X>250.0</X>
          <Y>-250.0</Y>
        </X2Y2>
```

</details>

SarPy output:

```shell
(sarpy) 15:17:59 [sarpy] (1036)$ python -m sarpy.consistency.cphd_consistency spotlight_example_small.cphd.xml  -v
check_channel_imagearea_x1y1_1: Image area X1Y1 and X2Y2 work with global X1Y1 and X2Y2 for channel 1.
    [Error] Need: Channel/Parameters/ImageArea/X1Y1 < Channel/Parameters/ImageArea/X2Y2
        line#1142: assert x1y1[1] < x2y2[1]
        assert -250.0 < -250.0
```

# Test Plan
These code changes were tested in SarPy environments in python 3.6, 3.8, and 3.10

<details><summary>3.6</summary>

```shell
======================================================================================================================================================================================================== test session starts ========================================================================================================================================================================================================
platform linux -- Python 3.6.13, pytest-6.2.4, py-1.11.0, pluggy-0.13.1
rootdir: /home/vscuser/git/glweb/software/third-party/sarpy
collected 207 items                                                                                                                                                                                                                                                                                                                                                                                                                 

tests/test_class_string.py .                                                                                                                                                                                                                                                                                                                                                                                                  [  0%]
tests/consistency/test_consistency.py ........                                                                                                                                                                                                                                                                                                                                                                                [  4%]
tests/consistency/test_cphd_consistency.py ..............................................................                                                                                                                                                                                                                                                                                                                     [ 34%]
tests/geometry/test_geocoords.py ..........                                                                                                                                                                                                                                                                                                                                                                                   [ 39%]
tests/geometry/test_geometry_elements.py ..........                                                                                                                                                                                                                                                                                                                                                                           [ 43%]
tests/geometry/test_latlon.py ...                                                                                                                                                                                                                                                                                                                                                                                             [ 45%]
tests/geometry/test_point_projection.py ............                                                                                                                                                                                                                                                                                                                                                                          [ 51%]
tests/io/DEM/test_geoid.py s                                                                                                                                                                                                                                                                                                                                                                                                  [ 51%]
tests/io/DEM/test_geotiff1deg_list.py ....                                                                                                                                                                                                                                                                                                                                                                                    [ 53%]
tests/io/DEM/test_geotiff1deg_reader.py .ss..ss.                                                                                                                                                                                                                                                                                                                                                                              [ 57%]
tests/io/complex/test_reader.py sssssssssss                                                                                                                                                                                                                                                                                                                                                                                   [ 62%]
tests/io/complex/test_remote.py .                                                                                                                                                                                                                                                                                                                                                                                             [ 63%]
tests/io/complex/test_sicd.py s                                                                                                                                                                                                                                                                                                                                                                                               [ 63%]
tests/io/complex/test_utils.py .                                                                                                                                                                                                                                                                                                                                                                                              [ 64%]
tests/io/complex/sicd_elements/test_sicd_elements.py .................                                                                                                                                                                                                                                                                                                                                                        [ 72%]
tests/io/general/test_base.py ...                                                                                                                                                                                                                                                                                                                                                                                             [ 73%]
tests/io/general/test_data_segment.py ..........                                                                                                                                                                                                                                                                                                                                                                              [ 78%]
tests/io/general/test_format_function.py .......                                                                                                                                                                                                                                                                                                                                                                              [ 82%]
tests/io/general/test_nitf_headers.py s                                                                                                                                                                                                                                                                                                                                                                                       [ 82%]
tests/io/general/test_tre.py .                                                                                                                                                                                                                                                                                                                                                                                                [ 83%]
tests/io/phase_history/test_cphd.py .                                                                                                                                                                                                                                                                                                                                                                                         [ 83%]
tests/io/phase_history/cphd1_elements/test_utils.py .                                                                                                                                                                                                                                                                                                                                                                         [ 84%]
tests/io/product/test_reader.py ..s                                                                                                                                                                                                                                                                                                                                                                                           [ 85%]
tests/io/product/test_sidd_schema.py ........                                                                                                                                                                                                                                                                                                                                                                                 [ 89%]
tests/io/product/test_sidd_writing.py s                                                                                                                                                                                                                                                                                                                                                                                       [ 89%]
tests/io/received/test_crsd.py s                                                                                                                                                                                                                                                                                                                                                                                              [ 90%]
tests/visualization/test_remap.py ....................                                                                                                                                                                                                                                                                                                                                                                        [100%]

========================================================================================================================================================================================================= warnings summary ==========================================================================================================================================================================================================
tests/geometry/test_point_projection.py::test_image_to_ground_errors
tests/geometry/test_point_projection.py::test_image_to_ground_dem
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/geometry/point_projection.py:1903: RuntimeWarning: divide by zero encountered in double_scalars
    lon_grid_size = min(10, lat_grid_size/abs(numpy.sin(numpy.deg2rad(ref_llh[0]))))

-- Docs: https://docs.pytest.org/en/stable/warnings.html
=========================================================================================================================================================================================== 186 passed, 21 skipped, 2 warnings in 19.98s ============================================================================================================================================================================================
```

</details>

<details><summary>3.8</summary>

```
======================================================================================================================================================================================================== test session starts ========================================================================================================================================================================================================
platform linux -- Python 3.8.16, pytest-7.1.2, pluggy-1.0.0
rootdir: /home/vscuser/git/glweb/software/third-party/sarpy
collected 207 items                                                                                                                                                                                                                                                                                                                                                                                                                 

tests/test_class_string.py .                                                                                                                                                                                                                                                                                                                                                                                                  [  0%]
tests/consistency/test_consistency.py ........                                                                                                                                                                                                                                                                                                                                                                                [  4%]
tests/consistency/test_cphd_consistency.py ..............................................................                                                                                                                                                                                                                                                                                                                     [ 34%]
tests/geometry/test_geocoords.py ..........                                                                                                                                                                                                                                                                                                                                                                                   [ 39%]
tests/geometry/test_geometry_elements.py ..........                                                                                                                                                                                                                                                                                                                                                                           [ 43%]
tests/geometry/test_latlon.py ...                                                                                                                                                                                                                                                                                                                                                                                             [ 45%]
tests/geometry/test_point_projection.py ............                                                                                                                                                                                                                                                                                                                                                                          [ 51%]
tests/io/DEM/test_geoid.py s                                                                                                                                                                                                                                                                                                                                                                                                  [ 51%]
tests/io/DEM/test_geotiff1deg_list.py ....                                                                                                                                                                                                                                                                                                                                                                                    [ 53%]
tests/io/DEM/test_geotiff1deg_reader.py .ss..ss.                                                                                                                                                                                                                                                                                                                                                                              [ 57%]
tests/io/complex/test_reader.py sssssssssss                                                                                                                                                                                                                                                                                                                                                                                   [ 62%]
tests/io/complex/test_remote.py .                                                                                                                                                                                                                                                                                                                                                                                             [ 63%]
tests/io/complex/test_sicd.py s                                                                                                                                                                                                                                                                                                                                                                                               [ 63%]
tests/io/complex/test_utils.py .                                                                                                                                                                                                                                                                                                                                                                                              [ 64%]
tests/io/complex/sicd_elements/test_sicd_elements.py .................                                                                                                                                                                                                                                                                                                                                                        [ 72%]
tests/io/general/test_base.py ...                                                                                                                                                                                                                                                                                                                                                                                             [ 73%]
tests/io/general/test_data_segment.py ..........                                                                                                                                                                                                                                                                                                                                                                              [ 78%]
tests/io/general/test_format_function.py .......                                                                                                                                                                                                                                                                                                                                                                              [ 82%]
tests/io/general/test_nitf_headers.py s                                                                                                                                                                                                                                                                                                                                                                                       [ 82%]
tests/io/general/test_tre.py .                                                                                                                                                                                                                                                                                                                                                                                                [ 83%]
tests/io/phase_history/test_cphd.py .                                                                                                                                                                                                                                                                                                                                                                                         [ 83%]
tests/io/phase_history/cphd1_elements/test_utils.py .                                                                                                                                                                                                                                                                                                                                                                         [ 84%]
tests/io/product/test_reader.py ..s                                                                                                                                                                                                                                                                                                                                                                                           [ 85%]
tests/io/product/test_sidd_schema.py ........                                                                                                                                                                                                                                                                                                                                                                                 [ 89%]
tests/io/product/test_sidd_writing.py s                                                                                                                                                                                                                                                                                                                                                                                       [ 89%]
tests/io/received/test_crsd.py s                                                                                                                                                                                                                                                                                                                                                                                              [ 90%]
tests/visualization/test_remap.py ....................                                                                                                                                                                                                                                                                                                                                                                        [100%]

========================================================================================================================================================================================================= warnings summary ==========================================================================================================================================================================================================
tests/geometry/test_point_projection.py::test_image_to_ground_errors
tests/geometry/test_point_projection.py::test_image_to_ground_dem
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/geometry/point_projection.py:1903: RuntimeWarning: divide by zero encountered in double_scalars
    lon_grid_size = min(10, lat_grid_size/abs(numpy.sin(numpy.deg2rad(ref_llh[0]))))

tests/visualization/test_remap.py::TestRemap::test_LUTRemap_matplotlib
tests/visualization/test_remap.py::TestRemap::test_remap_names
tests/visualization/test_remap.py::TestRemap::test_remap_names
tests/visualization/test_remap.py::TestRemap::test_remap_names
tests/visualization/test_remap.py::TestRemap::test_remap_names
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/visualization/remap.py:1562: MatplotlibDeprecationWarning: The get_cmap function was deprecated in Matplotlib 3.7 and will be removed two minor releases later. Use ``matplotlib.colormaps[name]`` or ``matplotlib.colormaps.get_cmap(obj)`` instead.
    cmap = cm.get_cmap(value, max_out_size+1)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================================================================================================================================================================================== 186 passed, 21 skipped, 7 warnings in 21.48s ============================================================================================================================================================================================
```

</details>

<details><summary>3.10</summary>

```
======================================================================================================================================================================================================== test session starts ========================================================================================================================================================================================================
platform linux -- Python 3.10.9, pytest-7.1.2, pluggy-1.0.0
rootdir: /home/vscuser/git/glweb/software/third-party/sarpy
plugins: cov-3.0.0
collected 207 items                                                                                                                                                                                                                                                                                                                                                                                                                 

tests/test_class_string.py .                                                                                                                                                                                                                                                                                                                                                                                                  [  0%]
tests/consistency/test_consistency.py ........                                                                                                                                                                                                                                                                                                                                                                                [  4%]
tests/consistency/test_cphd_consistency.py ..............................................................                                                                                                                                                                                                                                                                                                                     [ 34%]
tests/geometry/test_geocoords.py ..........                                                                                                                                                                                                                                                                                                                                                                                   [ 39%]
tests/geometry/test_geometry_elements.py ..........                                                                                                                                                                                                                                                                                                                                                                           [ 43%]
tests/geometry/test_latlon.py ...                                                                                                                                                                                                                                                                                                                                                                                             [ 45%]
tests/geometry/test_point_projection.py ............                                                                                                                                                                                                                                                                                                                                                                          [ 51%]
tests/io/DEM/test_geoid.py s                                                                                                                                                                                                                                                                                                                                                                                                  [ 51%]
tests/io/DEM/test_geotiff1deg_list.py ....                                                                                                                                                                                                                                                                                                                                                                                    [ 53%]
tests/io/DEM/test_geotiff1deg_reader.py .ss..ss.                                                                                                                                                                                                                                                                                                                                                                              [ 57%]
tests/io/complex/test_reader.py sssssssssss                                                                                                                                                                                                                                                                                                                                                                                   [ 62%]
tests/io/complex/test_remote.py .                                                                                                                                                                                                                                                                                                                                                                                             [ 63%]
tests/io/complex/test_sicd.py s                                                                                                                                                                                                                                                                                                                                                                                               [ 63%]
tests/io/complex/test_utils.py .                                                                                                                                                                                                                                                                                                                                                                                              [ 64%]
tests/io/complex/sicd_elements/test_sicd_elements.py .................                                                                                                                                                                                                                                                                                                                                                        [ 72%]
tests/io/general/test_base.py ...                                                                                                                                                                                                                                                                                                                                                                                             [ 73%]
tests/io/general/test_data_segment.py ..........                                                                                                                                                                                                                                                                                                                                                                              [ 78%]
tests/io/general/test_format_function.py .......                                                                                                                                                                                                                                                                                                                                                                              [ 82%]
tests/io/general/test_nitf_headers.py s                                                                                                                                                                                                                                                                                                                                                                                       [ 82%]
tests/io/general/test_tre.py .                                                                                                                                                                                                                                                                                                                                                                                                [ 83%]
tests/io/phase_history/test_cphd.py .                                                                                                                                                                                                                                                                                                                                                                                         [ 83%]
tests/io/phase_history/cphd1_elements/test_utils.py .                                                                                                                                                                                                                                                                                                                                                                         [ 84%]
tests/io/product/test_reader.py ..s                                                                                                                                                                                                                                                                                                                                                                                           [ 85%]
tests/io/product/test_sidd_schema.py ........                                                                                                                                                                                                                                                                                                                                                                                 [ 89%]
tests/io/product/test_sidd_writing.py s                                                                                                                                                                                                                                                                                                                                                                                       [ 89%]
tests/io/received/test_crsd.py s                                                                                                                                                                                                                                                                                                                                                                                              [ 90%]
tests/visualization/test_remap.py ....................                                                                                                                                                                                                                                                                                                                                                                        [100%]

========================================================================================================================================================================================================= warnings summary ==========================================================================================================================================================================================================
tests/geometry/test_point_projection.py::test_image_to_ground_errors
tests/geometry/test_point_projection.py::test_image_to_ground_dem
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/geometry/point_projection.py:1903: RuntimeWarning: divide by zero encountered in double_scalars
    lon_grid_size = min(10, lat_grid_size/abs(numpy.sin(numpy.deg2rad(ref_llh[0]))))

tests/visualization/test_remap.py::TestRemap::test_LUTRemap_matplotlib
tests/visualization/test_remap.py::TestRemap::test_remap_names
tests/visualization/test_remap.py::TestRemap::test_remap_names
tests/visualization/test_remap.py::TestRemap::test_remap_names
tests/visualization/test_remap.py::TestRemap::test_remap_names
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/visualization/remap.py:1562: PendingDeprecationWarning: The get_cmap function will be deprecated in a future version. Use ``matplotlib.colormaps[name]`` or ``matplotlib.colormaps.get_cmap(obj)`` instead.
    cmap = cm.get_cmap(value, max_out_size+1)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================================================================================================================================================================================== 186 passed, 21 skipped, 7 warnings in 20.16s ============================================================================================================================================================================================
```

</details>