### PR TITLE
SICD sidelobe control and SICD-to-SIDD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,18 @@ release points are not being annotated in GitHub.
 - Introduce `conftest.py`, add unit tests for `cphd1_elements/GeoInfo.py`
 - Added unit test `cphd1_elements/test_cphd_versions.py`
 - Added 1.0.1 CPHD to `test_cphd.py`
+- Added `sarpy/processing/sicd/spectral_taper.py` and `sarpy/utils/sicd_sidelobe_control.py`
+- Added `--remap` argument to `sarpy/utils/create_product.py`
+- Added `sarpy/utils/sicd_to_sidd.py`
+- Added `GDM` to `sarpy/visualization/remap.py`
 ### Fixed
 - Fixed `sarpy.io.kml.add_polygon` coordinate conditioning for older numpy versions
 - Replace unsupported `pillow` constant `Image.ANTIALIAS` with `Image.LANCZOS`
 - Ensure invalid setter inputs for `LineType` and `PolygonType` throw a ValueError in `GeoInfo.py` and typo fix
+- Fixed SquintAngle calculation in `sarpy/io/complex/sicd_elements/SCPCOA.py`
+- Fix incorrectly assigned Graze in SIDD 2.0.0 and SIDD 3.0.0 ExploitationFeatures
+- Fix SIDD `TimeCOAPoly` calculation
+- Set SIDD Display//Interpolation/Operation values to CORRELATION
 
 ## [1.3.58] - 2023-08-07
 ### Added

--- a/docs/processing/sicd/spectral_taper.rst
+++ b/docs/processing/sicd/spectral_taper.rst
@@ -1,0 +1,8 @@
+Spectral Taper methods (sarpy.processing.sicd.spectral_taper)
+=============================================================
+
+.. automodule:: sarpy.processing.sicd.spectral_taper
+    :members:
+    :show-inheritance:
+    :inherited-members:
+

--- a/docs/utils/sicd_sidelobe_control.rst
+++ b/docs/utils/sicd_sidelobe_control.rst
@@ -1,0 +1,7 @@
+Apply/Remove a spectral taper window to/from a SICD (sarpy.utils.sicd_sidelobe_control)
+==================================================================================
+
+.. automodule:: sarpy.utils.sicd_sidelobe_control
+    :members:
+    :show-inheritance:
+    :inherited-members:

--- a/docs/utils/sicd_to_sidd.rst
+++ b/docs/utils/sicd_to_sidd.rst
@@ -1,0 +1,7 @@
+Apply spectral taper to SICD then remap to create a SIDD (sarpy.utils.sicd_to_sidd)
+===================================================================================
+
+.. automodule:: sarpy.utils.sicd_to_sidd
+    :members:
+    :show-inheritance:
+    :inherited-members:

--- a/sarpy/io/complex/sicd_elements/SCPCOA.py
+++ b/sarpy/io/complex/sicd_elements/SCPCOA.py
@@ -120,10 +120,13 @@ class GeometryCalculator(object):
 
     @property
     def SquintAngle(self) -> float:
+        # Note: squint angle is not defined in the SICD DIDD, but it is defined in the SIDD DIDD v2 (7.5.4)
+        #     squint_angle = arccos(-Xs_hat dot Va_hat), where "hat" means unit vector.
+        # In this code, uLOS = -xs_hat, so the minus sign is omitted from the argument of the arccos function.
+        # It is also stated in table 4.2.5 that "Left-look is positive, right-look is negative".
         arp_vel_proj = self._make_unit(self.uARP_vel - self.uARP_vel.dot(self.uARP)*self.uARP)
         los_proj = self._make_unit(self.uLOS - self.uLOS.dot(self.uARP)*self.uARP)
-        return float(numpy.rad2deg(
-            numpy.arctan2(numpy.cross(los_proj, arp_vel_proj).dot(self.uARP), arp_vel_proj.dot(los_proj))))
+        return float(self.look * numpy.rad2deg(numpy.arccos(los_proj.dot(arp_vel_proj))))
 
     @property
     def SlopeAng(self) -> float:

--- a/sarpy/io/general/base.py
+++ b/sarpy/io/general/base.py
@@ -462,6 +462,18 @@ class BaseReader(object):
         # may be unreliable
         self.close()
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exception_type, exception_value, traceback):
+        self.close()
+
+        if exception_type is not None:
+            logger.error(
+                'The {} file writer generated an exception during processing'.format(
+                    self.__class__.__name__))
+            # The exception will be reraised.
+            # It's unclear how any exception could really be caught.
 
 class FlatReader(BaseReader):
     """

--- a/sarpy/io/product/sidd2_elements/ExploitationFeatures.py
+++ b/sarpy/io/product/sidd2_elements/ExploitationFeatures.py
@@ -600,7 +600,7 @@ class ExploitationFeaturesCollectionGeometryType(Serializable):
 
         return cls(Azimuth=calculator.AzimuthAngle,
                    Slope=calculator.SlopeAngle,
-                   Graze=calculator.SlopeAngle,
+                   Graze=calculator.GrazeAngle,
                    Tilt=calculator.TiltAngle,
                    DopplerConeAngle=calculator.DopplerConeAngle,
                    Squint=calculator.SquintAngle)
@@ -889,7 +889,6 @@ class ExploitationFeaturesType(Serializable):
         -------
         ExploitationFeaturesType
         """
-
         if isinstance(sicd, (list, tuple)):
             collections = []
             feats = []

--- a/sarpy/io/product/sidd3_elements/ExploitationFeatures.py
+++ b/sarpy/io/product/sidd3_elements/ExploitationFeatures.py
@@ -462,7 +462,7 @@ class ExploitationFeaturesCollectionGeometryType(Serializable):
 
         return cls(Azimuth=calculator.AzimuthAngle,
                    Slope=calculator.SlopeAngle,
-                   Graze=calculator.SlopeAngle,
+                   Graze=calculator.GrazeAngle,
                    Tilt=calculator.TiltAngle,
                    DopplerConeAngle=calculator.DopplerConeAngle,
                    Squint=calculator.SquintAngle)
