### PR TITLE
Add unit tests for some cphd1_elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ release points are not being annotated in GitHub.
 - Introduce `conftest.py`, add unit tests for `cphd1_elements/GeoInfo.py`
 - Added unit test `cphd1_elements/test_cphd_versions.py`
 - Added 1.0.1 CPHD to `test_cphd.py`
+- Added unit tests for `cphd1_elements/Dwell.py`, `cphd1_elements/SupportArray.py`, and `cphd1_elements/TxRcv.py`
 ### Fixed
 - Fixed `sarpy.io.kml.add_polygon` coordinate conditioning for older numpy versions
 - Replace unsupported `pillow` constant `Image.ANTIALIAS` with `Image.LANCZOS`

--- a/tests/io/phase_history/cphd1_elements/test_cphd1_elements_dwell.py
+++ b/tests/io/phase_history/cphd1_elements/test_cphd1_elements_dwell.py
@@ -1,0 +1,33 @@
+#
+# Copyright 2023 Valkyrie Systems Corporation
+#
+# Licensed under MIT License.  See LICENSE.
+#
+import numpy as np
+
+from sarpy.io.phase_history.cphd1_elements import Dwell
+
+
+def test_dwell_dwelltype():
+    """Test DwellType class"""
+    dwell_type = Dwell.DwellType()
+    assert dwell_type.NumCODTimes == 0
+    assert dwell_type.NumDwellTimes == 0
+
+    expected_num_cods = 2
+    dwell_type.CODTimes = [
+        Dwell.CODTimeType(Identifier=str(x), CODTimePoly=np.zeros((3, 4)))
+        for x in range(expected_num_cods)
+    ]
+    assert dwell_type.NumCODTimes == expected_num_cods
+
+    expected_num_dwells = 8
+    dwell_type.DwellTimes = [
+        Dwell.DwellTimeType(Identifier=str(x), DwellTimePoly=np.zeros((3, 4)))
+        for x in range(expected_num_dwells)
+    ]
+    assert dwell_type.NumDwellTimes == expected_num_dwells
+
+    dwell_type.DwellTimes.clear()
+    assert dwell_type.NumDwellTimes == 0
+

--- a/tests/io/phase_history/cphd1_elements/test_cphd1_elements_supportarray.py
+++ b/tests/io/phase_history/cphd1_elements/test_cphd1_elements_supportarray.py
@@ -1,0 +1,86 @@
+#
+# Copyright 2023 Valkyrie Systems Corporation
+#
+# Licensed under MIT License.  See LICENSE.
+#
+import xml.etree.ElementTree as ET
+
+import numpy as np
+import pytest
+
+from sarpy.io.phase_history.cphd1_elements import SupportArray
+
+
+def test_support_array_supportarraycore(cphd):
+    """Test SupporyArrayCore class"""
+    sa = SupportArray.SupportArrayCore(
+        Identifier=cphd.SupportArray.AntGainPhase[0].Identifier,
+        ElementFormat=cphd.SupportArray.AntGainPhase[0].ElementFormat,
+        X0=cphd.SupportArray.AntGainPhase[0].X0,
+        Y0=cphd.SupportArray.AntGainPhase[0].Y0,
+        XSS=cphd.SupportArray.AntGainPhase[0].XSS,
+        YSS=cphd.SupportArray.AntGainPhase[0].YSS,
+    )
+    sa.NODATA = None
+    assert sa.NODATA == None
+    assert sa.get_nodata_as_int() is None
+    assert sa.get_nodata_as_float() is None
+
+    sa.NODATA = ET.fromstring("<NODATA>deadbeef12345678</NODATA>")
+    assert sa.NODATA == "deadbeef12345678"
+
+    sa.NODATA = "deadbeef12345678"
+    assert sa.NODATA == "deadbeef12345678"
+
+    sa.NODATA = b"deadbeef12345678"
+    assert sa.NODATA == "deadbeef12345678"
+
+    with pytest.raises(NotImplementedError):
+        sa.NODATA = 1.0
+
+    with pytest.raises(NotImplementedError):
+        sa.NODATA = 1
+
+    with pytest.raises(TypeError, match="Got unexpected type"):
+        sa.NODATA = {1}
+
+    with pytest.raises(NotImplementedError):
+        sa.get_nodata_as_int()
+
+    with pytest.raises(NotImplementedError):
+        sa.get_nodata_as_float()
+
+    fmt = sa.get_numpy_format()
+    assert fmt[0] == np.dtype(">f4")
+    assert fmt[1] == 2
+
+
+def test_support_array_supportarraytype(cphd):
+    """Test SupporyArrayType class"""
+    sa = SupportArray.SupportArrayType(
+        IAZArray=cphd.SupportArray.IAZArray,
+        AntGainPhase=cphd.SupportArray.AntGainPhase,
+        DwellTimeArray=cphd.SupportArray.DwellTimeArray,
+        AddedSupportArray=cphd.SupportArray.AddedSupportArray,
+    )
+
+    iaz_array = sa.find_support_array("iaz_id0")
+    assert iaz_array.Identifier == cphd.SupportArray.IAZArray[0].Identifier
+
+    ant_gain_phase = sa.find_support_array("transmit_array")
+    assert ant_gain_phase.Identifier == cphd.SupportArray.AntGainPhase[0].Identifier
+
+    dwell_time_array = sa.find_support_array("dta_id0")
+    assert dwell_time_array.Identifier == cphd.SupportArray.DwellTimeArray[0].Identifier
+
+    added_support_array = sa.find_support_array("added_support_array0")
+    assert (
+        added_support_array.Identifier
+        == cphd.SupportArray.AddedSupportArray[0].Identifier
+    )
+
+    with pytest.raises(
+        KeyError, match="Identifier IAZArrayType not associated with a support array"
+    ):
+        iaz_array = sa.find_support_array("IAZArrayType")
+

