### PR TITLE
Added SCANSAR mode for SIDD RadarMode

### DIFF
--- a/sarpy/io/complex/sicd_elements/CollectionInfo.py
+++ b/sarpy/io/complex/sicd_elements/CollectionInfo.py
@@ -71,8 +71,6 @@ class RadarModeType(Serializable):
             return 'ST'
         elif mode == 'DYNAMIC STRIPMAP':
             return 'DS'
-        elif mode == 'SCANSAR':
-            return 'SS'
         else:
             return 'UN'
 

--- a/sarpy/io/product/sidd2_elements/blocks.py
+++ b/sarpy/io/product/sidd2_elements/blocks.py
@@ -313,7 +313,17 @@ class GeoInfoType(GeoInfoTypeBase):
 
 
 class RadarModeType(RadarModeTypeBase):
+    """
+    Radar mode type container class
+    """
+
     _child_xml_ns_key = {'ModeType': 'sicommon', 'ModeID': 'sicommon'}
+    # other class variable
+    _MODE_TYPE_VALUES = RadarModeTypeBase._MODE_TYPE_VALUES + ('SCANSAR',)
+    # descriptors
+    ModeType = StringEnumDescriptor(
+        'ModeType', _MODE_TYPE_VALUES, RadarModeTypeBase._required, strict=True,
+        docstring="The Radar imaging mode.")  # type: str
 
 
 class ReferencePointType(Serializable):

--- a/sarpy/io/product/sidd3_elements/ExploitationFeatures.py
+++ b/sarpy/io/product/sidd3_elements/ExploitationFeatures.py
@@ -21,9 +21,7 @@ from sarpy.geometry.geocoords import ecf_to_geodetic
 
 from .base import DEFAULT_STRICT, FLOAT_FORMAT
 from sarpy.io.product.sidd2_elements.ExploitationFeatures import ExploitationCalculator as BaseExploitationCalculator
-from sarpy.io.product.sidd2_elements.blocks import RowColDoubleType, RangeAzimuthType, \
-    RadarModeType
-from .blocks import AngleZeroToExclusive360MagnitudeType
+from .blocks import AngleZeroToExclusive360MagnitudeType, RadarModeType, RangeAzimuthType, RowColDoubleType
 
 from sarpy.io.product.sidd2_elements.ExploitationFeatures import (
     InputROIType,

--- a/sarpy/io/product/sidd3_elements/blocks.py
+++ b/sarpy/io/product/sidd3_elements/blocks.py
@@ -26,7 +26,10 @@ from sarpy.io.product.sidd2_elements.blocks import (
     PredefinedFilterType,
     PredefinedLookupType,
     Poly2DType,
+    RadarModeType,
+    RangeAzimuthType,
     ReferencePointType,
+    RowColDoubleType,
     XYZPolyType,
     XYZType,
 )
@@ -40,7 +43,10 @@ __REUSED__ = (  # to avoid unused imports
     PredefinedFilterType,
     PredefinedLookupType,
     Poly2DType,
+    RadarModeType,
+    RangeAzimuthType,
     ReferencePointType,
+    RowColDoubleType,
     XYZPolyType,
     XYZType,
 )


### PR DESCRIPTION
SIDD permits a `ModeType` of `SCANSAR`, which isn't a valid option in SICD.  This PR creates a SIDD specific `RadarModeType` class which has `SCANSAR` as an option.