@@ -751,7 +751,6 @@ class ExploitationFeaturesType(Serializable):
         -------
         ExploitationFeaturesType
         """
-
         if isinstance(sicd, (list, tuple)):
             collections = []
             feats = []

--- a/sarpy/processing/sicd/spectral_taper.py
+++ b/sarpy/processing/sicd/spectral_taper.py
@@ -1,0 +1,315 @@
+"""
+Remove the existing spectral taper window from a sicd-type, if necessary,
+then apply a new spectral taper window.
+"""
+
+__classification__ = "UNCLASSIFIED"
+__author__ = "Valkyrie Systems Corporation"
+
+import copy
+
+import numpy as np
+import scipy.fft
+import scipy.interpolate as spi
+
+from sarpy.io.complex.sicd_elements.Grid import WgtTypeType
+from sarpy.processing.sicd.normalize_sicd import apply_skew_poly
+import sarpy.processing.sicd.windows as windows
+
+
+class Taper:
+    """
+    This is a helper class that wraps various window function in a common interface.
+
+    Args
+    ----
+    window: str
+        The name of the taper (window) function name.  Acceptable (case insensitive) names are:
+            "uniform": This is a flat spectral taper (i.e., no spectral taper).
+            "hamming": Hamming window taper (0.54 + 0.46 * cos(2*pi*n/M))
+            "hanning" | "hann":  Hann window taper (0.5 + 0.5 * cos(2*pi*n/M))
+            "general_hamming": Raised cosine window (alpha + (1 - alpha) * cos(2*pi*n/M)), default (alpha = 0.5)
+            "kaiser": Kaiser-Bessel window (I0[beta * sqrt(1 - (2*n/M - 1)**2)] / I0[beta]) default (beta = 4)
+            "taylor": Taylor window: Default is a nbar = 4, sll = -30.
+
+    pars: dict | None
+        Optional dictionary of parameter values for those windows that have parameter values.
+        If omitted or None, the default parameters are used.
+        The parameter values for each window are listed above.
+            "uniform": no parameters
+            "hamming": no parameters
+            "hanning" | "hann": no parameters
+            "general_hamming": parameter "alpha"
+                 Raised cosine window, w[n] = (alpha + (1 - alpha) * cos(2*pi*n/M)).
+                 The default value is alpha = 0.5
+            "kaiser": parameter "beta"
+                Kaiser-Bessel window, w[n] = I0[beta * sqrt(1 - (2*n/M - 1)**2)] / I0[beta]
+                The default value is beta = 4.
+            "taylor": parameters "nbar" and "sll"
+                "nbar" = number of near side lobes and "sll" = side lobe level (dB) of near side lobes.
+                The default values are nbar = 4, sll = -30.
+
+    default_size: int
+        Optional taper window size.  This argument is almost never needed (see note below).  (default: 513)
+
+    Note
+    ----
+    This class always creates a symmetric window regardless of whether the window length is odd or even.
+    It is not intended that the internal representation of the window samples be used directly.  Instead,
+    the "get_vals(size, sym)" method should be used.  Accessing the window values this way will give you
+    full control over the size of the window function and whether the window is symmetric.
+
+    """
+    def __init__(self, window='UNIFORM', pars=None, default_size=513):
+        pars = {key.upper(): val for key, val in pars.items()} if pars else {}    # Force upper-case parameter names
+
+        self.default_pars = {"UNIFORM": {},
+                             "HAMMING": {},
+                             "HANNING": {},
+                             "HANN": {},
+                             "GENERAL_HAMMING": {'ALPHA': 0.50},
+                             "KAISER": {'BETA': 4.0},
+                             "TAYLOR": {"NBAR": 4, "SLL": -30.0},
+                             }
+        self.default_size = default_size
+        self.window_type = window.upper()
+        self.window_pars = {**self.default_pars.get(self.window_type, {}), **pars}
+        self.window_vals = self._make_sym_1d_window(self.default_size)
+
+    def _make_sym_1d_window(self, window_size=None):
+        """Make the sample values of a 1-D symmetric window"""
+        window_size = self.default_size if window_size is None else window_size
+
+        if self.window_type == 'UNIFORM':
+            wgts = np.ones(window_size)
+
+        elif self.window_type in ['HAMMING']:
+            wgts = windows.hamming(window_size, sym=True)
+
+        elif self.window_type in ['HANNING', 'HANN']:
+            wgts = windows.hanning(window_size, sym=True)
+
+        elif self.window_type in ['GENERAL_HAMMING']:
+            alpha = float(self.window_pars['ALPHA'])
+            wgts = windows.general_hamming(window_size, alpha=alpha, sym=True)
+
+        elif self.window_type == 'TAYLOR':
+            nbar = int(self.window_pars['NBAR'])
+            sll = float(self.window_pars['SLL'])
+            wgts = windows.taylor(window_size, nbar=nbar, sll=-np.abs(sll), sym=True)
+
+        elif self.window_type == 'KAISER':
+            beta = float(self.window_pars['BETA'])
+            wgts = windows.kaiser(window_size, beta=beta, sym=True)
+
+        else:
+            raise ValueError(f'Window type "{self.window_type}" is not supported.')
+
+        return wgts
+
+    def get_vals(self, size, sym=True):
+        """
+        Get interpolated samples of the prototype window.
+
+        Args
+        ----
+        size: int
+            The number of output samples
+        sym: bool
+            Whether interpolated samples should be symmetric (Default: True)
+
+        Returns
+        -------
+        vals: numpy.ndarray
+            1-D array of sampled taper values.
+        """
+        return _fit_1d_window(self.window_vals, size) if sym else _fit_1d_window(self.window_vals, size+1)[:-1]
+
+
+def apply_spectral_taper(sicd_reader, taper):
+    """
+    Apply a spectral taper window function to SICD image data.
+    If necessary, the existing spectral taper window will be removed prior to applying
+    the new spectral taper window. To remove an existing spectral taper window without
+    applying a new taper, specify a new taper=None.
+
+    Args
+    ----
+    sicd_reader: sarpy.io.complex.sicd.SICDReader
+        A SICD reader object containing both image data and metadata.
+
+    taper: Taper | str | None
+        A Taper object specifying the spectral domain taper function to be applied.
+        Alternative, a string indicating the taper type.  When a string is provided, a Taper
+        object will be created with default parameters for the specified taper type.  Use a
+        Taper object if you need to modify the taper parameters.  For example:
+            apply_spectral_taper(sicd, Taper(window_name, pars=pars_dict))
+
+    Returns
+    -------
+    cdata: numpy.ndarray
+        The sicd image data modified by removing the existing spectral taper window and applying the specified window.
+
+    sicd_mdata: SICDType
+        The modified sicd metadata with updated Grid parameters
+
+    """
+    taper = "UNIFORM" if taper is None else taper
+
+    if isinstance(taper, str):
+        taper = Taper(taper)
+
+    cdata = sicd_reader[:, :]
+    mdata = copy.deepcopy(sicd_reader.sicd_meta)
+
+    cdata = _apply_2d_spectral_taper(cdata, mdata, taper.window_vals)
+
+    # Update the SICD metadata to account for the spectral weighting changes
+    row_inv_osf = mdata.Grid.Row.ImpRespBW * mdata.Grid.Row.SS
+    col_inv_osf = mdata.Grid.Col.ImpRespBW * mdata.Grid.Col.SS
+
+    old_row_wgts = _get_sicd_wgt_funct(mdata, 'Row', len(taper.window_vals))
+    old_col_wgts = _get_sicd_wgt_funct(mdata, 'Col', len(taper.window_vals))
+    old_coh_amp_gain = np.mean(old_row_wgts) * np.mean(old_col_wgts) * row_inv_osf * col_inv_osf
+    old_rms_amp_gain = np.sqrt(np.mean(old_row_wgts**2) * np.mean(old_col_wgts**2) * row_inv_osf * col_inv_osf)
+
+    new_row_wgts = taper.window_vals
+    new_col_wgts = taper.window_vals
+    new_coh_amp_gain = np.mean(new_row_wgts) * np.mean(new_col_wgts) * row_inv_osf * col_inv_osf
+    new_rms_amp_gain = np.sqrt(np.mean(new_row_wgts**2) * np.mean(new_col_wgts**2) * row_inv_osf * col_inv_osf)
+
+    coh_pwr_gain = (new_coh_amp_gain / old_coh_amp_gain) ** 2
+    rms_pwr_gain = (new_rms_amp_gain / old_rms_amp_gain) ** 2
+
+    mdata.Grid.Row.WgtType = WgtTypeType(WindowName=taper.window_type.upper(), Parameters=taper.window_pars)
+    mdata.Grid.Col.WgtType = WgtTypeType(WindowName=taper.window_type.upper(), Parameters=taper.window_pars)
+
+    taper_is_uniform = np.all(taper.window_vals == taper.window_vals[0])
+    mdata.Grid.Row.WgtFunct = None if taper_is_uniform else taper.window_vals
+    mdata.Grid.Col.WgtFunct = None if taper_is_uniform else taper.window_vals
+
+    ipr_half_power_width = windows.find_half_power(taper.window_vals, oversample=16)
+    mdata.Grid.Row.ImpRespWid = ipr_half_power_width / mdata.Grid.Row.ImpRespBW
+    mdata.Grid.Col.ImpRespWid = ipr_half_power_width / mdata.Grid.Col.ImpRespBW
+
+    if mdata.Radiometric:
+        if mdata.Radiometric.NoiseLevel:
+            if mdata.Radiometric.NoiseLevel.NoiseLevelType == "ABSOLUTE":
+                mdata.Radiometric.NoiseLevel.NoisePoly.Coefs *= rms_pwr_gain
+
+        if mdata.Radiometric.RCSSFPoly:
+            mdata.Radiometric.RCSSFPoly.Coefs /= coh_pwr_gain
+
+        if mdata.Radiometric.SigmaZeroSFPoly:
+            mdata.Radiometric.SigmaZeroSFPoly.Coefs /= rms_pwr_gain
+
+        if mdata.Radiometric.BetaZeroSFPoly:
+            mdata.Radiometric.BetaZeroSFPoly.Coefs /= rms_pwr_gain
+
+        if mdata.Radiometric.GammaZeroSFPoly:
+            mdata.Radiometric.GammaZeroSFPoly.Coefs /= rms_pwr_gain
+
+    return cdata, mdata
+
+
+def _apply_2d_spectral_taper(cdata, mdata, window_vals):
+    for axis in ['Row', 'Col']:
+        existing_window = _get_sicd_wgt_funct(mdata, axis, len(window_vals))
+        both_windows = window_vals / np.maximum(existing_window, 0.01 * np.max(existing_window))
+
+        cdata = _apply_1d_spectral_taper(cdata, mdata, axis, both_windows)
+
+    return cdata
+
+
+def _apply_1d_spectral_taper(cdata, mdata, axis, window_vals):
+    axis_index = {'Row': 0, 'Col': 1}[axis]
+    axis_mdata = {'Row': mdata.Grid.Row, 'Col': mdata.Grid.Col}[axis]
+
+    xrow = (np.arange(0, mdata.ImageData.NumRows) - mdata.ImageData.SCPPixel.Row) * mdata.Grid.Row.SS
+    ycol = (np.arange(0, mdata.ImageData.NumCols) - mdata.ImageData.SCPPixel.Col) * mdata.Grid.Col.SS
+
+    delta_k_coa_poly = np.array([[0.0]]) if axis_mdata.DeltaKCOAPoly is None else axis_mdata.DeltaKCOAPoly.Coefs
+
+    if not np.all(delta_k_coa_poly == 0):
+        cdata = apply_skew_poly(cdata, delta_k_coa_poly, row_array=xrow, col_array=ycol,
+                                fft_sgn=axis_mdata.Sgn, dimension=axis_index, forward=False)
+
+    cdata = _fft_window_ifft(cdata, mdata, axis, window_vals)
+
+    if not np.all(delta_k_coa_poly == 0):
+        cdata = apply_skew_poly(cdata, delta_k_coa_poly, row_array=xrow, col_array=ycol,
+                                fft_sgn=axis_mdata.Sgn, dimension=axis_index, forward=True)
+    return cdata
+
+
+def _get_sicd_wgt_funct(mdata, axis, desired_size=513):
+    axis_mdata = {'Row': mdata.Grid.Row, 'Col': mdata.Grid.Col}[axis]
+
+    if axis_mdata.WgtFunct is not None:
+        # Get the SICD WgtFunct values and interpolate as needed to produce a window of the desired size.
+        wgts = _fit_1d_window(axis_mdata.WgtFunct, desired_size=desired_size)
+
+    else:
+        # The SICD WgtFunct values do not exist, so if WindowName is not specified,
+        # or the WindowName is "UNIFORM", then return a window of all ones.
+        # If WindowName is specified as other than "UNIFORM" then we can not presume to
+        # know what the WindowName means because it is not clearly defined in the SICD spec.
+        window_name = axis_mdata.WgtType.WindowName if axis_mdata.WgtType else "UNIFORM"
+
+        if window_name.upper() == 'UNIFORM':
+            wgts = np.ones(desired_size)
+        else:
+            raise ValueError(f'SICD/Grid/{axis}/WgtFunct is not part of the SICD metadata, but there appears '
+                             f'to be a window of type "{window_name}" applied to the {axis} axis spectrum.')
+
+    return wgts
+
+
+def _fit_1d_window(window_vals, desired_size):
+    if len(window_vals) == desired_size:
+        w = window_vals
+    else:
+        x = np.linspace(0, 1, len(window_vals))
+        f = spi.interp1d(x, window_vals, kind='cubic')
+        w = f(np.linspace(0, 1, desired_size))
+    return w
+
+
+def _fft_window_ifft(cdata, mdata, axis, window_vals):
+    axis_index = {'Row': 0, 'Col': 1}[axis]
+    axis_mdata = {'Row': mdata.Grid.Row, 'Col': mdata.Grid.Col}[axis]
+    nyquist_bw = 1.0 / axis_mdata.SS
+    ipr_bw = axis_mdata.ImpRespBW
+    osf = nyquist_bw / ipr_bw
+
+    # Zero pad the image data to avoid IPR wrap-around, then
+    # find a good FFT size which creates some additional zero pad.
+    axis_size = cdata.shape[axis_index]
+    wrap_around_pad = int(min(200 * osf, 0.1 * axis_size))
+    good_fft_size = scipy.fft.next_fast_len(axis_size + wrap_around_pad)
+
+    # Forward transform without FFTSHIFT so the DC bin is at index=0
+    if axis_mdata.Sgn == -1:
+        cdata_fft = scipy.fft.fft(cdata, n=good_fft_size, axis=axis_index)
+    else:
+        cdata_fft = scipy.fft.ifft(cdata, n=good_fft_size, axis=axis_index)
+
+    # Interpolate the taper to cover the spectral support bandwidth and extend the
+    # taper window's end points into the over sample region of the spectrum.
+    f = spi.interp1d(np.linspace(-ipr_bw / 2, ipr_bw / 2, len(window_vals)), window_vals, kind='cubic',
+                     bounds_error=False, fill_value=(window_vals[0], window_vals[-1]))
+    padded_taper = f(scipy.fft.fftfreq(good_fft_size, axis_mdata.SS))
+
+    # Apply the taper to the spectrum.
+    taper_2d = padded_taper[:, np.newaxis] if axis == 'Row' else padded_taper[np.newaxis, :]
+    cdata_fft *= taper_2d
+
+    # Inverse transform without FFTSHIFT and trim back to the original image size.
+    nrows, ncols = cdata.shape
+    if axis_mdata.Sgn == -1:
+        cdata = scipy.fft.ifft(cdata_fft, n=good_fft_size, axis=axis_index)[:nrows, :ncols]
+    else:
+        cdata = scipy.fft.fft(cdata_fft, n=good_fft_size, axis=axis_index)[:nrows, :ncols]
+
+    return cdata

--- a/sarpy/processing/sidd/sidd_structure_creation.py
+++ b/sarpy/processing/sidd/sidd_structure_creation.py
@@ -97,12 +97,10 @@ def _fit_timecoa_poly(proj_helper, bounds):
         pixel_grid[:, :, 1], proj_helper.sicd.Grid, proj_helper.sicd.ImageData, 'col')
     # evaluate the sicd timecoapoly
     timecoa_values = proj_helper.sicd.Grid.TimeCOAPoly(pixel_rows_m, pixel_cols_m)
-    # fit this at the ortho_grid coordinates
     sidd_timecoa_coeffs, residuals, rank, sing_values = two_dim_poly_fit(
-        ortho_grid[:, :, 0] - bounds[0],
-        ortho_grid[:, :, 1] - bounds[2], timecoa_values,
+        pixel_rows_m, pixel_cols_m, timecoa_values,
         x_order=use_order, y_order=use_order, x_scale=1e-3, y_scale=1e-3, rcond=1e-40)
-    logger.warning(
+    logger.info(
         'The time_coa_fit details:\n\t'
         'root mean square residuals = {}\n\t'
         'rank = {}\n\t'
@@ -172,10 +170,9 @@ def _fit_timecoa_poly_v3(proj_helper, bounds):
     timecoa_values = proj_helper.sicd.Grid.TimeCOAPoly(pixel_rows_m, pixel_cols_m)
     # fit this at the ortho_grid coordinates
     sidd_timecoa_coeffs, residuals, rank, sing_values = two_dim_poly_fit(
-        ortho_grid[:, :, 0] - bounds[0],
-        ortho_grid[:, :, 1] - bounds[2], timecoa_values,
+        pixel_rows_m, pixel_cols_m, timecoa_values,
         x_order=use_order, y_order=use_order, x_scale=1e-3, y_scale=1e-3, rcond=1e-40)
-    logger.warning(
+    logger.info(
         'The time_coa_fit details:\n\t'
         'root mean square residuals = {}\n\t'
         'rank = {}\n\t'
@@ -553,6 +550,6 @@ def create_sidd_structure(ortho_helper, bounds, product_class, pixel_type, versi
     if version == 1:
         return create_sidd_structure_v1(ortho_helper, bounds, product_class, pixel_type)
     elif version == 2:
-        return create_sidd_structure_v2(ortho_helper, bounds, product_class, pixel_type)    
+        return create_sidd_structure_v2(ortho_helper, bounds, product_class, pixel_type)
     else:
         return create_sidd_structure_v3(ortho_helper, bounds, product_class, pixel_type)

--- a/sarpy/processing/sidd/sidd_structure_creation.py
+++ b/sarpy/processing/sidd/sidd_structure_creation.py
@@ -264,7 +264,7 @@ def create_sidd_structure_v3(ortho_helper, bounds, product_class, pixel_type):
                             FilterName='Interpolation',
                             FilterBank=FilterBankType3(
                                 Predefined=PredefinedFilterType3(DatabaseName='BILINEAR')),
-                            Operation='CONVOLUTION')),
+                            Operation='CORRELATION')),
                     Orientation=OrientationType3(ShadowDirection='ARBITRARY')),
                 SharpnessEnhancement=SharpnessEnhancementType3(
                     ModularTransferFunctionEnhancement=FilterType3(
@@ -381,7 +381,7 @@ def create_sidd_structure_v2(ortho_helper, bounds, product_class, pixel_type):
                             FilterName='Interpolation',
                             FilterBank=FilterBankType(
                                 Predefined=PredefinedFilterType(DatabaseName='BILINEAR')),
-                            Operation='CONVOLUTION')),
+                            Operation='CORRELATION')),
                     Orientation=OrientationType2(ShadowDirection='ARBITRARY')),
                 SharpnessEnhancement=SharpnessEnhancementType2(
                     ModularTransferFunctionEnhancement=FilterType(

--- a/sarpy/utils/create_product.py
+++ b/sarpy/utils/create_product.py
@@ -18,6 +18,7 @@ from sarpy.io.complex.converter import open_complex
 from sarpy.processing.ortho_rectify import BivariateSplineMethod, NearestNeighborMethod
 from sarpy.processing.sidd.sidd_product_creation import create_detected_image_sidd, \
     create_csi_sidd, create_dynamic_image_sidd
+import sarpy.visualization.remap as remap
 
 
 def _parse_method(method):
@@ -27,7 +28,9 @@ def _parse_method(method):
         return 'nearest'
 
 
-if __name__ == '__main__':
+def main(args=None):
+    remap_names = [r[0] for r in remap.get_remap_list()]
+
     parser = argparse.ArgumentParser(
         description="Create derived product is SIDD format from a SICD type file.",
         formatter_class=argparse.RawTextHelpFormatter)
@@ -49,17 +52,20 @@ if __name__ == '__main__':
         '-t', '--type', default='detected', choices=['detected', 'csi', 'dynamic'],
         help="The type of derived product.")
     parser.add_argument(
+        '-r', '--remap', default=remap_names[0], choices=remap_names,
+        help="The pixel value remap function. (default: %(default)s)")
+    parser.add_argument(
         '-m', '--method', default='nearest', choices=['nearest', ]+['spline_{}'.format(i) for i in range(1, 6)],
         help="The interpolation method.")
     parser.add_argument(
-        '--version', default=2, type=int, choices=[1, 2],
+        '--version', default=2, type=int, choices=[1, 2, 3],
         help="The version of the SIDD standard used.")
     parser.add_argument(
         '-v', '--verbose', action='store_true', help='Verbose (level="INFO") logging?')
     parser.add_argument(
         '-s', '--sicd', action='store_true', help='Include the SICD structure in the SIDD?')
 
-    args = parser.parse_args()
+    args = parser.parse_args(args)
 
     level = 'INFO' if args.verbose else 'WARNING'
     logging.basicConfig(level=level)
@@ -74,10 +80,20 @@ if __name__ == '__main__':
         else:
             ortho_helper = NearestNeighborMethod(reader, index=i)
         if args.type == 'detected':
-            create_detected_image_sidd(ortho_helper, args.output_directory, version=args.version, include_sicd=args.sicd)
+            create_detected_image_sidd(ortho_helper, args.output_directory,
+                                       remap_function=remap.get_registered_remap(args.remap),
+                                       version=args.version, include_sicd=args.sicd)
         elif args.type == 'csi':
-            create_csi_sidd(ortho_helper, args.output_directory, version=args.version, include_sicd=args.sicd)
+            create_csi_sidd(ortho_helper, args.output_directory,
+                            remap_function=remap.get_registered_remap(args.remap),
+                            version=args.version, include_sicd=args.sicd)
         elif args.type == 'dynamic':
-            create_dynamic_image_sidd(ortho_helper, args.output_directory, version=args.version, include_sicd=args.sicd)
+            create_dynamic_image_sidd(ortho_helper, args.output_directory,
+                                      remap_function=remap.get_registered_remap(args.remap),
+                                      version=args.version, include_sicd=args.sicd)
         else:
             raise ValueError('Got unhandled type {}'.format(args.type))
+
+
+if __name__ == '__main__':
+    main()

--- a/sarpy/utils/create_product.py
+++ b/sarpy/utils/create_product.py
@@ -29,8 +29,6 @@ def _parse_method(method):
 
 
 def main(args=None):
-    remap_names = [r[0] for r in remap.get_remap_list()]
-
     parser = argparse.ArgumentParser(
         description="Create derived product is SIDD format from a SICD type file.",
         formatter_class=argparse.RawTextHelpFormatter)
@@ -52,7 +50,7 @@ def main(args=None):
         '-t', '--type', default='detected', choices=['detected', 'csi', 'dynamic'],
         help="The type of derived product.")
     parser.add_argument(
-        '-r', '--remap', default=remap_names[0], choices=remap_names,
+        '-r', '--remap', default=remap.get_remap_names()[0], choices=remap.get_remap_names(),
         help="The pixel value remap function. (default: %(default)s)")
     parser.add_argument(
         '-m', '--method', default='nearest', choices=['nearest', ]+['spline_{}'.format(i) for i in range(1, 6)],
@@ -74,6 +72,7 @@ def main(args=None):
 
     reader = open_complex(args.input_file)
     degree = _parse_method(args.method)
+
     for i, sicd in enumerate(reader.get_sicds_as_tuple()):
         if isinstance(degree, int):
             ortho_helper = BivariateSplineMethod(reader, index=i, row_order=degree, col_order=degree)

--- a/sarpy/utils/sicd_sidelobe_control.py
+++ b/sarpy/utils/sicd_sidelobe_control.py
@@ -1,0 +1,94 @@
+"""
+Apply or remove an impulse response side lobe control window function.
+
+For a basic help on the command-line, check
+
+>>> python -m sarpy.utils.sicd_sidelobe_control --help
+
+"""
+
+__classification__ = "UNCLASSIFIED"
+__author__ = "Valkyrie Systems Corporation"
+
+import argparse
+import logging
+
+import numpy as np
+
+from sarpy.io.complex.sicd import SICDReader, SICDWriter, validate_sicd_for_writing
+from sarpy.processing.sicd.spectral_taper import Taper, apply_spectral_taper
+
+
+def main(args=None):
+    parser = argparse.ArgumentParser(
+        description="Remove and/or apply a sidelobe control spectral taper window to a SICD file.",
+        formatter_class=argparse.RawTextHelpFormatter)
+    parser.add_argument(
+        'input_file', metavar='input_file', help='Path to the input data SICD file.')
+    parser.add_argument(
+        'output_file', metavar='output_file', help='Path to the output SICD file.\n')
+    window_args_parser(parser)
+    parser.add_argument(
+        '-v', '--verbose', action='store_true', help='Verbose (level="INFO") logging?')
+
+    args = parser.parse_args(args)
+
+    window = 'UNIFORM' if args.window is None else args.window.upper()
+    default_pars = Taper().default_pars
+
+    # Convert the list of par values into a dict of pars {name: value}.
+    pars = {p: args.pars[n] for n, p in enumerate(default_pars.get(window, {}))}
+
+    level = 'INFO' if args.verbose else 'WARNING'
+    logging.basicConfig(level=level)
+    logger = logging.getLogger('sarpy')
+    logger.setLevel(level)
+
+    reader = SICDReader(args.input_file)
+
+    taper = Taper(window, pars)
+
+    cdata, mdata = apply_spectral_taper(reader, taper)
+
+    # Write the results to a new SICD file.
+    writer = SICDWriter(
+        file_object=args.output_file,
+        sicd_meta=validate_sicd_for_writing(mdata),
+        check_existence=False
+    )
+    writer.write(cdata.astype(np.complex64))
+    writer.close()
+
+
+def window_args_parser(parser):
+    def pars_text(pars):
+        prefix = 'takes 1 parameter: ' if len(pars) == 1 else f'takes {len(pars)} parameters: '
+        return prefix + ', '.join([f'"{p.lower()}"' for p in pars.keys()])
+
+    window_name_choices = [w.lower() for w in Taper().default_pars.keys()]
+    window_pars_choices = [f'  "{w.lower()}": {pars_text(p)}' for w, p in Taper().default_pars.items() if p]
+    parser.add_argument(
+        '-w', '--window', type=str.lower, choices=window_name_choices,
+        help='The name of the window function.  Acceptable (case insensitive) names are:\n'
+             '  "uniform": This is a flat spectral taper (i.e., no spectral taper).\n'
+             '  "hamming": Hamming window taper (0.54 + 0.46 * cos(2*pi*n/M))\n'
+             '  "hanning" | "hann":  Hann window taper (0.5 + 0.5 * cos(2*pi*n/M))\n'
+             '  "general_hamming": Raised cosine window (alpha + (1 - alpha) * cos(2*pi*n/M)), default (alpha = 0.5)\n'
+             '  "kaiser": Kaiser-Bessel window (I0[beta * sqrt(1 - (2*n/M - 1)**2)] / I0[beta]) default (beta = 14)\n'
+             '  "taylor": Taylor window: Default (nbar = 4, sll = -30)\n'
+    )
+    parser.add_argument(
+        '-p', '--pars', nargs='+',
+        help=("One or more parameter values to modify the window characteristics.\n" +
+              '\n'.join(window_pars_choices +
+                        ["For example:",
+                         "  --window general_hamming --pars 0.6",
+                         "  --window taylor          --pars 5 -35.0",
+                         "  --window kaiser          --pars 15"]
+                        )
+              )
+    )
+
+
+if __name__ == '__main__':
+    main()    # pragma: no cover

--- a/sarpy/utils/sicd_to_sidd.py
+++ b/sarpy/utils/sicd_to_sidd.py
@@ -11,6 +11,8 @@ __classification__ = "UNCLASSIFIED"
 __author__ = "Valkyrie Systems Corporation"
 
 import argparse
+import contextlib
+import copy
 import logging
 import pathlib
 import tempfile
@@ -19,8 +21,16 @@ import numpy as np
 
 from sarpy.io.complex.sicd import SICDReader
 from sarpy.utils import sicd_sidelobe_control, create_product
-from sarpy.processing.sicd.spectral_taper import Taper
-import sarpy.visualization.remap as remap
+from sarpy.visualization import remap
+
+
+@contextlib.contextmanager
+def temporary_remap_registry():
+    current_registry = copy.deepcopy(remap._REMAP_DICT)
+    try:
+        yield
+    finally:
+        remap._REMAP_DICT = current_registry
 
 
 def main(args=None):
@@ -56,7 +66,7 @@ def main(args=None):
     logger = logging.getLogger('sarpy')
     logger.setLevel(level)
 
-    with tempfile.TemporaryDirectory() as tempdir:
+    with tempfile.TemporaryDirectory() as tempdir, temporary_remap_registry():
         tempdir_path = pathlib.Path(tempdir)
 
         input_sicd = args.input_file

--- a/sarpy/utils/sicd_to_sidd.py
+++ b/sarpy/utils/sicd_to_sidd.py
@@ -94,8 +94,8 @@ def main(args=None):
                 graze_deg = reader.sicd_meta.SCPCOA.GrazeAng
                 slope_deg = reader.sicd_meta.SCPCOA.SlopeAng
 
-                # If there is any non-uniform spectral weighting then GDM will choose parameters as if
-                # Taylor weighting was applied, instead of choosing the parameters for Uniform weighting.
+                # If there is non-uniform spectral weighting then GDM will choose parameters as if Taylor
+                # weighting was applied, otherwise it will choose the parameters for Uniform weighting.
                 if args.window is None:
                     row_wgt = [1] if reader.sicd_meta.Grid.Row.WgtFunct is None else reader.sicd_meta.Grid.Row.WgtFunct
                     col_wgt = [1] if reader.sicd_meta.Grid.Col.WgtFunct is None else reader.sicd_meta.Grid.Col.WgtFunct

--- a/sarpy/utils/sicd_to_sidd.py
+++ b/sarpy/utils/sicd_to_sidd.py
@@ -15,14 +15,15 @@ import logging
 import pathlib
 import tempfile
 
+import numpy as np
+
+from sarpy.io.complex.sicd import SICDReader
 from sarpy.utils import sicd_sidelobe_control, create_product
 from sarpy.processing.sicd.spectral_taper import Taper
 import sarpy.visualization.remap as remap
 
 
 def main(args=None):
-    remap_names = [r[0] for r in remap.get_remap_list()]
-
     parser = argparse.ArgumentParser(
         description="Create derived product in SIDD format from a SICD type file.",
         formatter_class=argparse.RawTextHelpFormatter)
@@ -38,7 +39,7 @@ def main(args=None):
         help="The projection interpolation method. (default: %(default)s)")
     sicd_sidelobe_control.window_args_parser(parser)
     parser.add_argument(
-        '-r', '--remap', default=remap_names[0], choices=remap_names,
+        '-r', '--remap', default='gdm', choices=['gdm', ] + remap.get_remap_names(),
         help="The pixel value remap function. (default: %(default)s)")
     parser.add_argument(
         '--version', default=3, type=int, choices=[1, 2, 3],
@@ -69,6 +70,56 @@ def main(args=None):
                 sicd_window_args += ['--pars'] + args.pars
             sicd_sidelobe_control.main(sicd_window_args)
             input_sicd = windowed_sicd
+
+        # Register new remap functions that use the global statistics of the SICD.
+        with SICDReader(input_sicd) as reader:
+            amp = np.abs(reader[:, :])
+
+            if args.remap == 'density':
+                remap.register_remap(remap.Density(override_name='density', bit_depth=8, max_output_value=255,
+                                                   data_mean=float(np.mean(amp))), overwrite=True)
+            elif args.remap == 'high_contrast':
+                remap.register_remap(remap.High_Contrast(override_name='high_contrast', bit_depth=8, max_output_value=255,
+                                                         data_mean=float(np.mean(amp))), overwrite=True)
+            elif args.remap == 'brighter':
+                remap.register_remap(remap.Brighter(override_name='brighter', bit_depth=8, max_output_value=255,
+                                                    data_mean=float(np.mean(amp))), overwrite=True)
+            elif args.remap == 'darker':
+                remap.register_remap(remap.Darker(override_name='darker', bit_depth=8, max_output_value=255,
+                                                  data_mean=float(np.mean(amp))), overwrite=True)
+            elif args.remap == 'pedf':
+                remap.register_remap(remap.PEDF(override_name='darker', bit_depth=8, max_output_value=255,
+                                                data_mean=float(np.mean(amp))), overwrite=True)
+            elif args.remap == 'gdm':
+                graze_deg = reader.sicd_meta.SCPCOA.GrazeAng
+                slope_deg = reader.sicd_meta.SCPCOA.SlopeAng
+
+                # If there is any non-uniform spectral weighting then GDM will choose parameters as if
+                # Taylor weighting was applied, instead of choosing the parameters for Uniform weighting.
+                if args.window is None:
+                    row_wgt = [1] if reader.sicd_meta.Grid.Row.WgtFunct is None else reader.sicd_meta.Grid.Row.WgtFunct
+                    col_wgt = [1] if reader.sicd_meta.Grid.Col.WgtFunct is None else reader.sicd_meta.Grid.Col.WgtFunct
+                    is_uniform = np.allclose(row_wgt, row_wgt[0]) and np.allclose(col_wgt, col_wgt[0])
+                    weighting = 'UNIFORM' if is_uniform else 'TAYLOR'
+                else:
+                    weighting = args.window
+
+                remap.register_remap(remap.GDM(override_name='gdm', bit_depth=8, max_output_value=255,
+                                               weighting=weighting, graze_deg=graze_deg, slope_deg=slope_deg,
+                                               data_mean=float(np.mean(amp)), data_median=float(np.median(amp))),
+                                     overwrite=True)
+            elif args.remap == 'linear':
+                remap.register_remap(remap.Linear(override_name='linear', bit_depth=8, max_output_value=255,
+                                                  min_value=float(np.min(amp)),  max_value=float(np.max(amp))),
+                                     overwrite=True)
+            elif args.remap == 'log':
+                remap.register_remap(remap.Logarithmic(override_name='log', bit_depth=8, max_output_value=255,
+                                                       min_value=float(np.min(amp)),  max_value=float(np.max(amp))),
+                                     overwrite=True)
+            else:
+                logger.warning(f'Remap function "{args.remap}" might not be using global statistics.')
+
+            del amp
 
         # Convert the SICD to the specified SIDD product
         sidd_product_args = [input_sicd, output_sidd_dir, '--type', args.type,

--- a/sarpy/utils/sicd_to_sidd.py
+++ b/sarpy/utils/sicd_to_sidd.py
@@ -1,0 +1,83 @@
+"""
+Create products based on SICD type reader.
+
+For a basic help on the command-line, check
+
+>>> python -m sarpy.utils.sicd_to_sidd --help
+
+"""
+
+__classification__ = "UNCLASSIFIED"
+__author__ = "Valkyrie Systems Corporation"
+
+import argparse
+import logging
+import pathlib
+import tempfile
+
+from sarpy.utils import sicd_sidelobe_control, create_product
+from sarpy.processing.sicd.spectral_taper import Taper
+import sarpy.visualization.remap as remap
+
+
+def main(args=None):
+    remap_names = [r[0] for r in remap.get_remap_list()]
+
+    parser = argparse.ArgumentParser(
+        description="Create derived product in SIDD format from a SICD type file.",
+        formatter_class=argparse.RawTextHelpFormatter)
+    parser.add_argument(
+        'input_file', metavar='input_file', help='Input SICD file')
+    parser.add_argument(
+        'output_directory', metavar='output_directory', help='SIDD Output directory')
+    parser.add_argument(
+        '-t', '--type', default='detected', choices=['detected', 'csi', 'dynamic'],
+        help="The type of derived product. (default: %(default)s)")
+    parser.add_argument(
+        '-m', '--method', default='nearest', choices=['nearest', ]+['spline_{}'.format(i) for i in range(1, 6)],
+        help="The projection interpolation method. (default: %(default)s)")
+    sicd_sidelobe_control.window_args_parser(parser)
+    parser.add_argument(
+        '-r', '--remap', default=remap_names[0], choices=remap_names,
+        help="The pixel value remap function. (default: %(default)s)")
+    parser.add_argument(
+        '--version', default=3, type=int, choices=[1, 2, 3],
+        help="The version of the SIDD standard used. (default: %(default)d)")
+    parser.add_argument(
+        '-v', '--verbose', action='store_true', help='Verbose (level="INFO") logging?')
+    parser.add_argument(
+        '-s', '--sicd', action='store_true', help='Include the SICD structure in the SIDD?')
+
+    args = parser.parse_args(args)
+
+    level = 'INFO' if args.verbose else 'WARNING'
+    logging.basicConfig(level=level)
+    logger = logging.getLogger('sarpy')
+    logger.setLevel(level)
+
+    with tempfile.TemporaryDirectory() as tempdir:
+        tempdir_path = pathlib.Path(tempdir)
+
+        input_sicd = args.input_file
+        output_sidd_dir = args.output_directory
+
+        # Apply a spectral taper window to the SICD, if necessary
+        if args.window is not None:
+            windowed_sicd = str(tempdir_path / 'windowed_sicd.nitf')
+            sicd_window_args = [input_sicd, windowed_sicd, '--window', args.window]
+            if args.pars:
+                sicd_window_args += ['--pars'] + args.pars
+            sicd_sidelobe_control.main(sicd_window_args)
+            input_sicd = windowed_sicd
+
+        # Convert the SICD to the specified SIDD product
+        sidd_product_args = [input_sicd, output_sidd_dir, '--type', args.type,
+                             '--remap', args.remap, '--method', args.method, '--version', str(args.version)]
+        sidd_product_args += ['--verbose'] if args.verbose else []
+        sidd_product_args += ['--sicd'] if args.sicd else []
+
+        create_product.main(sidd_product_args)
+
+
+if __name__ == '__main__':
+    main()    # pragma: no cover

--- a/sarpy/visualization/remap.py
+++ b/sarpy/visualization/remap.py
@@ -718,6 +718,195 @@ class High_Contrast(Density):
             data_mean=data_mean)
 
 
+class GDM(MonochromaticRemap):
+    """
+    The Density remap using image specific parameters
+    """
+
+    __slots__ = ('_override_name', '_bit_depth', '_dimension', '_weighting', '_graze_rad', '_slope_rad',
+                 '_data_mean', '_data_median')
+    _name = 'gdm'
+
+    def __init__(
+            self,
+            override_name: Optional[str] = None,
+            bit_depth: int = 8,
+            max_output_value: Optional[int] = None,
+            weighting: Optional[str] = 'UNIFORM',
+            graze_deg: Union[None, int, float] = None,
+            slope_deg: Union[None, int, float] = None,
+            data_mean: Union[None, int, float] = None,
+            data_median: Union[None, int, float] = None
+    ):
+        """
+
+        Parameters
+        ----------
+        override_name : None|str
+            Override name for a specific class instance
+        bit_depth : int
+            Number of bits in unsigned integer output (default: 8)
+        max_output_value: int
+            Maximum output value [0, 2**bit_depth]
+        weighting : str
+            The spectral taper weighting ('taylor' | 'uniform') (default: 'uniform')
+        graze_deg: None|float|int
+            Required Graze angle (degrees)
+        slope_deg: None|float|int
+            Required Slope angle (degrees)
+        data_mean : None|float|int
+            The global data mean (for continuity). The appropriate value will be
+            calculated on a per calling array basis if not provided.
+        data_median : None|float|int
+            The global data median (for continuity). The appropriate value will be
+            calculated on a per calling array basis if not provided.
+        """
+
+        MonochromaticRemap.__init__(
+            self, override_name=override_name, bit_depth=bit_depth, max_output_value=max_output_value)
+
+        if graze_deg is None or slope_deg is None:
+            raise ValueError("The Graze and Slope angles are required parameters of GDM remap.")
+
+        self._data_mean = data_mean
+        self._data_median = data_median
+        self._weighting = weighting.lower()
+        self._graze_rad = numpy.radians(graze_deg)
+        self._slope_rad = numpy.radians(slope_deg)
+
+    @property
+    def data_mean(self) -> Optional[float]:
+        """
+        None|float: The data mean for global use.
+        """
+        return self._data_mean
+
+    @data_mean.setter
+    def data_mean(self, value: Optional[float]):
+        if value is None:
+            self._data_mean = None
+            return
+
+        self._data_mean = float(value)
+
+    @property
+    def data_median(self) -> Optional[float]:
+        """
+        None|float: The data median for global use.
+        """
+        return self._data_median
+
+    @data_mean.setter
+    def data_median(self, value: Optional[float]):
+        self._data_median = None if value is None else float(value)
+
+    def _cutoff_values(self, data_mean, data_median):
+        # This is a subset of the GDM remap algorithm defined in the AGI Algorithm Description Document.
+        # Only those parts of the algorithm relevant to existing SarPy capabilities are included here.
+        # If a weighting name other than 'uniform' is specified, 'taylor' parameters will be chosen.
+        c3 = {'taylor': 1.33, 'uniform': 1.23}.get(self._weighting, 1.33)
+        w1 = {'taylor': 0.77, 'uniform': 0.77}.get(self._weighting, 0.77)
+        w2 = -0.0422
+        w5 = -1.95
+        a1 = data_median
+        a2 = numpy.sin(self._graze_rad) / numpy.cos(self._slope_rad)
+        a5 = numpy.log10(data_median / data_mean)
+        cl_init = a1 * w1
+        ch_init = a1 * 10**(c3 + w2*a2 + w5*a5)
+        r_min = 24
+        r_max = 40
+        r = 20*numpy.log10(ch_init / cl_init)
+        if r < r_min:
+            beta = 10**((r - r_min) / 40.0)         # pragma: nocover
+        elif r > r_max:
+            beta = 10**((r - r_max) / 40.0)         # pragma: nocover
+        else:
+            beta = 1.0
+        cl = cl_init * beta
+        ch = ch_init / beta
+
+        return cl, ch
+
+    def raw_call(
+            self,
+            data: numpy.ndarray,
+            data_mean: Optional[float] = None,
+            data_median: Optional[float] = None) -> numpy.ndarray:
+        """
+        This performs the mapping from input data to output floating point
+        version, this is directly used by the :func:`call` method.
+
+        Parameters
+        ----------
+        data : numpy.ndarray
+            The (presumably) complex data to remap.
+        data_mean : None|float
+            The pre-calculated data mean, for consistent global use. The order
+            of preference is the value provided here, the class data_mean property
+            value, then the value calculated from the present sample.
+        data_median : None|float
+            The pre-calculated data median, for consistent global use. The order
+            of preference is the value provided here, the class data_median property
+            value, then the value calculated from the present sample.
+
+        Returns
+        -------
+        numpy.ndarray
+        """
+        amplitude = numpy.abs(data)
+
+        data_mean = float(data_mean) if data_mean is not None else self._data_mean
+        if data_mean is None:
+            # Warning: this is likely to be a local mean value rather than the global mean value.
+            data_mean = numpy.mean(amplitude[numpy.isfinite(amplitude)])
+
+        data_median = float(data_median) if data_median is not None else self._data_median
+        if data_median is None:
+            # Warning: this is likely to be a local median value rather than the global median value.
+            data_median = numpy.median(amplitude[numpy.isfinite(amplitude)])
+
+        c_l, c_h = self._cutoff_values(data_mean, data_median)
+
+        multiplier = float(self.max_output_value)/255.0
+        return multiplier*amplitude_to_density(data, dmin=30, mmult=c_h / c_l, data_mean=c_l / 0.8)
+
+    def call(
+            self,
+            data: numpy.ndarray,
+            data_mean: Optional[float] = None,
+            data_median: Optional[float] = None) -> numpy.ndarray:
+        """
+        This performs the mapping from input data to output discrete version.
+
+        This method is directly called by the :func:`__call__` method, so the
+        class instance (once constructed) is itself callable, as follows:
+
+        >>> remap = GDM(weighting, graze_deg, slope_deg)
+        >>> discrete_data = remap(data, data_mean, data_median)
+
+        Parameters
+        ----------
+        data : numpy.ndarray
+            The (presumably) complex data to remap.
+        data_mean : None|float
+            The pre-calculated data mean, for consistent global use. The order
+            of preference is the value provided here, the class data_mean property
+            value, then the value calculated from the present sample.
+        data_median : None|float
+            The pre-calculated data median, for consistent global use. The order
+            of preference is the value provided here, the class data_median property
+            value, then the value calculated from the present sample.
+
+        Returns
+        -------
+        numpy.ndarray
+        """
+
+        return clip_cast(
+            self.raw_call(data, data_mean=data_mean, data_median=data_median),
+            dtype=self.output_dtype, min_value=0, max_value=self.max_output_value)
+
+
 class Linear(MonochromaticRemap):
     """
     A monochromatic linear remap function.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,7 +1,6 @@
