### PR TITLE
Unit tests and minor bugfixes for sicd_elements.CollectionInfo

### DIFF
--- a/sarpy/io/complex/sicd_elements/CollectionInfo.py
+++ b/sarpy/io/complex/sicd_elements/CollectionInfo.py
@@ -63,18 +63,12 @@ class RadarModeType(Serializable):
         """
 
         mode = self.ModeType
-        if mode is None:
-            return 'UN'
-        elif mode == 'SPOTLIGHT':
+        if mode == 'SPOTLIGHT':
             return 'SL'
         elif mode == 'STRIPMAP':
             return 'ST'
         elif mode == 'DYNAMIC STRIPMAP':
             return 'DS'
-        elif mode == 'SCANSAR':
-            return 'SS'
-        else:
-            return 'UN'
 
 
 class CollectionInfoType(Serializable):

--- a/tests/io/complex/sicd_elements/test_sicd_elements_collectioninfo.py
+++ b/tests/io/complex/sicd_elements/test_sicd_elements_collectioninfo.py
@@ -1,0 +1,62 @@
+#
+# Copyright 2023 Valkyrie Systems Corporation
+#
+# Licensed under MIT License.  See LICENSE.
+#
+from sarpy.io.complex.sicd_elements import CollectionInfo
+
+
+def test_collectioninfo_radarmodetype(kwargs):
+    radar_mode_type = CollectionInfo.RadarModeType(ModeType="SPOTLIGHT", ModeID="SL")
+    assert radar_mode_type.ModeType == "SPOTLIGHT"
+    assert radar_mode_type.ModeID == "SL"
+    assert not hasattr(radar_mode_type, "_xml_ns")
+    assert not hasattr(radar_mode_type, "_xml_ns_key")
+
+    # Init with kwargs
+    radar_mode_type = CollectionInfo.RadarModeType(
+        ModeType="SPOTLIGHT", ModeID="SL", **kwargs
+    )
+    assert radar_mode_type._xml_ns == kwargs["_xml_ns"]
+    assert radar_mode_type._xml_ns_key == kwargs["_xml_ns_key"]
+
+    radar_mode_type = CollectionInfo.RadarModeType(ModeType="SPOTLIGHT")
+    assert radar_mode_type.get_mode_abbreviation() == "SL"
+    radar_mode_type = CollectionInfo.RadarModeType(ModeType="STRIPMAP")
+    assert radar_mode_type.get_mode_abbreviation() == "ST"
+    radar_mode_type = CollectionInfo.RadarModeType(ModeType="DYNAMIC STRIPMAP")
+    assert radar_mode_type.get_mode_abbreviation() == "DS"
+
+
+def test_collectioninfo_collinfotype(sicd, kwargs):
+    collection_info_type = CollectionInfo.CollectionInfoType(
+        CollectorName=sicd.CollectionInfo.CollectorName,
+        IlluminatorName="FAKE_ILLUMINATOR",
+        CoreName=sicd.CollectionInfo.CoreName,
+        CollectType=sicd.CollectionInfo.CollectType,
+        RadarMode=sicd.CollectionInfo.RadarMode,
+        Classification=sicd.CollectionInfo.Classification,
+        CountryCodes=["FAKE_CC"],
+        Parameters={"FAKE": "PARAMETERS"},
+    )
+    assert collection_info_type.CollectorName == sicd.CollectionInfo.CollectorName
+    assert collection_info_type.IlluminatorName == "FAKE_ILLUMINATOR"
+    assert collection_info_type.CoreName == sicd.CollectionInfo.CoreName
+    assert collection_info_type.CollectType == sicd.CollectionInfo.CollectType
+    assert collection_info_type.RadarMode == sicd.CollectionInfo.RadarMode
+    assert collection_info_type.Classification == sicd.CollectionInfo.Classification
+    assert collection_info_type.CountryCodes == ["FAKE_CC"]
+    assert collection_info_type.Parameters["FAKE"] == "PARAMETERS"
+    assert not hasattr(collection_info_type, "_xml_ns")
+    assert not hasattr(collection_info_type, "_xml_ns_key")
+
+    # Init with kwargs
+    collection_info_type = CollectionInfo.CollectionInfoType(
+        CollectorName=sicd.CollectionInfo.CollectorName,
+        CoreName=sicd.CollectionInfo.CoreName,
+        RadarMode=sicd.CollectionInfo.RadarMode,
+        Classification=sicd.CollectionInfo.Classification,
+        **kwargs
+    )
+    assert collection_info_type._xml_ns == kwargs["_xml_ns"]
+    assert collection_info_type._xml_ns_key == kwargs["_xml_ns_key"]


### PR DESCRIPTION
Add additional unit tests for the `sicd_elements` module, specifically `CollectionInfo.py`

This PR:

1. New tests in `test_sicd_elements_collectioninfo.py`
2. Bugfixes for `CollectionInfo.py`

Details + Before/After coverage report

BUGFIXES:

- The code prevents certain mode types, yet the `get_mode_abbreviation` code checks for impossible `ModeType` values (like `None` or some unknown type).  The `_MODE_TYPE_VALUES` variable defines the allowable types and you cannot instantiate the class without matching one of those.  I removed invalid conditions.
- Also, `SCANSAR` is not a valid `ModeType` for SICD, so I removed it.

**_Coverage from main branch:_**

`pytest tests --cov=sarpy.io.complex.sicd_elements.CollectionInfo --cov-report term-missing`

|Name|Stmts|Miss|Cover|Missing|
|----|-----|----|-----|-------|
|sarpy/io/complex/sicd_elements/CollectionInfo.py|59|7|88%|67, 70-75|
|TOTAL|59|7|88%||

**_Coverage from this branch:_**

`pytest tests/io/complex/sicd_elements/test_sicd_elements_collectioninfo.py --cov=sarpy.io.complex.sicd_elements.CollectionInfo --cov-report term-missing`

|Name|Stmts|Miss|Cover|Missing|
|----|-----|----|-----|-------|
|sarpy/io/complex/sicd_elements/CollectionInfo.py|57|0|100%||
|TOTAL|57|0|100%||