### PR TITLE
Add tests for cphd1_elements.GeoInfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,11 @@ release points are not being annotated in GitHub.
 - Added `noxfile.py`
 - Added TOA visualization to `sarpy/visualization/cphd_kmz_product_creation.py`
 - Added unit tests for `sicd_elements/base.py`
-- Introduce `conftest.py`, add unit tests for `cphd1_elements/GeoInfo.py`, bugfixes
+- Introduce `conftest.py`, add unit tests for `cphd1_elements/GeoInfo.py`
 ### Fixed
 - Fixed `sarpy.io.kml.add_polygon` coordinate conditioning for older numpy versions
 - Replace unsupported `pillow` constant `Image.ANTIALIAS` with `Image.LANCZOS`
+- Ensure invalid setter inputs for `LineType` and `PolygonType` throw a ValueError in `GeoInfo.py` and typo fix
 
 ## [1.3.58] - 2023-08-07
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ release points are not being annotated in GitHub.
 - Added `noxfile.py`
 - Added TOA visualization to `sarpy/visualization/cphd_kmz_product_creation.py`
 - Added unit tests for `sicd_elements/base.py`
+- Introduce `conftest.py`, add unit tests for `cphd1_elements/GeoInfo.py`, bugfixes
 ### Fixed
 - Fixed `sarpy.io.kml.add_polygon` coordinate conditioning for older numpy versions
 - Replace unsupported `pillow` constant `Image.ANTIALIAS` with `Image.LANCZOS`

--- a/sarpy/io/phase_history/cphd1_elements/GeoInfo.py
+++ b/sarpy/io/phase_history/cphd1_elements/GeoInfo.py
@@ -18,7 +18,6 @@ from sarpy.io.complex.sicd_elements.blocks import LatLonRestrictionType, LatLonA
 
 from .base import DEFAULT_STRICT
 
-
 class LineType(Serializable):
     _fields = ('Endpoint', 'size')
     _required = ('Endpoint', 'size')
@@ -61,6 +60,10 @@ class LineType(Serializable):
         if value is None:
             self._array = None
             return
+
+        # LineType must have at least 2 Elements
+        if len(value) < 2:
+            raise ValueError(f'LineType must have at least 2 endpoints, got {len(value)}')
 
         if isinstance(value, numpy.ndarray):
             is_type = True
@@ -187,6 +190,10 @@ class PolygonType(Serializable):
             self._array = None
             return
 
+        # PolygonType must have at least 3 Vertices
+        if len(value) < 3:
+            raise ValueError(f'PolygonType must have at least 3 vertices, got {len(value)}')
+
         if isinstance(value, numpy.ndarray):
             is_type = True
             for entry in value:
@@ -309,7 +316,7 @@ class GeoInfoType(Serializable):
         Point : List[LatLonRestrictionType]
         Line : List[LineType]
         Polygon : List[PolygonType]