-
+import json
 import os
 import logging
-
 
 parent_path = os.environ.get('SARPY_TEST_PATH', None)
 if parent_path == 'NONE':
@@ -11,6 +10,35 @@ if parent_path is not None:
 
 if parent_path is not None and not os.path.isdir(parent_path):
     raise IOError('SARPY_TEST_PATH is given as {}, but is not a directory'.format(parent_path))
+
+
+def find_test_data_files(test_json_file):
+    """
+    Find the test data files listed in the specified test JSON file.
+
+    Parameters
+    ----------
+    test_json_file : str | pathlib.Path
+        The full path specification to a JSON file that specifies unit test data files.
+
+    Returns
+    -------
+    dict:
+        A dictionary of files specified in the JSON file, if they exist in
+        the path specified by the environmental variable SARPY_TEST_PATH.
+    """
+    test_data_files = {}
+    if os.path.isfile(test_json_file):
+        with open(test_json_file, 'r') as fi:
+            the_files = json.load(fi)
+            for the_type in the_files:
+                valid_entries = []
+                for entry in the_files[the_type]:
+                    the_file = parse_file_entry(entry)
+                    if the_file is not None:
+                        valid_entries.append(the_file)
+                test_data_files[the_type] = valid_entries
+    return test_data_files
 
 
 def parse_file_entry(entry, default='absolute'):

