### PR TITLE
Add unit tests for sicd_elements antenna

### DIFF
--- a/tests/data/example.sicd.xml
+++ b/tests/data/example.sicd.xml
@@ -1039,6 +1039,79 @@
             </GainBSPoly>
             <MLFreqDilation>false</MLFreqDilation>
         </Rcv>
+        <TwoWay>
+            <XAxisPoly>
+                <X order1="2">
+                    <Coef exponent1="0">0.13982986262005959</Coef>
+                    <Coef exponent1="1">-0.0027594341203054122</Coef>
+                    <Coef exponent1="2">-2.642141233211328e-06</Coef>
+                </X>
+                <Y order1="2">
+                    <Coef exponent1="0">-0.985103968766331</Coef>
+                    <Coef exponent1="1">-0.00072022999981332595</Coef>
+                    <Coef exponent1="2">8.6929909937280073e-06</Coef>
+                </Y>
+                <Z order1="2">
+                    <Coef exponent1="0">0.10008886172036295</Coef>
+                    <Coef exponent1="1">-0.0032336279155612555</Coef>
+                    <Coef exponent1="2">-3.6150726160461875e-06</Coef>
+                </Z>
+            </XAxisPoly>
+            <YAxisPoly>
+                <X order1="2">
+                    <Coef exponent1="0">-0.85523535607199153</Coef>
+                    <Coef exponent1="1">-0.00010473716447760117</Coef>
+                    <Coef exponent1="2">1.0612386361416289e-06</Coef>
+                </X>
+                <Y order1="2">
+                    <Coef exponent1="0">-0.06921308838843146</Coef>
+                    <Coef exponent1="1">0.00073787526119144643</Coef>
+                    <Coef exponent1="2">7.399077245060788e-08</Coef>
+                </Y>
+                <Z order1="2">
+                    <Coef exponent1="0">0.51359715158881925</Coef>
+                    <Coef exponent1="1">-7.4969848184029868e-05</Coef>
+                    <Coef exponent1="2">1.2309351838082699e-06</Coef>
+                </Z>
+            </YAxisPoly>
+            <FreqZero>10000000000</FreqZero>
+            <EB>
+                <DCXPoly order1="0">
+                    <Coef exponent1="0">0</Coef>
+                </DCXPoly>
+                <DCYPoly order1="0">
+                    <Coef exponent1="0">0</Coef>
+                </DCYPoly>
+            </EB>
+            <Array>
+                <GainPoly order1="2" order2="2">
+                    <Coef exponent1="0" exponent2="0">0</Coef>
+                    <Coef exponent1="0" exponent2="1">-4.1430777012935061e-12</Coef>
+                    <Coef exponent1="0" exponent2="2">-25810177.686242383</Coef>
+                    <Coef exponent1="1" exponent2="0">-4.1430777012935061e-12</Coef>
+                    <Coef exponent1="1" exponent2="1">0</Coef>
+                    <Coef exponent1="1" exponent2="2">0</Coef>
+                    <Coef exponent1="2" exponent2="0">-25810177.686242383</Coef>
+                    <Coef exponent1="2" exponent2="1">0</Coef>
+                    <Coef exponent1="2" exponent2="2">0</Coef>
+                </GainPoly>
+                <PhasePoly order1="0" order2="0">
+                    <Coef exponent1="0" exponent2="0">0</Coef>
+                </PhasePoly>
+            </Array>
+            <Elem>
+                <GainPoly order1="0" order2="0">
+                    <Coef exponent1="0" exponent2="0">0</Coef>
+                </GainPoly>
+                <PhasePoly order1="0" order2="0">
+                    <Coef exponent1="0" exponent2="0">0</Coef>
+                </PhasePoly>
+            </Elem>
+            <GainBSPoly order1="0">
+                <Coef exponent1="0">0</Coef>
+            </GainBSPoly>
+            <MLFreqDilation>false</MLFreqDilation>
+        </TwoWay>
     </Antenna>
     <PFA>
         <FPN>