--- a/tests/io/phase_history/cphd1_elements/test_cphd1_elements_txrcv.py
+++ b/tests/io/phase_history/cphd1_elements/test_cphd1_elements_txrcv.py
@@ -1,0 +1,44 @@
+#
+# Copyright 2023 Valkyrie Systems Corporation
+#
+# Licensed under MIT License.  See LICENSE.
+#
+from sarpy.io.phase_history.cphd1_elements import TxRcv
+
+
+def test_txrcv_txrcvtype():
+    """Smoke test"""
+    tx_rcv_type = TxRcv.TxRcvType()
+    assert tx_rcv_type.NumTxWFs == 0
+    assert tx_rcv_type.NumRcvs == 0
+
+    expected_num_tx_wf_params = 2
+    tx_rcv_type.TxWFParameters = [
+        TxRcv.TxWFParametersType(Identifier=str(x),
+                                 PulseLength=x*1e-6,
+                                 RFBandwidth=x*1e8,
+                                 FreqCenter=1e10,
+                                 LFMRate=0.0,
+                                 Polarization="S",
+                                 Power=1.23456789)
+        for x in range(expected_num_tx_wf_params)
+    ]
+    assert tx_rcv_type.NumTxWFs == expected_num_tx_wf_params
+
+    expected_num_rcv_params = 8
+    tx_rcv_type.RcvParameters = [
+        TxRcv.RcvParametersType(Identifier=str(x),
+                                WindowLength=x*1e-6,
+                                SampleRate=x*1e8,
+                                IFFilterBW=x*1e8,
+                                FreqCenter=10036761634.5518,
+                                LFMRate=0.0,
+                                Polarization="S",
+                                PathGain=5.6789)
+        for x in range(expected_num_rcv_params)
+    ]
+    assert tx_rcv_type.NumRcvs == expected_num_rcv_params
+
+    tx_rcv_type.RcvParameters.clear()
+    assert tx_rcv_type.NumRcvs == 0
+


### PR DESCRIPTION
Add unit tests for the `cphd1_elements` module, specifically `Dwell.py`, `SupportArray.py`, and `TxRcv.py`

This PR:

1. New tests in `test_cphd1_elements_dwell.py`
2. New tests in `test_cphd1_elements_supportarray.py`
3. New tests in `test_cphd1_elements_txrcv.py`

Details + coverage report

**_Coverage from this branch:_**

`pytest tests --cov=sarpy.io.phase_history.cphd1_elements.Dwell --cov-report term-missing`

