### PR TITLE
Fill out NITF FL field

### DIFF
--- a/sarpy/io/general/nitf.py
+++ b/sarpy/io/general/nitf.py
@@ -4160,7 +4160,7 @@ class NITFWriter(BaseWriter):
 
             check = self.nitf_writing_details.verify_all_offsets(require=False)
             if check:
-                self.nitf_writing_details.write_header(self._file_object, overwrite=False)
+                self.nitf_writing_details.write_header(self._file_object, overwrite=True)
             self.nitf_writing_details.write_all_populated_items(self._file_object)
         except AttributeError:
             return

--- a/sarpy/processing/sidd/sidd_product_creation.py
+++ b/sarpy/processing/sidd/sidd_product_creation.py
@@ -173,11 +173,10 @@ def create_detected_image_sidd(
 
     # create the sidd writer
     full_filename = _validate_filename(output_directory, output_file, sidd_structure)
-    writer = SIDDWriter(full_filename, sidd_structure, ortho_helper.sicd if include_sicd else None)
-
-    # iterate and write
-    for data, start_indices in ortho_iterator:
-        writer(data, start_indices=start_indices, index=0)
+    with SIDDWriter(full_filename, sidd_structure, ortho_helper.sicd if include_sicd else None) as writer:
+        # iterate and write
+        for data, start_indices in ortho_iterator:
+            writer(data, start_indices=start_indices, index=0)
 
 
 def create_csi_sidd(
@@ -263,11 +262,10 @@ def create_csi_sidd(
 
     # create the sidd writer
     full_filename = _validate_filename(output_directory, output_file, sidd_structure)
-    writer = SIDDWriter(full_filename, sidd_structure, csi_calculator.sicd if include_sicd else None)
-
-    # iterate and write
-    for data, start_indices in ortho_iterator:
-        writer(data, start_indices=start_indices, index=0)
+    with SIDDWriter(full_filename, sidd_structure, csi_calculator.sicd if include_sicd else None) as writer:
+        # iterate and write
+        for data, start_indices in ortho_iterator:
+            writer(data, start_indices=start_indices, index=0)
 
 
 def create_dynamic_image_sidd(
@@ -371,8 +369,7 @@ def create_dynamic_image_sidd(
         full_filename = os.path.join(output_directory, output_file)
     if os.path.exists(os.path.expanduser(full_filename)):
         raise SarpyIOError('File {} already exists.'.format(full_filename))
-    writer = SIDDWriter(full_filename, the_sidds, subap_calculator.sicd if include_sicd else None)
-
-    # iterate and write
-    for data, start_indices, the_frame in ortho_iterator:
-        writer(data, start_indices=start_indices, index=the_frame)
+    with SIDDWriter(full_filename, the_sidds, subap_calculator.sicd if include_sicd else None) as writer:
+        # iterate and write
+        for data, start_indices, the_frame in ortho_iterator:
+            writer(data, start_indices=start_indices, index=the_frame)

--- a/tests/io/complex/test_sicd.py
+++ b/tests/io/complex/test_sicd.py
@@ -56,6 +56,9 @@ class TestSICDWriting(unittest.TestCase):
             with self.subTest(msg='Test conversion (recreation) of the sicd file {}'.format(fil)):
                 with tempfile.TemporaryDirectory() as tmpdirname:
                     conversion_utility(reader, tmpdirname)
+                    new_filename = os.path.join(tmpdirname, os.listdir(tmpdirname)[0])
+                    reader2 = SICDReader(new_filename)
+                    self.assertEqual(os.stat(new_filename).st_size, reader2.nitf_details.nitf_header.FL)
 
             with self.subTest(msg='Test writing a single row of the sicd file {}'.format(fil)):
                 with tempfile.TemporaryDirectory() as tmpdirname:


### PR DESCRIPTION
The NITF `FL` field wasn't being filled out and was populated with zeros.  The `FL` field was already being computed as part of `verify_all_offsets`, but the updated value wasn't being written out.

Also, while looking into it we noticed the SIDD product creators weren't using the context manager interface, so they weren't necessarily closing/flushing the files.