### PR TITLE
fix test bug

### DIFF
--- a/tests/io/DEM/test_geotiff1deg_reader.py
+++ b/tests/io/DEM/test_geotiff1deg_reader.py
@@ -389,8 +389,8 @@ def test_exceptions(dummy_dem_file_path_high_res, monkeypatch, caplog):
 
     caplog.clear()
     caplog.set_level(logging.WARNING)
-    obj = GeoTIFF1DegInterpolator(filename_format, ref_surface="WGS84", geoid_path=str(GEOID_FILE_PATH))
-    obj.get_elevation_geoid(1, 1)
+    obj = GeoTIFF1DegInterpolator(filename_format, ref_surface="WGS84")
+    obj.get_elevation_native(1, 1)
     assert caplog.text.startswith("WARNING  sarpy.io.DEM.geotiff1deg:geotiff1deg.py")
     assert "The GeoAsciiParamsTag tag implies that the reference surface is EGM2008" in caplog.text
 


### PR DESCRIPTION
We found that running `test_geotiff1deg_reader.py` without a geoid file failed a test that was never intended to run without a geoid file.  This PR is meant to address that bug.

<details><summary>To duplicate the error</summary>

`git clone git@github.com:ngageoint/sarpy.git`

`cd sarpy`

`conda create -n sarpy python==3.10.11 pytest pillow`

`conda activate spy`

`python setup.py install`

`pytest tests/io/DEM/test_geotiff1deg_reader.py`

```
pytest tests/io/DEM/test_geotiff1deg_reader.py
================================================================================================= test session starts ==================================================================================================
platform linux -- Python 3.10.11, pytest-7.3.1, pluggy-1.0.0
rootdir: /home/vscuser/testing/sarpy
collected 8 items                                                                                                                                                                                                      

tests/io/DEM/test_geotiff1deg_reader.py .ss..ssF                                                                                                                                                                 [100%]

======================================================================================================= FAILURES =======================================================================================================
___________________________________________________________________________________________________ test_exceptions ____________________________________________________________________________________________________

dummy_dem_file_path_high_res = PosixPath('/tmp/tmp6laka4mi/high_res'), monkeypatch = \<_pytest.monkeypatch.MonkeyPatch object at 0x7f50ec786170\>, caplog = \<_pytest.logging.LogCaptureFixture object at 0x7f50ec7862c0\>

    def test_exceptions(dummy_dem_file_path_high_res, monkeypatch, caplog):
        filename_format = infer_filename_format(dummy_dem_file_path_high_res)
        obj = GeoTIFF1DegInterpolator(filename_format)
        with pytest.raises(ValueError, match="^The lat and lon arrays are not the same shape\\."):
            obj.get_elevation_native([1, 2, 3], [1, 2])
    
        monkeypatch.setattr(Image, 'open', lambda filename: dummy_pil_image_open(filename, "WGS84"))
        obj = GeoTIFF1DegInterpolator(filename_format, ref_surface="WGS84")
        with pytest.raises(ValueError,
                           match="^The geoid_dir parameter was not defined so geoid calculations are disabled\\."):
            obj.get_elevation_geoid(1, 1)
    
        caplog.clear()
        caplog.set_level(logging.WARNING)
        obj = GeoTIFF1DegInterpolator(filename_format, ref_surface="EGM2008")
        obj.get_elevation_geoid(1, 1)
        assert caplog.text.startswith("WARNING  sarpy.io.DEM.geotiff1deg:geotiff1deg.py")
        assert "The GeoAsciiParamsTag tag implies that the reference surface is WGS84" in caplog.text
    
        monkeypatch.setattr(Image, 'open', lambda filename: dummy_pil_image_open(filename, "EGM2008"))
        obj = GeoTIFF1DegInterpolator(filename_format)
        with pytest.raises(ValueError,
                           match="^The geoid_dir parameter was not defined so geoid calculations are disabled\\."):
            obj.get_elevation_hae(1, 1)
    
        caplog.clear()
        caplog.set_level(logging.WARNING)
        obj = GeoTIFF1DegInterpolator(filename_format, ref_surface="WGS84", geoid_path=str(GEOID_FILE_PATH))
>       obj.get_elevation_geoid(1, 1)

tests/io/DEM/test_geotiff1deg_reader.py:393: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <sarpy.io.DEM.geotiff1deg.GeoTIFF1DegInterpolator object at 0x7f50ec778580>, lat = 1, lon = 1, block_size = None

    def get_elevation_geoid(self, lat, lon, block_size=None):
        """
        Get the elevation value relative to the geoid.
    
        Parameters
        ----------
        lat : numpy.ndarray | list | tuple | int | float
        lon : numpy.ndarray | list | tuple | int | float
        block_size : int | None (default: None)
            Block processing is not supported; this argument is present to maintain a common interface with
            the DEMInterpolator parent class.  A value other than None will result in a warning.
    
        Returns
        -------
        numpy.ndarray
            the elevation relative to the geoid
        """
        height_native = self.get_elevation_native(lat, lon, block_size)
    
        if self._ref_surface.startswith("EGM"):
            return height_native
        elif self._ref_surface.startswith('WGS'):
            if self._geoid_obj is None:
\>               raise ValueError("The geoid_dir parameter was not defined so geoid calculations are disabled.")
E               ValueError: The geoid_dir parameter was not defined so geoid calculations are disabled.

sarpy/io/DEM/geotiff1deg.py:277: ValueError
-------------------------------------------------------------------------------------------------- Captured log call ---------------------------------------------------------------------------------------------------
WARNING  sarpy.io.DEM.geotiff1deg:geotiff1deg.py:204 /tmp/tmp6laka4mi/high_res/tdt_n01e001_01/DEM/TDT_N01E001_01_DEM.tif
The GeoAsciiParamsTag tag implies that the reference surface is WGS84,
but the explicit reference surface was defined to be EGM2008.
This might cause the elevation values to be calculated incorrectly.

WARNING  sarpy.io.DEM.geotiff1deg:geotiff1deg.py:204 /tmp/tmp6laka4mi/high_res/tdt_n01e001_01/DEM/TDT_N01E001_01_DEM.tif
The GeoAsciiParamsTag tag implies that the reference surface is EGM2008,
but the explicit reference surface was defined to be WGS84.
This might cause the elevation values to be calculated incorrectly.
=============================================================================================== short test summary info ================================================================================================
FAILED tests/io/DEM/test_geotiff1deg_reader.py::test_exceptions - ValueError: The geoid_dir parameter was not defined so geoid calculations are disabled.
======================================================================================== 1 failed, 3 passed, 4 skipped in 0.27s ========================================================================================
```

</details>

<details><summary>Test run after the fix</summary>

`pytest tests/io/DEM/test_geotiff1deg_reader.py`

```
================================================================================================= test session starts ==================================================================================================
platform linux -- Python 3.9.15, pytest-6.2.4, py-1.11.0, pluggy-0.13.1
rootdir: /home/vscuser/repos/sarpy
plugins: cov-2.12.1, anyio-3.5.0
collected 8 items                                                                                                                                                                                                      

tests/io/DEM/test_geotiff1deg_reader.py .ss..ss.                                                                                                                                                                 [100%]

============================================================================================= 4 passed, 4 skipped in 0.22s =============================================================================================
```

</details>
