### PR TITLE
Fix image_header reference in other_nitf.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ release points are not being annotated in GitHub.
 ### Fixed
 - Fixed `sarpy.io.kml.add_polygon` coordinate conditioning for older numpy versions
 - Replace unsupported `pillow` constant `Image.ANTIALIAS` with `Image.LANCZOS`
+- Fix `image_header` reference in `other_nitf.py`
 
 ## [1.3.58] - 2023-08-07
 ### Added

--- a/sarpy/io/complex/other_nitf.py
+++ b/sarpy/io/complex/other_nitf.py
@@ -806,8 +806,8 @@ def _extract_transform_data(
         raise ValueError('Got unhandled PVTYPE {}'.format(pv_type))
 
     # noinspection PyUnresolvedReferences
-    tre = None if img_header.ExtendedHeader.data is None else \
-        img_header.ExtendedHeader.data['CMETAA']  # type: Optional[CMETAA]
+    tre = None if image_header.ExtendedHeader.data is None else \
+        image_header.ExtendedHeader.data['CMETAA']  # type: Optional[CMETAA]
 
     if tre is None:
         return ComplexFormatFunction(raw_dtype, complex_order, band_dimension=band_dimension)

--- a/tests/io/complex/test_other_nitf.py
+++ b/tests/io/complex/test_other_nitf.py
@@ -1,0 +1,57 @@
+import os
+import json
+import tempfile
+import unittest
+
+from sarpy.io.complex.converter import conversion_utility
+from sarpy.io.complex.other_nitf import ComplexNITFDetails, ComplexNITFReader
+from sarpy.io.complex.sicd import SICDReader
+from sarpy.io.complex.sicd_schema import get_schema_path, get_default_version_string
+
+
+from tests import parse_file_entry
+
+try:
+    from lxml import etree
+except ImportError:
+    etree = None
+
+
+complex_file_types = {}
+this_loc = os.path.abspath(__file__)
+file_reference = os.path.join(os.path.split(this_loc)[0], 'complex_file_types.json')  # specifies file locations
+if os.path.isfile(file_reference):
+    with open(file_reference, 'r') as fi:
+        the_files = json.load(fi)
+        for the_type in the_files:
+            valid_entries = []
+            for entry in the_files[the_type]:
+                the_file = parse_file_entry(entry)
+                if the_file is not None:
+                    valid_entries.append(the_file)
+            complex_file_types[the_type] = valid_entries
+
+sicd_files = complex_file_types.get('SICD', [])
+
+the_version = get_default_version_string()
+the_schema = get_schema_path(the_version)
+
+
+class TestSICDWriting(unittest.TestCase):
+
+    @unittest.skipIf(len(sicd_files) == 0, 'No sicd files found')
+    def test_sicd_creation(self):
+        for fil in sicd_files:
+            details = ComplexNITFDetails(fil)
+            reader = ComplexNITFReader(details)
+
+            with self.subTest(msg='Test conversion (recreation) of the sicd file {}'.format(fil)):
+                with tempfile.TemporaryDirectory() as tmpdirname:
+                    conversion_utility(reader, tmpdirname)
+                    new_filename = os.path.join(tmpdirname, os.listdir(tmpdirname)[0])
+                    reader2 = SICDReader(new_filename)
+                    self.assertEqual(os.stat(new_filename).st_size, reader2.nitf_details.nitf_header.FL)
+
+            with self.subTest(msg='Test writing a single row of the sicd file {}'.format(fil)):
+                with tempfile.TemporaryDirectory() as tmpdirname:
+                    conversion_utility(reader, tmpdirname, row_limits=(0, 1))

--- a/tests/io/complex/test_other_nitf.py
+++ b/tests/io/complex/test_other_nitf.py
@@ -1,27 +1,20 @@
 import os
 import json
-import tempfile
-import unittest
 
-from sarpy.io.complex.converter import conversion_utility
-from sarpy.io.complex.other_nitf import ComplexNITFDetails, ComplexNITFReader
-from sarpy.io.complex.sicd import SICDReader
-from sarpy.io.complex.sicd_schema import get_schema_path, get_default_version_string
+import pytest
 
+from sarpy.io.complex import other_nitf
 
 from tests import parse_file_entry
-
-try:
-    from lxml import etree
-except ImportError:
-    etree = None
 
 
 complex_file_types = {}
 this_loc = os.path.abspath(__file__)
-file_reference = os.path.join(os.path.split(this_loc)[0], 'complex_file_types.json')  # specifies file locations
+file_reference = os.path.join(
+    os.path.split(this_loc)[0], "complex_file_types.json"
+)  # specifies file locations
 if os.path.isfile(file_reference):
-    with open(file_reference, 'r') as fi:
+    with open(file_reference, "r") as fi:
         the_files = json.load(fi)
         for the_type in the_files:
             valid_entries = []
@@ -31,27 +24,10 @@ if os.path.isfile(file_reference):
                     valid_entries.append(the_file)
             complex_file_types[the_type] = valid_entries
 
-sicd_files = complex_file_types.get('SICD', [])
-
-the_version = get_default_version_string()
-the_schema = get_schema_path(the_version)
+sicd_files = complex_file_types.get("SICD", [])
 
 
-class TestSICDWriting(unittest.TestCase):
-
-    @unittest.skipIf(len(sicd_files) == 0, 'No sicd files found')
-    def test_sicd_creation(self):
-        for fil in sicd_files:
-            details = ComplexNITFDetails(fil)
-            reader = ComplexNITFReader(details)
-
-            with self.subTest(msg='Test conversion (recreation) of the sicd file {}'.format(fil)):
-                with tempfile.TemporaryDirectory() as tmpdirname:
-                    conversion_utility(reader, tmpdirname)
-                    new_filename = os.path.join(tmpdirname, os.listdir(tmpdirname)[0])
-                    reader2 = SICDReader(new_filename)
-                    self.assertEqual(os.stat(new_filename).st_size, reader2.nitf_details.nitf_header.FL)
-
-            with self.subTest(msg='Test writing a single row of the sicd file {}'.format(fil)):
-                with tempfile.TemporaryDirectory() as tmpdirname:
-                    conversion_utility(reader, tmpdirname, row_limits=(0, 1))
+@pytest.mark.parametrize("sicd_file", sicd_files)
+def test_read_sicd_with_complex_reader(sicd_file):
+    details = other_nitf.ComplexNITFDetails(sicd_file)
+    assert other_nitf.ComplexNITFReader(details) is not None


### PR DESCRIPTION
Some tiling logic work we were doing ended up hitting this line and exposing the issue. Seems the refactor in commit Seems commit 3ad5ef23e4eaac419bd824f772953327a7915a78 missed renaming these two references.

Did my best to add a test that matched your current structure.  