--- a/tests/io/complex/sicd_elements/test_sicd_elements_antenna.py
+++ b/tests/io/complex/sicd_elements/test_sicd_elements_antenna.py
@@ -1,0 +1,91 @@
+#
+# Copyright 2023 Valkyrie Systems Corporation
+#
+# Licensed under MIT License.  See LICENSE.
+#
+import numpy as np
+import pytest
+
+from sarpy.io.complex.sicd_elements import Antenna
+from sarpy.io.complex.sicd_elements import blocks
+
+
+@pytest.fixture
+def tx_ant_param(sicd, kwargs):
+    return Antenna.AntParamType(XAxisPoly=sicd.Antenna.Tx.XAxisPoly,
+                                YAxisPoly=sicd.Antenna.Tx.YAxisPoly,
+                                FreqZero=sicd.Antenna.Tx.FreqZero,
+                                EB=sicd.Antenna.Tx.EB,
+                                Array=sicd.Antenna.Tx.Array,
+                                Elem=sicd.Antenna.Tx.Elem,
+                                GainBSPoly=sicd.Antenna.Tx.GainBSPoly,
+                                EBFreqShift=True,
+                                MLFreqDilation=sicd.Antenna.Tx.MLFreqDilation,
+                                **kwargs)
+
+@pytest.fixture
+def rcv_ant_param(sicd, kwargs):
+    return Antenna.AntParamType(XAxisPoly=sicd.Antenna.Rcv.XAxisPoly,
+                                YAxisPoly=sicd.Antenna.Rcv.YAxisPoly,
+                                FreqZero=sicd.Antenna.Rcv.FreqZero,
+                                EB=sicd.Antenna.Rcv.EB,
+                                Array=sicd.Antenna.Rcv.Array,
+                                Elem=sicd.Antenna.Rcv.Elem,
+                                GainBSPoly=sicd.Antenna.Rcv.GainBSPoly,
+                                EBFreqShift=True,
+                                MLFreqDilation=sicd.Antenna.Rcv.MLFreqDilation,
+                                **kwargs)
+
+@pytest.fixture
+def twoway_ant_param(sicd, kwargs):
+    return Antenna.AntParamType(XAxisPoly=sicd.Antenna.TwoWay.XAxisPoly,
+                                YAxisPoly=sicd.Antenna.TwoWay.YAxisPoly,
+                                FreqZero=sicd.Antenna.TwoWay.FreqZero,
+                                EB=sicd.Antenna.TwoWay.EB,
+                                Array=sicd.Antenna.TwoWay.Array,
+                                Elem=sicd.Antenna.TwoWay.Elem,
+                                GainBSPoly=sicd.Antenna.TwoWay.GainBSPoly,
+                                EBFreqShift=True,
+                                MLFreqDilation=sicd.Antenna.TwoWay.MLFreqDilation,
+                                **kwargs)
+
+def test_antenna_ebtype(kwargs):
+    x_poly = blocks.Poly1DType(Coefs=[10.5, 5.1, 1.2, 0.2])
+    y_poly = blocks.Poly1DType(Coefs=[5.1, 1.2, 0.2])
+
+    antenna_eb = Antenna.EBType(DCXPoly=x_poly, DCYPoly=y_poly)
+    assert antenna_eb.DCXPoly == x_poly
+    assert antenna_eb.DCYPoly == y_poly
+    assert not hasattr(antenna_eb, "_xml_ns")
+    assert not hasattr(antenna_eb, "_xml_ns_key")
+
+    # Init with kwargs
+    antenna_eb = Antenna.EBType(DCXPoly=x_poly, DCYPoly=y_poly, **kwargs)
+    assert antenna_eb._xml_ns == kwargs["_xml_ns"]
+    assert antenna_eb._xml_ns_key == kwargs["_xml_ns_key"]
+
+    assert np.all(antenna_eb(0) == [x_poly.Coefs[0], y_poly.Coefs[0]])
+
+    antenna_eb = Antenna.EBType(DCXPoly=None, DCYPoly=y_poly)
+    assert antenna_eb(0) is None
+
+
+def test_antenna_antparamtype(tx_ant_param, sicd, kwargs):
+    assert tx_ant_param._xml_ns == kwargs["_xml_ns"]
+    assert tx_ant_param._xml_ns_key == kwargs["_xml_ns_key"]
+
+    shift = 100000
+    tx_ant_param._apply_reference_frequency(shift)
+    assert tx_ant_param.FreqZero == sicd.Antenna.Tx.FreqZero + shift
+
+
+def test_antenna_anttype(tx_ant_param, rcv_ant_param, twoway_ant_param, sicd, kwargs):
+    antenna = Antenna.AntennaType(Tx=tx_ant_param, Rcv=rcv_ant_param, TwoWay=twoway_ant_param, **kwargs)
+    assert antenna._xml_ns == kwargs["_xml_ns"]
+    assert antenna._xml_ns_key == kwargs["_xml_ns_key"]
+
+    shift = 100000
+    antenna._apply_reference_frequency(shift)
+    assert antenna.Tx.FreqZero == sicd.Antenna.Tx.FreqZero + shift
+    assert antenna.Rcv.FreqZero == sicd.Antenna.Rcv.FreqZero + shift
+    assert antenna.TwoWay.FreqZero == sicd.Antenna.TwoWay.FreqZero + shift


### PR DESCRIPTION
Add additional unit tests for the `sicd_elements` module, specifically `Antenna.py`

This PR:

1. New tests in `test_sicd_elements_antenna.py`
2. Added a simple TwoWay node to the example xml in `example.sicd.xml`

Details + Before/After coverage report

**_Coverage from main branch:_**

`pytest tests --cov=sarpy.io.complex.sicd_elements.Antenna --cov-report term-missing`

|Name|Stmts|Miss|Cover|Missing|
|----|-----|----|-----|-------|
|sarpy/io/complex/sicd_elements/Antenna.py|73|4|95%|77-79, 245|
|TOTAL|73|4|95%||

**_Coverage from this branch:_**

`pytest tests/io/complex/sicd_elements/test_sicd_elements_antenna.py --cov=sarpy.io.complex.sicd_elements.Antenna --cov-report term-missing`

|Name|Stmts|Miss|Cover|Missing|
|----|-----|----|-----|-------|
|sarpy/io/complex/sicd_elements/Antenna.py|73|0|100%||
|TOTAL|73|0|100%||