-        GeoInfo : Dict[GeoInfoTpe]
+        GeoInfo : Dict[GeoInfoType]
         kwargs
         """
 

--- a/tests/io/phase_history/cphd1_elements/conftest.py
+++ b/tests/io/phase_history/cphd1_elements/conftest.py
@@ -1,0 +1,35 @@
+#
+# Copyright 2023 Valkyrie Systems Corporation
+#
+# Licensed under MIT License.  See LICENSE.
+#
+import pytest
+
+from sarpy.io.phase_history.cphd1_elements import CPHD
+
+
+@pytest.fixture()
+def cphd(tests_path):
+    xml_file = tests_path / 'data/syntax-only-cphd-1.1.0-monostatic.xml'
+    structure = CPHD.CPHDType().from_xml_file(xml_file)
+
+    return structure
+
+
+@pytest.fixture()
+def bistatic_cphd(tests_path):
+    xml_file = tests_path / 'data/syntax-only-cphd-1.1.0-bistatic.xml'
+    structure = CPHD.CPHDType().from_xml_file(xml_file)
+
+    return structure
+
+
+@pytest.fixture()
+def kwargs():
+    return {'_xml_ns': 'ns', '_xml_ns_key': 'key'}
+
+
+@pytest.fixture()
+def tol():
+    return 1e-8
+

--- a/tests/io/phase_history/cphd1_elements/test_cphd1_elements_geoinfo.py
+++ b/tests/io/phase_history/cphd1_elements/test_cphd1_elements_geoinfo.py
@@ -1,0 +1,282 @@
+#
+# Copyright 2023 Valkyrie Systems Corporation
+#
+# Licensed under MIT License.  See LICENSE.
+#
+from collections import OrderedDict
+import xml.etree.ElementTree as ET
+
+import numpy as np
+import pytest
+
+from sarpy.io.complex.sicd_elements.blocks import LatLonRestrictionType, LatLonArrayElementType
+from sarpy.io.phase_history.cphd1_elements import GeoInfo
+from sarpy.io.xml.base import parse_xml_from_string
+
+
+@pytest.fixture
+def line_doc():
+    root = ET.Element("LineType")
+
+    doc = ET.ElementTree(root)
+    return doc
+
+
+@pytest.fixture
+def poly_doc():
+    root = ET.Element("PolygonType")
+
+    doc = ET.ElementTree(root)
+    return doc
+
+
+@pytest.fixture
+def geo_info_doc():
+    root = ET.Element("GeoInfoType")
+    root.attrib["name"] = "target0"
+
+    doc = ET.ElementTree(root)
+    return doc
+
+
+def test_cphd1_elements_linetype(cphd, line_doc, kwargs):
+    # Init with kwargs
+    line_type = GeoInfo.LineType(Endpoint=[[1, 2], [3, 4]], **kwargs)
+    assert line_type.size == 2
+    assert isinstance(line_type.Endpoint, np.ndarray)
+    assert line_type._xml_ns == kwargs["_xml_ns"]
+    assert line_type._xml_ns_key == kwargs["_xml_ns_key"]
+
+    # Test getitem/setitem
+    first_endpoint = line_type[0]
+    assert first_endpoint.Lat == 1.0
+    assert first_endpoint.Lon == 2.0
+    assert first_endpoint.index == 1
+    point = LatLonArrayElementType(Lat=11.0, Lon=31.0, index=1)
+    line_type[0] = point
+    assert line_type.Endpoint[0] == point
+
+    line_type.Endpoint = None
+    assert line_type.size == 0
+
+    line_type.Endpoint = np.array(
+        [cphd.GeoInfo[0].Line[0][0], cphd.GeoInfo[0].Line[0][1]]
+    )
+    assert line_type.size == 2
+
+    # dict endpints
+    line_type.Endpoint = [{"Lat": "1.0", "Lon": "3.0"}, {"Lat": "5.0", "Lon": "7.0"}]
+    assert line_type.size == 2
+
+    # tuple endpoints
+    line_type.Endpoint = [(1.0, 3.0), (2.0, 4.0)]
+    assert line_type.size == 2
+
+    # Endpoint with length 1
+    with pytest.raises(
+        ValueError, match="LineType must have at least 2 endpoints, got 1"
+    ):
+        line_type.Endpoint = [(1.0, 3.0)]
+
+    # Invalid types
+    with pytest.raises(
+        TypeError, match="Got unexpected type for element of Endpoint array"
+    ):
+        line_type.Endpoint = [(1.0, 3.0), 3.0]
+
+    with pytest.raises(TypeError, match="Got unexpected type for Endpoint array"):
+        line_type.Endpoint = {"Lat": "1.0", "Lon": "3.0"}
+
+    # to/from_node round trip
+    line_type.Endpoint = [cphd.GeoInfo[0].Line[0][0], cphd.GeoInfo[0].Line[0][1]]
+    this_node = line_type.to_node(doc=line_doc, tag="LineType")
+    assert this_node.tag == "LineType"
+    assert len(this_node.findall("Endpoint")) == 2
+    line_type1 = line_type.from_node(this_node, None)
+    assert isinstance(line_type1, GeoInfo.LineType)
+    assert np.all(
+        line_type1.Endpoint[0].get_array() == cphd.GeoInfo[0].Line[0][0].get_array()
+    )
+
+    this_node = line_type.to_node(doc=line_doc, tag="LineType", ns_key="test")
+    assert this_node.tag == "test:LineType"
+
+    line_dict = line_type.to_dict()
+    assert isinstance(line_dict, OrderedDict)
+
+
+def test_cphd1_elements_polygontype(cphd, poly_doc, kwargs):
+    # Init with kwargs
+    poly_type = GeoInfo.PolygonType(Vertex=[[1, 2], [3, 4], [4, 1]], **kwargs)
+    assert poly_type.size == 3
+    assert isinstance(poly_type.Vertex, np.ndarray)
+    assert poly_type._xml_ns == kwargs["_xml_ns"]
+    assert poly_type._xml_ns_key == kwargs["_xml_ns_key"]
+
+    # Test getitem/setitem
+    first_vertex = poly_type[0]
+    assert first_vertex.Lat == 1.0
+    assert first_vertex.Lon == 2.0
+    assert first_vertex.index == 1
+    point = LatLonArrayElementType(Lat=11.0, Lon=31.0, index=1)
+    poly_type[0] = point
+    assert poly_type.Vertex[0] == point
+
+    poly_type._array = None
+    assert poly_type.size == 0
+    assert poly_type.Vertex == np.array([0])
+
+    poly_type.Vertex = None
+    assert poly_type.size == 0
+
+    poly_type.Vertex = np.array(
+        [
+            cphd.GeoInfo[0].Polygon[0].Vertex[0],
+            cphd.GeoInfo[0].Polygon[0].Vertex[1],
+            cphd.GeoInfo[0].Polygon[0].Vertex[2],
+        ]
+    )
+    assert poly_type.size == 3
+
+    # dict vertices
+    poly_type.Vertex = [
+        {"Lat": "1.0", "Lon": "3.0"},
+        {"Lat": "5.0", "Lon": "7.0"},
+        {"Lat": "9.0", "Lon": "11.0"},
+    ]
+    assert poly_type.size == 3
+
+    # tuple vertices
+    poly_type.Vertex = [(1.0, 3.0), (5.0, 7.0), (9.0, 11.0)]
+    assert poly_type.size == 3
+
+    # Vertex with length 2
+    with pytest.raises(
+        ValueError, match="PolygonType must have at least 3 vertices, got 2"
+    ):
+        poly_type.Vertex = [(1.0, 3.0), (5.0, 7.0)]
+
+    # Invalid types
+    with pytest.raises(
+        TypeError, match="Got unexpected type for element of Vertex array"
+    ):
+        poly_type.Vertex = [(1.0, 3.0), (5.0, 7.0), 3.0]
+
+    with pytest.raises(TypeError, match="Got unexpected type for Vertex array"):
+        poly_type.Vertex = {
+            "vertex1": {"Lat": "1.0", "Lon": "3.0"},
+            "vertex2": {"Lat": "5.0", "Lon": "7.0"},
+            "vertex3": {"Lat": "9.0", "Lon": "11.0"},
+        }
+
+    # to/from_node round trip
+    poly_type.Vertex = [
+        cphd.GeoInfo[0].Polygon[0].Vertex[0],
+        cphd.GeoInfo[0].Polygon[0].Vertex[1],
+        cphd.GeoInfo[0].Polygon[0].Vertex[2],
+    ]
+    this_node = poly_type.to_node(doc=poly_doc, tag="PolygonType")
+    assert this_node.tag == "PolygonType"
+    assert len(this_node.findall("Vertex")) == 3
+    poly_type1 = poly_type.from_node(this_node, None)
+    assert isinstance(poly_type1, GeoInfo.PolygonType)
+    assert np.all(
+        poly_type1.Vertex[0].get_array()
+        == cphd.GeoInfo[0].Polygon[0].Vertex[0].get_array()
+    )
+
+    this_node = poly_type.to_node(doc=poly_doc, tag="PolygonType", ns_key="test")
+    assert this_node.tag == "test:PolygonType"
+
+    line_dict = poly_type.to_dict()
+    assert isinstance(line_dict, OrderedDict)
+
+
+def test_cphd1_elements_geoinfotype(cphd, geo_info_doc, kwargs, caplog):
+    # Init with kwargs
+    geo_info_type = GeoInfo.GeoInfoType(name="test", **kwargs)
+    assert geo_info_type._xml_ns == kwargs["_xml_ns"]
+    assert geo_info_type._xml_ns_key == kwargs["_xml_ns_key"]
+
+    # Instantiate with various GeoInfos styles
+    point = LatLonRestrictionType(Lat=1.0, Lon=3.0)
+    line_type = GeoInfo.LineType(Endpoint=[[1, 2], [3, 4]])
+    poly_type = GeoInfo.PolygonType(Vertex=[[1, 2], [3, 4], [4, 1]])
+    geo_info_type = GeoInfo.GeoInfoType(
+        name="targets",
+        Point=point,
+        Line=line_type,
+        Polygon=poly_type,
+        GeoInfo=cphd.GeoInfo[0].GeoInfo,
+    )
+    assert isinstance(geo_info_type.Point[0], LatLonRestrictionType)
+    assert geo_info_type.Point[0] == point
+    assert isinstance(geo_info_type.Line[0], GeoInfo.LineType)
+    assert geo_info_type.Line[0] == line_type
+    assert isinstance(geo_info_type.Polygon[0], GeoInfo.PolygonType)
+    assert geo_info_type.Polygon[0] == poly_type
+    assert geo_info_type.GeoInfo == cphd.GeoInfo[0].GeoInfo
+
+    geo_info_type1 = GeoInfo.GeoInfoType(name="targets", GeoInfo=geo_info_type)
+    assert geo_info_type1.GeoInfo[0] == geo_info_type
+
+    # List and Tuple of GeoInfo
+    assert len(geo_info_type.GeoInfo) == 1
+    geo_info_type = GeoInfo.GeoInfoType(
+        name="targets", GeoInfo=[cphd.GeoInfo[0].GeoInfo[0], cphd.GeoInfo[0].GeoInfo[0]]
+    )
+    assert len(geo_info_type.GeoInfo) == 2
+
+    assert len(geo_info_type1.GeoInfo) == 1
+    geo_info_type1 = GeoInfo.GeoInfoType(
+        name="targets", GeoInfo=(cphd.GeoInfo[0].GeoInfo[0], cphd.GeoInfo[0].GeoInfo[0])
+    )
+    assert len(geo_info_type1.GeoInfo) == 2
+
+    with pytest.raises(ValueError, match="GeoInfo got unexpected type"):
+        geo_info_type = GeoInfo.GeoInfoType(
+            name="targets", GeoInfo=(cphd.GeoInfo[0].GeoInfo[0].to_dict)
+        )
+
+    assert len(geo_info_type.getGeoInfo("target0")) == 2
+
+    # Add GeoInfo to an empty instance
+    geo_info_type1 = GeoInfo.GeoInfoType(name="test")
+    geo_dict = geo_info_type.GeoInfo[0].to_dict()
+    geo_info_type1.addGeoInfo(geo_dict)
+
+    with pytest.raises(
+        TypeError, match="Trying to set GeoInfo element with unexpected type"
+    ):
+        geo_info_type1.addGeoInfo(3.0)
+
+    # Taken from cphd.GeoInfo[0].GeoInfo[0]
+    node_str = """
+        <GeoInfo name="target0">
+            <Desc name="ecef">[6378137.0, -202.78989383631944, 289.6139826697846]</Desc>
+            <Point>
+                <Lat>1.23</Lat>
+                <Lon>2.34</Lon>
+            </Point>
+        </GeoInfo>
+    """
+    geo_info_type = GeoInfo.GeoInfoType(name="test", GeoInfo=cphd.GeoInfo[0].GeoInfo[0])
+    node, ns = parse_xml_from_string(node_str)
+    geo_info_type1 = geo_info_type.from_node(node, ns)
+    assert (
+        geo_info_type1.Descriptions["ecef"]
+        == geo_info_type.GeoInfo[0].Descriptions["ecef"]
+    )
+    assert np.all(
+        geo_info_type1.Point[0].get_array()
+        == geo_info_type.GeoInfo[0].Point[0].get_array()
+    )
+
+    this_node = geo_info_type.to_node(doc=geo_info_doc, tag="GeoInfoType")
+    assert this_node.tag == "GeoInfoType"
+
+    geo_info_dict = geo_info_type.to_dict()
+    assert np.all(
+        geo_info_dict["GeoInfo"][0]["Descriptions"]["ecef"]
+        == cphd.GeoInfo[0].GeoInfo[0].Descriptions["ecef"]
+    )


### PR DESCRIPTION
Add unit tests for the `cphd1_elements` module, specifically `GeoInfo.py`

This PR:

1. New tests in `test_cphd1_elements_geoinfo.py`
2. Bugfixes in GeoInfo.py
3. Added `conftest.py` with shared fixtures

Details + Before/After coverage report

BUGFIXES
* Ensure LineType is not created with less than 2 endpoints
* Ensure PolygonType is not created with less that 3 vertices
* Minor typo fix

**_Coverage from main branch:_**

`pytest tests --cov=sarpy.io.phase_history.cphd1_elements.GeoInfo --cov-report term-missing`

|Name|Stmts|Miss|Cover|Missing|
|----|-----|----|-----|-------|
|sarpy/io/phase_history/cphd1_elements/GeoInfo.py|212|60|72%|37, 39, 62-63, 66-71, 79-86, 89, 92, 95, 120, 125, 136, 156, 158, 169, 180, 187-188, 191-196, 204-211, 214, 217, 220, 245, 250, 261, 328, 330, 335, 344, 359, 377-378, 383, 404-409|
|TOTAL|212|60|72%||

**_Coverage from this branch:_**

`pytest tests/io/phase_history/cphd1_elements/test_cphd1_elements_geoinfo.py --cov=sarpy.io.phase_history.sicd_elements.GeoInfo --cov-report term-missing`

|Name|Stmts|Miss|Cover|Missing|
|----|-----|----|-----|-------|
|sarpy/io/phase_history/cphd1_elements/GeoInfo.py|212|0|100%||
|TOTAL|212|0|100%||