### PR TITLE
Add Unit Tests for sicd_elements.ImageCreation

### DIFF
--- a/tests/io/complex/sicd_elements/test_sicd_elements_imagecreation.py
+++ b/tests/io/complex/sicd_elements/test_sicd_elements_imagecreation.py
@@ -1,0 +1,35 @@
+#
+# Copyright 2023 Valkyrie Systems Corporation
+#
+# Licensed under MIT License.  See LICENSE.
+#
+import numpy as np
+
+from sarpy.io.complex.sicd_elements import ImageCreation
+
+
+def test_imagecreationtype(kwargs):
+    # Smoke test
+    image_creation_type = ImageCreation.ImageCreationType(
+        Application="Fake IFP",
+        DateTime=np.datetime64("2023-06-23"),
+        Site="Fake site",
+        Profile="Fake profile",
+    )
+    assert image_creation_type.Application == "Fake IFP"
+    assert image_creation_type.DateTime == np.datetime64("2023-06-23")
+    assert image_creation_type.Site == "Fake site"
+    assert image_creation_type.Profile == "Fake profile"
+    assert not hasattr(image_creation_type, "_xml_ns")
+    assert not hasattr(image_creation_type, "_xml_ns_key")
+
+    # Init with kwargs
+    image_creation_type = ImageCreation.ImageCreationType(
+        Application="Fake IFP",
+        DateTime=np.datetime64("today"),
+        Site="Fake site",
+        Profile="Fake profile",
+        **kwargs
+    )
+    assert image_creation_type._xml_ns == kwargs["_xml_ns"]
+    assert image_creation_type._xml_ns_key == kwargs["_xml_ns_key"]


### PR DESCRIPTION
Add additional unit tests for the `sicd_elements` module, specifically `ImageCreation.py`

Coverage for this branch does not change.  Since `ImageCreation` is simply a class definition there was already 100% code coverage by happenstance.  This effort simply adds a specific smoke test for this class for completeness.

This PR:

1. New tests in `test_sicd_elements_imagecreation.py`

Details + Before/After coverage report

**_Coverage from main branch:_**

`pytest tests --cov=sarpy.io.complex.sicd_elements.ImageCreation --cov-report term-missing`

|Name|Stmts|Miss|Cover|Missing|
|----|-----|----|-----|-------|
|sarpy/io/complex/sicd_elements/ImageCreation.py|25|0|100%||
|TOTAL|25|0|100%||

**_Coverage from this branch:_**

`pytest tests/io/complex/sicd_elements/test_sicd_elements_imagecreation.py --cov=sarpy.io.complex.sicd_elements.ImageCreation --cov-report term-missing`

|Name|Stmts|Miss|Cover|Missing|
|----|-----|----|-----|-------|
|sarpy/io/complex/sicd_elements/ImageCreation.py|25|0|100%||
|TOTAL|25|0|100%||