|Name|Stmts|Miss|Cover|Missing|
|----|-----|----|-----|-------|
|sarpy/io/phase_history/cphd1_elements/Dwell.py|57|0|100%||
|TOTAL|57|0|100%||

`pytest tests --cov=sarpy.io.phase_history.cphd1_elements.SupportArray --cov-report term-missing`

|Name|Stmts|Miss|Cover|Missing|
|----|-----|----|-----|-------|
|sarpy/io/phase_history/cphd1_elements/SupportArray.py|139|0|100%||
|TOTAL|139|0|100%||

`pytest tests --cov=sarpy.io.phase_history.cphd1_elements.TxRcv --cov-report term-missing`

|Name|Stmts|Miss|Cover|Missing|
|----|-----|----|-----|-------|
|sarpy/io/phase_history/cphd1_elements/TxRcv.py|81|0|100%||
|TOTAL|81|0|100%||

<details>
<summary>multi-environment test results></summary>

```

$ nox
nox > Running session test(version='3.6')
nox > Creating conda env in .nox/test-version-3-6 with python
nox > conda install --yes --prefix /home/vscuser/repos/int_sarpy/.nox/test-version-3-6 python=3.6
nox > python -m pip install '.[all]'
nox > pytest tests
===================================================================================== test session starts =====================================================================================
platform linux -- Python 3.6.13, pytest-7.0.1, pluggy-1.0.0
rootdir: /home/vscuser/repos/int_sarpy
collected 476 items                                                                                                                                                                           

tests/test_class_string.py .                                                                                                                                                            [  0%]
tests/consistency/test_consistency.py ........                                                                                                                                          [  1%]
tests/consistency/test_cphd_consistency.py ..............................................................                                                                               [ 14%]
tests/geometry/test_geocoords.py ..........                                                                                                                                             [ 17%]
tests/geometry/test_geometry_elements.py ..........                                                                                                                                     [ 19%]
tests/geometry/test_latlon.py ...                                                                                                                                                       [ 19%]
tests/geometry/test_point_projection.py ............                                                                                                                                    [ 22%]
tests/io/test_kml.py .                                                                                                                                                                  [ 22%]
tests/io/DEM/test_geoid.py .                                                                                                                                                            [ 22%]
tests/io/DEM/test_geotiff1deg_list.py ....                                                                                                                                              [ 23%]
tests/io/DEM/test_geotiff1deg_reader.py ........                                                                                                                                        [ 25%]
tests/io/complex/test_reader.py .ssssssssss                                                                                                                                             [ 27%]
tests/io/complex/test_remote.py s                                                                                                                                                       [ 27%]
tests/io/complex/test_sicd.py .                                                                                                                                                         [ 27%]
tests/io/complex/test_utils.py .                                                                                                                                                        [ 28%]
tests/io/complex/sicd_elements/test_sicd_elements_antenna.py ...                                                                                                                        [ 28%]
tests/io/complex/sicd_elements/test_sicd_elements_base.py ...                                                                                                                           [ 29%]
tests/io/complex/sicd_elements/test_sicd_elements_blocks.py .....................                                                                                                       [ 33%]
tests/io/complex/sicd_elements/test_sicd_elements_collectioninfo.py ..                                                                                                                  [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_errorstatistics.py .                                                                                                                  [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_geodata.py ...                                                                                                                        [ 35%]
tests/io/complex/sicd_elements/test_sicd_elements_grid.py ..                                                                                                                            [ 35%]
tests/io/complex/sicd_elements/test_sicd_elements_imagecreation.py .                                                                                                                    [ 35%]
tests/io/complex/sicd_elements/test_sicd_elements_imagedata.py .                                                                                                                        [ 35%]
tests/io/complex/sicd_elements/test_sicd_elements_imageformation.py ......                                                                                                              [ 37%]
tests/io/complex/sicd_elements/test_sicd_elements_matchinfo.py .                                                                                                                        [ 37%]
tests/io/complex/sicd_elements/test_sicd_elements_pfa.py .                                                                                                                              [ 37%]
tests/io/complex/sicd_elements/test_sicd_elements_position.py ...                                                                                                                       [ 38%]
tests/io/complex/sicd_elements/test_sicd_elements_radarcollection.py ..............                                                                                                     [ 41%]
tests/io/complex/sicd_elements/test_sicd_elements_radiometric.py .                                                                                                                      [ 41%]
tests/io/complex/sicd_elements/test_sicd_elements_rgazcomp.py .                                                                                                                         [ 41%]
tests/io/complex/sicd_elements/test_sicd_elements_rma.py ...                                                                                                                            [ 42%]
tests/io/complex/sicd_elements/test_sicd_elements_scpcoa.py ...................                                                                                                         [ 46%]
tests/io/complex/sicd_elements/test_sicd_elements_sicd.py ..................................                                                                                            [ 53%]
tests/io/complex/sicd_elements/test_sicd_elements_timeline.py .....                                                                                                                     [ 54%]
tests/io/complex/sicd_elements/test_sicd_elements_utils.py ...                                                                                                                          [ 55%]
tests/io/general/test_base.py ...                                                                                                                                                       [ 55%]
tests/io/general/test_data_segment.py ..........                                                                                                                                        [ 57%]
tests/io/general/test_format_function.py .......                                                                                                                                        [ 59%]
tests/io/general/test_nitf_headers.py s                                                                                                                                                 [ 59%]
tests/io/general/test_tre.py .                                                                                                                                                          [ 59%]
tests/io/phase_history/test_cphd.py .                                                                                                                                                   [ 59%]
tests/io/phase_history/test_cphd_versions.py .....                                                                                                                                      [ 60%]
tests/io/phase_history/cphd1_elements/test_cphd.py ....                                                                                                                                 [ 61%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_dwell.py .                                                                                                                    [ 61%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_geoinfo.py ...                                                                                                                [ 62%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_supportarray.py ..                                                                                                            [ 63%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_txrcv.py .                                                                                                                    [ 63%]
tests/io/phase_history/cphd1_elements/test_utils.py .                                                                                                                                   [ 63%]
tests/io/product/test_reader.py ..s                                                                                                                                                     [ 64%]
tests/io/product/test_sidd_schema.py .........                                                                                                                                          [ 65%]
tests/io/product/test_sidd_writing.py s                                                                                                                                                 [ 66%]
tests/io/product/sidd3_elements/test_exploitationfeatures.py .......................................................................................................................... [ 91%]
........                                                                                                                                                                                [ 93%]
tests/io/product/sidd3_elements/test_sidd3_elements.py .....                                                                                                                            [ 94%]
tests/io/received/test_crsd.py .                                                                                                                                                        [ 94%]
tests/visualization/test_cphd_kmz_product_creation.py ..                                                                                                                                [ 95%]
tests/visualization/test_crsd_kmz_product_creation.py .                                                                                                                                 [ 95%]
tests/visualization/test_kmz_product_creation.py .x                                                                                                                                     [ 95%]
tests/visualization/test_remap.py ....................                                                                                                                                  [100%]

====================================================================================== warnings summary =======================================================================================
tests/geometry/test_point_projection.py::test_image_to_ground_errors
tests/geometry/test_point_projection.py::test_image_to_ground_dem
  /home/vscuser/repos/int_sarpy/sarpy/geometry/point_projection.py:1903: RuntimeWarning: divide by zero encountered in double_scalars
    lon_grid_size = min(10, lat_grid_size/abs(numpy.sin(numpy.deg2rad(ref_llh[0]))))

tests/visualization/test_kmz_product_creation.py::test_create_kmz[True]
  /home/vscuser/repos/int_sarpy/sarpy/visualization/kmz_utils.py:169: RuntimeWarning: invalid value encountered in double_scalars
    + dir_z**2 * semiaxis_a**2 * semiaxis_b**2

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=================================================================== 461 passed, 14 skipped, 1 xfailed, 3 warnings in 25.92s ===================================================================
nox > Session test(version='3.6') was successful.
nox > Running session test(version='3.11')
nox > Creating conda env in .nox/test-version-3-11 with python
nox > conda install --yes --prefix /home/vscuser/repos/int_sarpy/.nox/test-version-3-11 python=3.11
nox > python -m pip install '.[all]'
nox > pytest tests
===================================================================================== test session starts =====================================================================================
platform linux -- Python 3.11.5, pytest-7.4.2, pluggy-1.3.0
rootdir: /home/vscuser/repos/int_sarpy
collected 476 items                                                                                                                                                                           

tests/test_class_string.py .                                                                                                                                                            [  0%]
tests/consistency/test_consistency.py ........                                                                                                                                          [  1%]
tests/consistency/test_cphd_consistency.py ..............................................................                                                                               [ 14%]
tests/geometry/test_geocoords.py ..........                                                                                                                                             [ 17%]
tests/geometry/test_geometry_elements.py ..........                                                                                                                                     [ 19%]
tests/geometry/test_latlon.py ...                                                                                                                                                       [ 19%]
tests/geometry/test_point_projection.py ............                                                                                                                                    [ 22%]
tests/io/test_kml.py .                                                                                                                                                                  [ 22%]
tests/io/DEM/test_geoid.py .                                                                                                                                                            [ 22%]
tests/io/DEM/test_geotiff1deg_list.py ....                                                                                                                                              [ 23%]
tests/io/DEM/test_geotiff1deg_reader.py ........                                                                                                                                        [ 25%]
tests/io/complex/test_reader.py .ssssssssss                                                                                                                                             [ 27%]
tests/io/complex/test_remote.py s                                                                                                                                                       [ 27%]
tests/io/complex/test_sicd.py .                                                                                                                                                         [ 27%]
tests/io/complex/test_utils.py .                                                                                                                                                        [ 28%]
tests/io/complex/sicd_elements/test_sicd_elements_antenna.py ...                                                                                                                        [ 28%]
tests/io/complex/sicd_elements/test_sicd_elements_base.py ...                                                                                                                           [ 29%]
tests/io/complex/sicd_elements/test_sicd_elements_blocks.py .....................                                                                                                       [ 33%]
tests/io/complex/sicd_elements/test_sicd_elements_collectioninfo.py ..                                                                                                                  [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_errorstatistics.py .                                                                                                                  [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_geodata.py ...                                                                                                                        [ 35%]
tests/io/complex/sicd_elements/test_sicd_elements_grid.py ..                                                                                                                            [ 35%]
tests/io/complex/sicd_elements/test_sicd_elements_imagecreation.py .                                                                                                                    [ 35%]
tests/io/complex/sicd_elements/test_sicd_elements_imagedata.py .                                                                                                                        [ 35%]
tests/io/complex/sicd_elements/test_sicd_elements_imageformation.py ......                                                                                                              [ 37%]
tests/io/complex/sicd_elements/test_sicd_elements_matchinfo.py .                                                                                                                        [ 37%]
tests/io/complex/sicd_elements/test_sicd_elements_pfa.py .                                                                                                                              [ 37%]
tests/io/complex/sicd_elements/test_sicd_elements_position.py ...                                                                                                                       [ 38%]
tests/io/complex/sicd_elements/test_sicd_elements_radarcollection.py ..............                                                                                                     [ 41%]
tests/io/complex/sicd_elements/test_sicd_elements_radiometric.py .                                                                                                                      [ 41%]
tests/io/complex/sicd_elements/test_sicd_elements_rgazcomp.py .                                                                                                                         [ 41%]
tests/io/complex/sicd_elements/test_sicd_elements_rma.py ...                                                                                                                            [ 42%]
tests/io/complex/sicd_elements/test_sicd_elements_scpcoa.py ...................                                                                                                         [ 46%]
tests/io/complex/sicd_elements/test_sicd_elements_sicd.py ..................................                                                                                            [ 53%]
tests/io/complex/sicd_elements/test_sicd_elements_timeline.py .....                                                                                                                     [ 54%]
tests/io/complex/sicd_elements/test_sicd_elements_utils.py ...                                                                                                                          [ 55%]
tests/io/general/test_base.py ...                                                                                                                                                       [ 55%]
tests/io/general/test_data_segment.py ..........                                                                                                                                        [ 57%]
tests/io/general/test_format_function.py .......                                                                                                                                        [ 59%]
tests/io/general/test_nitf_headers.py s                                                                                                                                                 [ 59%]
tests/io/general/test_tre.py .                                                                                                                                                          [ 59%]
tests/io/phase_history/test_cphd.py .                                                                                                                                                   [ 59%]
tests/io/phase_history/test_cphd_versions.py .....                                                                                                                                      [ 60%]
tests/io/phase_history/cphd1_elements/test_cphd.py ....                                                                                                                                 [ 61%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_dwell.py .                                                                                                                    [ 61%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_geoinfo.py ...                                                                                                                [ 62%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_supportarray.py ..                                                                                                            [ 63%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_txrcv.py .                                                                                                                    [ 63%]
tests/io/phase_history/cphd1_elements/test_utils.py .                                                                                                                                   [ 63%]
tests/io/product/test_reader.py ..s                                                                                                                                                     [ 64%]
tests/io/product/test_sidd_schema.py .........                                                                                                                                          [ 65%]
tests/io/product/test_sidd_writing.py s                                                                                                                                                 [ 66%]
tests/io/product/sidd3_elements/test_exploitationfeatures.py .......................................................................................................................... [ 91%]
........                                                                                                                                                                                [ 93%]
tests/io/product/sidd3_elements/test_sidd3_elements.py .....                                                                                                                            [ 94%]
tests/io/received/test_crsd.py .                                                                                                                                                        [ 94%]
tests/visualization/test_cphd_kmz_product_creation.py ..                                                                                                                                [ 95%]
tests/visualization/test_crsd_kmz_product_creation.py .                                                                                                                                 [ 95%]
tests/visualization/test_kmz_product_creation.py .x                                                                                                                                     [ 95%]
tests/visualization/test_remap.py ....................                                                                                                                                  [100%]

====================================================================================== warnings summary =======================================================================================
tests/test_class_string.py::TestClassString::test_class_str
  /home/vscuser/repos/int_sarpy/sarpy/annotation/afrl_rde_schema/__init__.py:7: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
    import pkg_resources

tests/geometry/test_point_projection.py::test_image_to_ground_errors
tests/geometry/test_point_projection.py::test_image_to_ground_dem
  /home/vscuser/repos/int_sarpy/sarpy/geometry/point_projection.py:1903: RuntimeWarning: divide by zero encountered in scalar divide
    lon_grid_size = min(10, lat_grid_size/abs(numpy.sin(numpy.deg2rad(ref_llh[0]))))

tests/visualization/test_cphd_kmz_product_creation.py::test_create_kmz
tests/visualization/test_cphd_kmz_product_creation.py::test_create_kmz
tests/visualization/test_cphd_kmz_product_creation.py::test_create_kmz
tests/visualization/test_cphd_kmz_product_creation.py::test_create_kmz
tests/visualization/test_cphd_kmz_product_creation.py::test_create_kmz
tests/visualization/test_cphd_kmz_product_creation.py::test_create_kmz
  /home/vscuser/repos/int_sarpy/sarpy/visualization/kmz_utils.py:302: MatplotlibDeprecationWarning: The collections attribute was deprecated in Matplotlib 3.8 and will be removed two minor releases later.
    for path in contour_sets.collections[0].get_paths()

tests/visualization/test_kmz_product_creation.py::test_create_kmz[True]
  /home/vscuser/repos/int_sarpy/sarpy/visualization/kmz_utils.py:145: RuntimeWarning: invalid value encountered in scalar divide
    distance = (

tests/visualization/test_remap.py::TestRemap::test_LUTRemap_matplotlib
tests/visualization/test_remap.py::TestRemap::test_remap_names
tests/visualization/test_remap.py::TestRemap::test_remap_names
tests/visualization/test_remap.py::TestRemap::test_remap_names
tests/visualization/test_remap.py::TestRemap::test_remap_names
  /home/vscuser/repos/int_sarpy/sarpy/visualization/remap.py:1562: MatplotlibDeprecationWarning: The get_cmap function was deprecated in Matplotlib 3.7 and will be removed two minor releases later. Use ``matplotlib.colormaps[name]`` or ``matplotlib.colormaps.get_cmap(obj)`` instead.
    cmap = cm.get_cmap(value, max_out_size+1)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================== 461 passed, 14 skipped, 1 xfailed, 15 warnings in 20.75s ===================================================================

```

</details>