--- a/tests/processing/sicd/test_spectral_taper.py
+++ b/tests/processing/sicd/test_spectral_taper.py
@@ -1,0 +1,309 @@
+"""
+These test functions will exercise the spectral_taper module which contains functions used to
+apply/remove spectral weighting functions to SICD data.
+
+"""
+import copy
+import logging
+
+import numpy as np
+import pytest
+import scipy
+import scipy.fft as scifft
+import scipy.signal.windows as sciwin
+
+from sarpy.io.complex.sicd_elements.SICD import SICDType
+from sarpy.io.complex.sicd_elements.ImageData import ImageDataType
+from sarpy.io.complex.sicd_elements.Grid import GridType, DirParamType, WgtTypeType
+from sarpy.io.complex.sicd_elements.Radiometric import RadiometricType, NoiseLevelType_, Poly2DType
+
+import sarpy.processing.sicd.windows as windows
+import sarpy.processing.sicd.spectral_taper as spectral_taper
+
+logging.basicConfig(level=logging.WARNING)
+
+old_scipy = [int(d) for d in scipy.__version__.split('.')][:2] < [1, 6]
+
+
+@pytest.fixture()
+def mock_sicd_meta():
+    nrows = 128
+    ncols = 256
+
+    row_ss = 1.5
+    col_ss = 1.5
+    ipr_wid = row_ss * 1.25
+    ipr_bw = 0.886 / ipr_wid
+
+    window_size = 17
+    alpha = 0.68
+    wgts = alpha + (1 - alpha) * np.cos(np.linspace(-np.pi, np.pi, window_size))
+
+    sicd_imagedata = ImageDataType(PixelType="RE32F_IM32F",
+                                   NumRows=nrows, NumCols=ncols,
+                                   FirstRow=0, FirstCol=0,
+                                   SCPPixel=(nrows//2, ncols//2)
+                                   )
+
+    grid_row = DirParamType(UVectECF=(1, 0, 0), SS=row_ss, ImpRespWid=ipr_wid, Sgn=-1, ImpRespBW=ipr_bw,
+                            KCtr=0, DeltaK1=-ipr_bw/2, DeltaK2=ipr_bw/2, DeltaKCOAPoly=np.array([[0.0]]),
+                            WgtType=WgtTypeType(WindowName="Hamming", Parameters={"ALPHA": alpha}), WgtFunct=wgts)
+    grid_col = DirParamType(UVectECF=(0, 1, 0), SS=col_ss, ImpRespWid=ipr_wid, Sgn=-1, ImpRespBW=ipr_bw,
+                            KCtr=0, DeltaK1=-ipr_bw/2, DeltaK2=ipr_bw/2, DeltaKCOAPoly=np.array([[0.0]]),
+                            WgtType=WgtTypeType(WindowName="Hamming", Parameters={"ALPHA": alpha}), WgtFunct=wgts)
+    sicd_grid = GridType(ImagePlane="SLANT", Type="RGAZIM", Row=grid_row, Col=grid_col)
+
+    sicd_radiometric = RadiometricType(NoiseLevel=NoiseLevelType_(NoiseLevelType="ABSOLUTE",
+                                                                  NoisePoly=Poly2DType([[1.0]])),
+                                       RCSSFPoly=Poly2DType([[1.0]]),
+                                       SigmaZeroSFPoly=Poly2DType([[1.0]]),
+                                       BetaZeroSFPoly=Poly2DType([[1.0]]),
+                                       GammaZeroSFPoly=Poly2DType([[1.0]]))
+
+    mdata = SICDType(ImageData=sicd_imagedata, Grid=sicd_grid, Radiometric=sicd_radiometric)
+
+    return mdata
+
+
+@pytest.mark.parametrize("window,parlist", [("uniform", None),
+                                            ("hamming", None),
+                                            ("hanning", None),
+                                            ("hann", None),
+                                            ('general_hamming', None),
+                                            ("kaiser", None),
+                                            ('general_hamming', ("alpha", 0.6)),
+                                            ("kaiser", ("beta", 15.0)),
+                                            pytest.param("taylor", None,
+                                                         marks=pytest.mark.skipif(old_scipy, reason="scipy ver < 1.6")),
+                                            pytest.param('taylor', ("nbar", 5, "sll", -35.0),
+                                                         marks=pytest.mark.skipif(old_scipy, reason="scipy ver < 1.6"))
+                                            ])
+def test_make_sym_1d_window(window, parlist):
+    n_evn = 20
+    n_odd = n_evn + 1
+
+    pars = None
+    if parlist:
+        pars = {parlist[n].upper(): parlist[n+1] for n in range(0, len(parlist), 2)}
+
+    # This dict translates SarPy window names into a scipy window names.
+    scipy_window = {'uniform': 'boxcar',
+                    'hanning': 'hann',
+                    }.get(window, window)
+
+    scipy_pars = spectral_taper.Taper().default_pars.get(window.upper(), {}) if pars is None else pars
+
+    for n in [n_evn, n_odd]:
+        w_actual = spectral_taper.Taper(window, pars=pars, default_size=n).window_vals
+
+        if scipy_window == 'boxcar':
+            w_expect = sciwin.boxcar(n, sym=True)
+        elif scipy_window == 'hamming':
+            w_expect = sciwin.hamming(n, sym=True)
+        elif scipy_window == 'hann':
+            w_expect = sciwin.hann(n, sym=True)
+        elif scipy_window == 'general_hamming':
+            w_expect = sciwin.general_hamming(n, alpha=scipy_pars['ALPHA'], sym=True)
+        elif scipy_window == 'kaiser':
+            w_expect = sciwin.kaiser(n, beta=scipy_pars['BETA'], sym=True)
+        elif scipy_window == 'taylor':
+            w_expect = sciwin.taylor(n, nbar=scipy_pars['NBAR'], sll=np.abs(scipy_pars['SLL']), norm=True, sym=True)
+        else:
+            raise ValueError(f"Unknown window function {scipy_window}")
+
+        assert np.allclose(w_actual, w_expect)
+
+
+def test_make_sym_1d_window_exceptions():
+    with pytest.raises(ValueError, match='Window type "SHAZAM" is not supported\\.'):
+        spectral_taper.Taper("shazam")
+
+
+def test_taper_get_vals():
+    taper1 = spectral_taper.Taper("hamming", default_size=101)
+    taper2 = spectral_taper.Taper("hamming", default_size=201)
+
+    assert np.allclose(taper1.get_vals(201, sym=True), taper2.get_vals(201, sym=True))
+    assert np.allclose(taper1.get_vals(201, sym=False), taper2.get_vals(201, sym=False))
+
+
+@pytest.mark.parametrize("axis", ["Row", "Col"])
+def test_get_sicd_wgt_funct(axis, mock_sicd_meta):
+    nsamp = 51
+    axis_mdata = {"Row": mock_sicd_meta.Grid.Row, "Col":  mock_sicd_meta.Grid.Col}[axis]
+
+    alpha = axis_mdata.WgtType.Parameters["ALPHA"]
+    w_expect = np.array(alpha + (1 - alpha) * np.cos(np.linspace(-np.pi, np.pi, nsamp)))
+    w_actual = spectral_taper._get_sicd_wgt_funct(mock_sicd_meta, axis, desired_size=nsamp)
+    assert np.allclose(w_actual, w_expect, atol=1.0e-3)
+
+    axis_mdata.WgtType.WindowName = "UNIFORM"
+    axis_mdata.WgtFunct = None
+    w_expect = np.ones(nsamp)
+    w_actual = spectral_taper._get_sicd_wgt_funct(mock_sicd_meta, axis, desired_size=nsamp)
+    assert np.all(w_actual == w_expect)
+
+    axis_mdata.WgtType.WindowName = 'SHAZAM'
+    with pytest.raises(ValueError, match=f'SICD/Grid/{axis}/WgtFunct is not part of the SICD metadata'):
+        spectral_taper._get_sicd_wgt_funct(mock_sicd_meta, axis, desired_size=nsamp)
+
+
+@pytest.mark.parametrize("img_rows,img_cols,fft_sgn,skew_axis", [(128, 256, -1, 9), (129, 257, -1, 9),
+                                                                 (128, 256, 1, 9), (129, 257, 1, 9),
+                                                                 (128, 256, -1, 0), (128, 256, -1, 1)
+                                                                 ])
+def test_apply_spectral_taper(mock_sicd_meta, img_rows, img_cols, fft_sgn, skew_axis):
+    class MockSICDReader():
+        def __init__(self, mdata):
+            self.sicd_meta = mdata
+
+            nrows_support = int(mdata.Grid.Row.ImpRespBW * mdata.Grid.Row.SS * mdata.ImageData.NumRows)
+            ncols_support = int(mdata.Grid.Col.ImpRespBW * mdata.Grid.Col.SS * mdata.ImageData.NumCols)
+
+            row_dc_bin = mdata.ImageData.NumRows // 2
+            row_edge_low = row_dc_bin - nrows_support // 2
+            row_edge_hgh = row_dc_bin + nrows_support // 2
+
+            col_dc_bin = mdata.ImageData.NumCols // 2
+            col_edge_low = col_dc_bin - ncols_support // 2
+            col_edge_hgh = col_dc_bin + ncols_support // 2
+
+            cdata_fft = np.zeros(shape=(mdata.ImageData.NumRows, mdata.ImageData.NumCols), dtype=complex)
+            cdata_fft[row_edge_low:row_edge_hgh+1,  col_edge_low:col_edge_hgh+1] = 1.0
+
+            if mdata.Grid.Row.WgtFunct is not None:
+                wgts = spectral_taper._fit_1d_window(mdata.Grid.Row.WgtFunct, row_edge_hgh - row_edge_low + 1)
+                cdata_fft[row_edge_low:row_edge_hgh+1, :] *= wgts[:, np.newaxis]
+
+            if mdata.Grid.Col.WgtFunct is not None:
+                wgts = spectral_taper._fit_1d_window(mdata.Grid.Col.WgtFunct, col_edge_hgh - col_edge_low + 1)
+                cdata_fft[:, col_edge_low:col_edge_hgh+1] *= wgts
+
+            self.cdata = (scifft.fftshift(scifft.fft2(scifft.fftshift(cdata_fft)))
+                          / (mdata.ImageData.NumRows * mdata.ImageData.NumCols))
+
+            if mdata.Grid.Row.DeltaKCOAPoly is not None:
+                self.apply_kspace_skew('Row', forward=True)
+
+            if mdata.Grid.Row.DeltaKCOAPoly is not None:
+                self.apply_kspace_skew('Col', forward=True)
+
+        def apply_kspace_skew(self, axis, forward=True):
+            axis_imdex = {'Row': 0, 'Col': 1}[axis]
+            axis_mdata = {'Row': self.sicd_meta.Grid.Row, 'Col': self.sicd_meta.Grid.Col}[axis]
+
+            xrow = ((np.arange(0, self.sicd_meta.ImageData.NumRows) - self.sicd_meta.ImageData.SCPPixel.Row)
+                    * self.sicd_meta.Grid.Row.SS)
+            ycol = ((np.arange(0, self.sicd_meta.ImageData.NumCols) - self.sicd_meta.ImageData.SCPPixel.Col)
+                    * self.sicd_meta.Grid.Col.SS)
+
+            delta_k_coa_poly = np.asarray(axis_mdata.DeltaKCOAPoly.Coefs)
+
+            phs_delta_k_coa_poly = np.polynomial.polynomial.polyint(delta_k_coa_poly, axis=axis_imdex)
+            phs_delta_k_vals = axis_mdata.Sgn * np.polynomial.polynomial.polygrid2d(xrow, ycol, phs_delta_k_coa_poly)
+
+            arg = (-1 if forward else 1) * 1j * 2 * np.pi
+            self.cdata *= np.exp(arg * phs_delta_k_vals)
+
+        def __getitem__(self, item):
+            return self.cdata
+
+    mock_sicd_meta.Grid.Row.Sgn = fft_sgn
+    mock_sicd_meta.Grid.Col.Sgn = fft_sgn
+
+    mock_sicd_meta.Grid.Row.WgtType = None
+    mock_sicd_meta.Grid.Row.WgtFunct = None
+    mock_sicd_meta.Grid.Col.WgtType = None
+    mock_sicd_meta.Grid.Col.WgtFunct = None
+
+    delta_k_coa_poly = np.array([[0.3, -6.6e-04, 2.5e-6], [-3.2e-5, 1.3e-09, -3.5e-15]])
+
+    if skew_axis == 0:
+        mock_sicd_meta.Grid.Row.DeltaKCOAPoly = delta_k_coa_poly
+
+    if skew_axis == 1:
+        mock_sicd_meta.Grid.Col.DeltaKCOAPoly = delta_k_coa_poly
+
+    mock_sicd_meta.ImageData.NumRows = img_rows
+    mock_sicd_meta.ImageData.NumCols = img_cols
+    mock_sicd_meta.ImageData.SCPPixel = (mock_sicd_meta.ImageData.NumRows//2, mock_sicd_meta.ImageData.NumCols//2)
+
+    sicd_reader = MockSICDReader(mock_sicd_meta)
+
+    taper_window = "Taylor"
+    taper = spectral_taper.Taper(taper_window)
+
+    cdata_in = copy.deepcopy(sicd_reader[:, :])
+    max_in = np.max(np.abs(cdata_in))
+    max_in_loc = np.where(np.abs(cdata_in) == max_in)
+    max_in_row = max_in_loc[0][0]
+    max_in_col = max_in_loc[1][0]
+
+    # Make sure that the input data has complex conjugate symmetry
+    r1 = 1 - cdata_in.shape[0] % 2
+    c1 = 1 - cdata_in.shape[1] % 2
+    assert max_in_row == cdata_in.shape[0] // 2 and max_in_col == cdata_in.shape[1] // 2
+    if skew_axis != 0:
+        assert np.allclose(cdata_in[r1:max_in_row, max_in_col], np.conj(cdata_in[-1:max_in_row:-1, max_in_col]))
+    if skew_axis != 1:
+        assert np.allclose(cdata_in[max_in_row, c1:max_in_col], np.conj(cdata_in[max_in_row, -1:max_in_col:-1]))
+
+    cdata_out, mdata = spectral_taper.apply_spectral_taper(sicd_reader, taper_window)
+
+    max_out = np.max(np.abs(cdata_out))
+    max_out_loc = np.where(np.abs(cdata_out) == max_out)
+    max_out_row = max_out_loc[0][0]
+    max_out_col = max_out_loc[1][0]
+
+    assert max_out_row == max_in_row and max_out_col == max_in_col
+
+    # Make sure that the output side lobes are less than the input side lobes
+    row_ipr_in = np.abs(cdata_in[max_out_row, :max_out_col-1] / cdata_in[max_out_row, max_out_col])
+    col_ipr_in = np.abs(cdata_in[:max_out_row-1, max_out_col] / cdata_in[max_out_row, max_out_col])
+
+    row_ipr_out = np.abs(cdata_out[max_out_row, :max_out_col-1] / cdata_out[max_out_row, max_out_col])
+    col_ipr_out = np.abs(cdata_out[:max_out_row-1, max_out_col] / cdata_out[max_out_row, max_out_col])
+
+    assert np.all(np.convolve(row_ipr_out, np.ones(3), mode='valid') <
+                  np.convolve(row_ipr_in, np.ones(3), mode='valid'))
+    assert np.all(np.convolve(col_ipr_out, np.ones(3), mode='valid') <
+                  np.convolve(col_ipr_in, np.ones(3), mode='valid'))
+
+    row_inv_osf = mdata.Grid.Row.ImpRespBW * mdata.Grid.Row.SS
+    col_inv_osf = mdata.Grid.Col.ImpRespBW * mdata.Grid.Col.SS
+
+    expected_max_in = row_inv_osf * col_inv_osf
+    assert np.allclose(max_in, expected_max_in, rtol=0.001)
+
+    expected_max_out = expected_max_in * np.mean(taper.window_vals)**2
+    assert np.allclose(max_out, expected_max_out, rtol=0.02)
+
+    expected_coh_pwr_gain = (expected_max_out / expected_max_in) ** 2
+    assert np.allclose(mdata.Radiometric.RCSSFPoly[0][0] * expected_coh_pwr_gain, 1.0)
+
+    rms_pwr_gain = np.mean(taper.window_vals**2)**2
+    assert np.allclose(mdata.Radiometric.NoiseLevel.NoisePoly.Coefs[0][0] / rms_pwr_gain, 1.0)
+    assert np.allclose(mdata.Radiometric.SigmaZeroSFPoly[0][0] * rms_pwr_gain, 1.0)
+    assert np.allclose(mdata.Radiometric.BetaZeroSFPoly[0][0] * rms_pwr_gain, 1.0)
+    assert np.allclose(mdata.Radiometric.GammaZeroSFPoly[0][0] * rms_pwr_gain, 1.0)
+
+
+def test_apply_2d_spectral_taper(mock_sicd_meta, monkeypatch):
+    def mock_apply_1d_spectral_taper(cdata, mdata, axis, window):
+        cdata[axis] = window
+        return cdata
+
+    monkeypatch.setattr(spectral_taper, '_apply_1d_spectral_taper', mock_apply_1d_spectral_taper)
+
+    row_scale = 2
+    col_scale = 4
+
+    mock_sicd_meta.Grid.Row.WgtFunct = np.full(shape=(11,), fill_value=row_scale)
+    mock_sicd_meta.Grid.Col.WgtFunct = np.full(shape=(12,), fill_value=col_scale)
+    window_vals = np.arange(13)
+
+    cdata = {}
+    cdata = spectral_taper._apply_2d_spectral_taper(cdata, mock_sicd_meta, window_vals)
+
+    assert np.allclose(cdata['Row'], window_vals / row_scale)
+    assert np.allclose(cdata['Col'], window_vals / col_scale)

--- a/tests/utils/test_sicd_sidelobe_control.py
+++ b/tests/utils/test_sicd_sidelobe_control.py
@@ -1,0 +1,34 @@
+import logging
+import pathlib
+import tempfile
+
+import pytest
+
+from tests import find_test_data_files
+import sarpy.utils.sicd_sidelobe_control
+
+sicd_files = find_test_data_files(pathlib.Path(__file__).parent / 'utils_file_types.json').get('SICD', [])
+
+logging.basicConfig(level=logging.WARNING)
+
+
+def test_sicd_sidelobe_control_help(capsys):
+    with pytest.raises(SystemExit):
+        sarpy.utils.sicd_sidelobe_control.main(['--help'])
+
+    captured = capsys.readouterr()
+
+    assert captured.err == ''
+    assert captured.out.startswith('usage:')
+
+
+@pytest.mark.parametrize("sicd_in_file", sicd_files)
+def test_sicd_sidelobe_control_pars(sicd_in_file):
+    with tempfile.TemporaryDirectory() as tempdir:
+        sicd_out_file = pathlib.Path(tempdir) / "sicd_taper.nitf"
+
+        args = [str(sicd_in_file), str(sicd_out_file), "--window", "taylor", "--pars", "5", "-35"]
+
+        sarpy.utils.sicd_sidelobe_control.main(args)
+
+        assert sicd_out_file.exists()

--- a/tests/utils/test_sicd_to_sidd.py
+++ b/tests/utils/test_sicd_to_sidd.py
@@ -1,0 +1,51 @@
+import logging
+import pathlib
+import tempfile
+
+import pytest
+
+from tests import find_test_data_files
+import sarpy.utils.sicd_to_sidd
+
+sicd_files = find_test_data_files(pathlib.Path(__file__).parent / 'utils_file_types.json').get('SICD', [])
+
+logging.basicConfig(level=logging.WARNING)
+
+
+def test_sicd_to_sidd_help(capsys):
+    with pytest.raises(SystemExit):
+        sarpy.utils.sicd_to_sidd.main(['--help'])
+
+    captured = capsys.readouterr()
+
+    assert captured.err == ''
+    assert captured.out.startswith('usage:')
+
+
+@pytest.mark.parametrize("sicd_file", sicd_files)
+def test_sicd_to_sidd_without_taper(sicd_file):
+    with tempfile.TemporaryDirectory() as tempdir:
+        sidd_dir_path = pathlib.Path(tempdir)
+
+        args = [str(sicd_file), str(sidd_dir_path),
+                "--type", "detected", "--method", "nearest", "--version", "3"]
+
+        sarpy.utils.sicd_to_sidd.main(args)
+
+        output_sidd_files = list(sidd_dir_path.iterdir())
+        assert len(output_sidd_files) == 1
+
+
+@pytest.mark.parametrize("sicd_file", sicd_files)
+def test_sicd_to_sidd_with_taper(sicd_file):
+    with tempfile.TemporaryDirectory() as tempdir:
+        sidd_dir_path = pathlib.Path(tempdir)
+
+        args = [str(sicd_file), str(sidd_dir_path),
+                "--window", "taylor", "--pars", "5", "-35",
+                "--type", "detected", "--method", "nearest", "--version", "3"]
+
+        sarpy.utils.sicd_to_sidd.main(args)
+
+        output_sidd_files = list(sidd_dir_path.iterdir())
+        assert len(output_sidd_files) == 1

--- a/tests/utils/test_sicd_to_sidd.py
+++ b/tests/utils/test_sicd_to_sidd.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 import logging
 import pathlib
 import tempfile
@@ -6,10 +7,26 @@ import pytest
 
 from tests import find_test_data_files
 import sarpy.utils.sicd_to_sidd
+import sarpy.visualization.remap as remap
 
 sicd_files = find_test_data_files(pathlib.Path(__file__).parent / 'utils_file_types.json').get('SICD', [])
 
 logging.basicConfig(level=logging.WARNING)
+
+
+def reset_remap_registry():
+    # Set the remap registry to its default state
+    remap._REMAP_DICT = OrderedDict()
+    remap._DEFAULTS_REGISTERED = False
+    remap._register_defaults()
+
+
+def setup():
+    reset_remap_registry()
+
+
+def teardown():
+    reset_remap_registry()
 
 
 def test_sicd_to_sidd_help(capsys):

--- a/tests/utils/test_sicd_to_sidd.py
+++ b/tests/utils/test_sicd_to_sidd.py
@@ -1,4 +1,3 @@
-from collections import OrderedDict
 import logging
 import pathlib
 import tempfile
@@ -7,26 +6,10 @@ import pytest
 
 from tests import find_test_data_files
 import sarpy.utils.sicd_to_sidd
-import sarpy.visualization.remap as remap
 
 sicd_files = find_test_data_files(pathlib.Path(__file__).parent / 'utils_file_types.json').get('SICD', [])
 
 logging.basicConfig(level=logging.WARNING)
-
-
-def reset_remap_registry():
-    # Set the remap registry to its default state
-    remap._REMAP_DICT = OrderedDict()
-    remap._DEFAULTS_REGISTERED = False
-    remap._register_defaults()
-
-
-def setup():
-    reset_remap_registry()
-
-
-def teardown():
-    reset_remap_registry()
 
 
 def test_sicd_to_sidd_help(capsys):

--- a/tests/utils/utils_file_types.json
+++ b/tests/utils/utils_file_types.json
@@ -1,0 +1,5 @@
+{
+  "SICD":  [
+    {"path":  "sicd/sicd_example_1_PFA_RE32F_IM32F_HH.nitf", "path_type":  "relative"}
+  ]
+}


### PR DESCRIPTION
This PR adds functions, classes, and utility programs that make it easy to convert SICD files to SIDD files.  The utility program called “sicd_sidelobe_control.py” will apply and/or remove a spectral taper widow to a SICD file.  The utility program called “sicd_to_sidd.py” will convert a SICD file to a SIDD file.  Command line arguments allow the user to specify the spectral taper window, the remap function, the projection interpolation function, and the SIDD version (1, 2, or 3).  In support of these utility programs, the module “spectral_taper.py” was added to the “processing/sicd” sub-package.

In addition, some of the SIDD metadata parameters were calculated incorrectly.  These problems have been fixed.

All new modules have 100% unit-test coverage and work in python versions 3.6, 3.7, 3.8, 3.9, and 3.10.
