### PR TITLE
Unit tests for cphd1 elements data and antenna

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,16 @@ release points are not being annotated in GitHub.
 - Introduce `conftest.py`, add unit tests for `cphd1_elements/GeoInfo.py`
 - Added unit test `cphd1_elements/test_cphd_versions.py`
 - Added 1.0.1 CPHD to `test_cphd.py`
+- Added unit test `cphd1_elements/test_cphd_versions.py`
+- Added unit test `cphd1_elements/test_cphd1_elements_antenna.py`
+- Added unit test `cphd1_elements/test_cphd1_elements_data.py`
 ### Fixed
 - Fixed `sarpy.io.kml.add_polygon` coordinate conditioning for older numpy versions
 - Replace unsupported `pillow` constant `Image.ANTIALIAS` with `Image.LANCZOS`
 - Ensure invalid setter inputs for `LineType` and `PolygonType` throw a ValueError in `GeoInfo.py` and typo fix
+- Updated the size calculators of `Data.DataType` to return 0 when channel data or support array data is not populated
+- Add `version_required` logic to `Antenna.AntennaType` to check versions for the `AntennaPatternType` input
+- Fix the return value in `Antenna.AntennaPatternType.version_required()` to return the max instead of a tuple
 
 ## [1.3.58] - 2023-08-07
 ### Added

--- a/sarpy/io/phase_history/cphd1_elements/Antenna.py
+++ b/sarpy/io/phase_history/cphd1_elements/Antenna.py
@@ -581,7 +581,7 @@ class AntPatternType(Serializable):
         if self.EBFreqShiftSF is not None or \
                 self.MLFreqDilationSF is not None or \
                 self.AntPolRef is not None:
-            required = (required, (1, 1, 0))
+            required = max(required, (1, 1, 0))
         return required
 
 
@@ -668,4 +668,8 @@ class AntennaType(Serializable):
         if self.AntCoordFrame is not None:
             for entry in self.AntCoordFrame:
                 required = max(required, entry.version_required())
+        if self.AntPattern is not None:
+            for entry in self.AntPattern:
+                required = max(required, entry.version_required())
+
         return required

--- a/sarpy/io/phase_history/cphd1_elements/Data.py
+++ b/sarpy/io/phase_history/cphd1_elements/Data.py
@@ -228,18 +228,27 @@ class DataType(Serializable):
         """
         Calculates the size of the support block in bytes as described by the SupportArray fields.
         """
-        return sum([s.calculate_size() for s in self.SupportArrays])
+        if self.SupportArrays is None:
+            return 0
+        else:
+            return sum([s.calculate_size() for s in self.SupportArrays])
 
     def calculate_pvp_block_size(self):
         """
         Calculates the size of the PVP block in bytes as described by the Data fields.
         """
-        return self.NumBytesPVP * sum([c.NumVectors for c in self.Channels])
+        if self.Channels is None:
+            return 0
+        else:
+            return self.NumBytesPVP * sum([c.NumVectors for c in self.Channels])
 
     def calculate_signal_block_size(self):
         """
         Calculates the size of the signal block in bytes as described by the Data fields.
         """
+        if self.Channels is None:
+            return 0
+
         if self.SignalCompressionID is not None:
             return sum([c.CompressedSignalSize for c in self.Channels])
         else:

--- a/tests/io/phase_history/cphd1_elements/test_cphd1_elements_antenna.py
+++ b/tests/io/phase_history/cphd1_elements/test_cphd1_elements_antenna.py
@@ -1,0 +1,136 @@
+#
+# Copyright 2023 Valkyrie Systems Corporation
+#
+# Licensed under MIT License.  See LICENSE.
+#
+import numpy as np
+import pytest
+
+from sarpy.io.phase_history.cphd1_elements import Antenna
+
+
+def test_antenna_freqsftype(cphd):
+    """Test FreqSFType class"""
+    sf_list = [cphd.Antenna.AntPattern[0].EBFreqShiftSF.DCXSF,
+               cphd.Antenna.AntPattern[0].EBFreqShiftSF.DCYSF]
+    freq_sf_type = Antenna.FreqSFType(
+        DCXSF=sf_list[0],
+        DCYSF=sf_list[1],
+    )
+    assert np.all(freq_sf_type.get_array() == np.array(sf_list))
+
+    assert freq_sf_type.from_array(None) is None
+
+    new_sf = [1, 1]
+    new_freq_sf_type = freq_sf_type.from_array(new_sf)
+    assert np.all(new_freq_sf_type.get_array() == np.array(new_sf))
+
+    with pytest.raises(ValueError, match="Expected array to be of length 2"):
+        baf_sf = [1]
+        freq_sf_type.from_array(baf_sf)
+
+    with pytest.raises(
+        ValueError, match="Expected array to be numpy.ndarray, list, or tuple"
+    ):
+        baf_sf = {1}
+        freq_sf_type.from_array(baf_sf)
+
+
+def test_antenna_antpolreftype():
+    """Test AntPolRefType class"""
+    ant_pol_ref_type = Antenna.AntPolRefType(
+        AmpX=0.0,
+        AmpY=1.0,
+        PhaseY=2.0,
+    )
+    assert np.all(ant_pol_ref_type.get_array() == np.array([0.0, 1.0, 2.0]))
+
+    assert ant_pol_ref_type.from_array(None) is None
+
+    new_ant_pol_ref = [1, 2, 3]
+    new_ant_pol_ref_type = ant_pol_ref_type.from_array(new_ant_pol_ref)
+    assert np.all(new_ant_pol_ref_type.get_array() == np.array(new_ant_pol_ref))
+
+    with pytest.raises(ValueError, match="Expected array to be of length 3"):
+        baf_ant_pol_ref = [1, 2]
+        ant_pol_ref_type.from_array(baf_ant_pol_ref)
+
+    with pytest.raises(
+        ValueError, match="Expected array to be numpy.ndarray, list, or tuple"
+    ):
+        baf_ant_pol_ref = {1}
+        ant_pol_ref_type.from_array(baf_ant_pol_ref)
+
+
+def test_antenna_ebtype():
+    """Test EBType class"""
+    eb_type = Antenna.EBType(
+        DCXPoly=None,
+        DCYPoly=np.zeros(4),
+        UseEBPVP=True,
+    )
+    assert eb_type(0) is None
+
+    eb_type = Antenna.EBType(
+        DCXPoly=np.ones(4),
+        DCYPoly=np.zeros(4),
+        UseEBPVP=True,
+    )
+    assert np.all(eb_type(0) == np.array([1.0, 0.0]))
+
+
+def test_antenna_gainphasepolytype():
+    """Test GainPhasePolyType class"""
+    gain_phase_poly_type = Antenna.GainPhasePolyType(
+        GainPoly=None,
+        PhasePoly=np.zeros((3, 4)),
+        AntGPId="xmit",
+    )
+    assert gain_phase_poly_type(0, 0) is None
+
+    gain_phase_poly_type = Antenna.GainPhasePolyType(
+        GainPoly=np.ones((3, 4)),
+        PhasePoly=np.zeros((3, 4)),
+        AntGPId="xmit",
+    )
+    assert np.all(gain_phase_poly_type(0, 0) == np.array([1.0, 0.0]))
+
+    assert len(gain_phase_poly_type.PhasePoly.Coefs) == 3
+    gain_phase_poly_type.minimize_order()
+    assert len(gain_phase_poly_type.PhasePoly.Coefs) == 1
+
+
+def test_antenna_antennatype():
+    """Test AntennaType class"""
+    antenna_type = Antenna.AntennaType()
+    assert antenna_type.NumACFs == 0
+    assert antenna_type.NumAPCs == 0
+    assert antenna_type.NumAntPats == 0
+
+    expected_num_acfs = 2
+    antenna_type.AntCoordFrame = [
+        Antenna.AntCoordFrameType(Identifier=str(x), XAxisPoly=np.zeros((3, 4)), YAxisPoly=np.zeros((3, 4)))
+        for x in range(expected_num_acfs)
+    ]
+    assert antenna_type.NumACFs == expected_num_acfs
+
+    expected_num_apcs = 2
+    antenna_type.AntPhaseCenter = [
+        Antenna.AntPhaseCenterType(Identifier=str(x), ACFId="ACF"+str(x), APCXYZ=np.zeros(3))
+        for x in range(expected_num_apcs)
+    ]
+    assert antenna_type.NumAPCs == expected_num_apcs
+
+    expected_num_arrays = 2
+    arrays = [
+        Antenna.GainPhasePolyType(GainPoly=np.zeros((3, 4)),
+                                  PhasePoly=np.ones((3, 4))),
+        Antenna.GainPhasePolyType(GainPoly=np.ones((3, 4)),
+                                  PhasePoly=np.zeros((3, 4)))
+    ]
+    antenna_type.AntPattern = [
+        Antenna.AntPatternType(Identifier=str(x), Array=arrays[x])
+        for x in range(len(arrays))
+    ]
+    assert antenna_type.NumAntPats == expected_num_arrays
+

--- a/tests/io/phase_history/cphd1_elements/test_cphd1_elements_data.py
+++ b/tests/io/phase_history/cphd1_elements/test_cphd1_elements_data.py
@@ -1,0 +1,82 @@
+#
+# Copyright 2023 Valkyrie Systems Corporation
+#
+# Licensed under MIT License.  See LICENSE.
+#
+from sarpy.io.phase_history.cphd1_elements import Data
+
+
+def test_data_datatype(kwargs):
+    """Test DataType class"""
+    data_type = Data.DataType()
+    assert data_type.NumCPHDChannels == 0
+    assert data_type.NumSupportArrays == 0
+    assert data_type.calculate_support_block_size() == 0
+    assert data_type.calculate_pvp_block_size() == 0
+    assert data_type.calculate_signal_block_size() == 0
+
+    channel0 = Data.ChannelSizeType(
+        Identifier="channel0",
+        NumVectors=10,
+        NumSamples=10,
+        SignalArrayByteOffset=0,
+        PVPArrayByteOffset=0,
+        CompressedSignalSize=123456,
+        **kwargs,
+    )
+
+    support_arr_size_type0 = Data.SupportArraySizeType(
+        Identifier="support0",
+        NumRows=10,
+        NumCols=10,
+        BytesPerElement=8,
+        ArrayByteOffset=0,
+        **kwargs,
+    )
+
+    assert support_arr_size_type0.calculate_size() == (
+        support_arr_size_type0.BytesPerElement
+        * support_arr_size_type0.NumRows
+        * support_arr_size_type0.NumCols
+    )
+
+    support_arr_size_type1 = Data.SupportArraySizeType(
+        Identifier="support1",
+        NumRows=10,
+        NumCols=10,
+        BytesPerElement=8,
+        ArrayByteOffset=0,
+        **kwargs,
+    )
+
+    data_type = Data.DataType(
+        SignalArrayFormat="CF8",
+        NumBytesPVP=100,
+        SignalCompressionID="NODATA",
+        Channels=channel0,
+        SupportArrays=[support_arr_size_type0, support_arr_size_type1],
+        **kwargs,
+    )
+
+    assert data_type.NumCPHDChannels == 1
+    assert data_type.NumSupportArrays == 2
+    assert (
+        data_type.calculate_support_block_size()
+        == support_arr_size_type0.calculate_size()
+        + support_arr_size_type1.calculate_size()
+    )
+    assert (
+        data_type.calculate_pvp_block_size()
+        == channel0.NumVectors * data_type.NumBytesPVP
+    )
+    assert (
+        data_type.calculate_signal_block_size()
+        == data_type.Channels[0].CompressedSignalSize
+    )
+
+    data_type.SignalCompressionID = None
+    assert (
+        data_type.calculate_signal_block_size()
+        == channel0.NumVectors * channel0.NumSamples * 8
+    )
+


### PR DESCRIPTION
Add unit tests for the `cphd1_elements` module, specifically `Data.py` and `Antenna.py`

This PR:

1. New tests in `test_cphd1_elements_data.py`
2. Bugfix in `Data.py` to return 0 for size calculations when the supporting data is not there
3. New tests in `test_cphd1_elements_antenna.py`
4. Bugfix in `Antenna.py` to add missing `version_required` logic and a missing `max` calculation

Details + coverage report

BUGFIXES:
* Updated the size calculators of DataType to return 0 when channel data or support array data is not populated
    It seemed inconsistent that sarpy allows class instantiation without all the required fields, but then returns errors when you try to use the size functions (see error below).  I thought it better to return size=0 when the fields required to calculate the size were empty.

<details>
<summary>error</summary>

```

========================================================================================================= FAILURES ==========================================================================================================
____________________________________________________________________________________________________ test_data_datatype _____________________________________________________________________________________________________

kwargs = {'_xml_ns': 'ns', '_xml_ns_key': 'key'}

    def test_data_datatype(kwargs):
        """Test DataType class"""
        data_type = Data.DataType()
        assert data_type.NumCPHDChannels == 0
        assert data_type.NumSupportArrays == 0
>       assert data_type.calculate_support_block_size() == 0

tests/io/phase_history/cphd1_elements/test_cphd1_elements_data.py:14: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = DataType(**OrderedDict([('NumCPHDChannels', 0), ('NumSupportArrays', 0)]))

    def calculate_support_block_size(self):
        """
        Calculates the size of the support block in bytes as described by the SupportArray fields.
        """
>       return sum([s.calculate_size() for s in self.SupportArrays])
E       TypeError: 'NoneType' object is not iterable

sarpy/io/phase_history/cphd1_elements/Data.py:231: TypeError

```

</details>

* Add `version_required` logic to `AntennaType` to check versions for the `AntennaPatternType` input.  Additionally, fix the return value in  `AntennaPatternType.version_required()` to return the max instead of a tuple of both.

**_Coverage from this branch:_**

`pytest tests --cov=sarpy.io.phase_history.cphd1_elements.Data --cov-report term-missing`

|Name|Stmts|Miss|Cover|Missing|
|----|-----|----|-----|-------|
|sarpy/io/phase_history/cphd1_elements/Data.py|94|0|100%||
|TOTAL|94|0|100%||

`pytest tests --cov=sarpy.io.phase_history.cphd1_elements.Antenna --cov-report term-missing`

|Name|Stmts|Miss|Cover|Missing|
|----|-----|----|-----|-------|
|sarpy/io/phase_history/cphd1_elements/Antenna.py|250|0|100%||
|TOTAL|250|0|100%||

<details>
<summary>multi-environment test results></summary>

```

[vscuser@dev-vm int_sarpy]$ nox
nox > Running session test(version='3.6')
nox > Creating conda env in .nox/test-version-3-6 with python
nox > conda install --yes --prefix /home/vscuser/repos/int_sarpy/.nox/test-version-3-6 python=3.6
nox > python -m pip install '.[all]'
nox > pytest tests
===================================================================================== test session starts =====================================================================================
platform linux -- Python 3.6.13, pytest-7.0.1, pluggy-1.0.0
rootdir: /home/vscuser/repos/int_sarpy
collected 478 items                                                                                                                                                                           

tests/test_class_string.py .                                                                                                                                                            [  0%]
tests/consistency/test_consistency.py ........                                                                                                                                          [  1%]
tests/consistency/test_cphd_consistency.py ..............................................................                                                                               [ 14%]
tests/geometry/test_geocoords.py ..........                                                                                                                                             [ 16%]
tests/geometry/test_geometry_elements.py ..........                                                                                                                                     [ 19%]
tests/geometry/test_latlon.py ...                                                                                                                                                       [ 19%]
tests/geometry/test_point_projection.py ............                                                                                                                                    [ 22%]
tests/io/test_kml.py .                                                                                                                                                                  [ 22%]
tests/io/DEM/test_geoid.py .                                                                                                                                                            [ 22%]
tests/io/DEM/test_geotiff1deg_list.py ....                                                                                                                                              [ 23%]
tests/io/DEM/test_geotiff1deg_reader.py ........                                                                                                                                        [ 25%]
tests/io/complex/test_reader.py .ssssssssss                                                                                                                                             [ 27%]
tests/io/complex/test_remote.py s                                                                                                                                                       [ 27%]
tests/io/complex/test_sicd.py .                                                                                                                                                         [ 27%]
tests/io/complex/test_utils.py .                                                                                                                                                        [ 28%]
tests/io/complex/sicd_elements/test_sicd_elements_antenna.py ...                                                                                                                        [ 28%]
tests/io/complex/sicd_elements/test_sicd_elements_base.py ...                                                                                                                           [ 29%]
tests/io/complex/sicd_elements/test_sicd_elements_blocks.py .....................                                                                                                       [ 33%]
tests/io/complex/sicd_elements/test_sicd_elements_collectioninfo.py ..                                                                                                                  [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_errorstatistics.py .                                                                                                                  [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_geodata.py ...                                                                                                                        [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_grid.py ..                                                                                                                            [ 35%]
tests/io/complex/sicd_elements/test_sicd_elements_imagecreation.py .                                                                                                                    [ 35%]
tests/io/complex/sicd_elements/test_sicd_elements_imagedata.py .                                                                                                                        [ 35%]
tests/io/complex/sicd_elements/test_sicd_elements_imageformation.py ......                                                                                                              [ 37%]
tests/io/complex/sicd_elements/test_sicd_elements_matchinfo.py .                                                                                                                        [ 37%]
tests/io/complex/sicd_elements/test_sicd_elements_pfa.py .                                                                                                                              [ 37%]
tests/io/complex/sicd_elements/test_sicd_elements_position.py ...                                                                                                                       [ 38%]
tests/io/complex/sicd_elements/test_sicd_elements_radarcollection.py ..............                                                                                                     [ 41%]
tests/io/complex/sicd_elements/test_sicd_elements_radiometric.py .                                                                                                                      [ 41%]
tests/io/complex/sicd_elements/test_sicd_elements_rgazcomp.py .                                                                                                                         [ 41%]
tests/io/complex/sicd_elements/test_sicd_elements_rma.py ...                                                                                                                            [ 42%]
tests/io/complex/sicd_elements/test_sicd_elements_scpcoa.py ...................                                                                                                         [ 46%]
tests/io/complex/sicd_elements/test_sicd_elements_sicd.py ..................................                                                                                            [ 53%]
tests/io/complex/sicd_elements/test_sicd_elements_timeline.py .....                                                                                                                     [ 54%]
tests/io/complex/sicd_elements/test_sicd_elements_utils.py ...                                                                                                                          [ 54%]
tests/io/general/test_base.py ...                                                                                                                                                       [ 55%]
tests/io/general/test_data_segment.py ..........                                                                                                                                        [ 57%]
tests/io/general/test_format_function.py .......                                                                                                                                        [ 58%]
tests/io/general/test_nitf_headers.py s                                                                                                                                                 [ 59%]
tests/io/general/test_tre.py .                                                                                                                                                          [ 59%]
tests/io/phase_history/test_cphd.py .                                                                                                                                                   [ 59%]
tests/io/phase_history/test_cphd_versions.py .....                                                                                                                                      [ 60%]
tests/io/phase_history/cphd1_elements/test_cphd.py ....                                                                                                                                 [ 61%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_antenna.py .....                                                                                                              [ 62%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_data.py .                                                                                                                     [ 62%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_geoinfo.py ...                                                                                                                [ 63%]
tests/io/phase_history/cphd1_elements/test_utils.py .                                                                                                                                   [ 63%]
tests/io/product/test_reader.py ..s                                                                                                                                                     [ 64%]
tests/io/product/test_sidd_schema.py .........                                                                                                                                          [ 66%]
tests/io/product/test_sidd_writing.py s                                                                                                                                                 [ 66%]
tests/io/product/sidd3_elements/test_exploitationfeatures.py .......................................................................................................................... [ 91%]
........                                                                                                                                                                                [ 93%]
tests/io/product/sidd3_elements/test_sidd3_elements.py .....                                                                                                                            [ 94%]
tests/io/received/test_crsd.py .                                                                                                                                                        [ 94%]
tests/visualization/test_cphd_kmz_product_creation.py ..                                                                                                                                [ 95%]
tests/visualization/test_crsd_kmz_product_creation.py .                                                                                                                                 [ 95%]
tests/visualization/test_kmz_product_creation.py .x                                                                                                                                     [ 95%]
tests/visualization/test_remap.py ....................                                                                                                                                  [100%]

====================================================================================== warnings summary =======================================================================================
tests/geometry/test_point_projection.py::test_image_to_ground_errors
tests/geometry/test_point_projection.py::test_image_to_ground_dem
  /home/vscuser/repos/int_sarpy/sarpy/geometry/point_projection.py:1903: RuntimeWarning: divide by zero encountered in double_scalars
    lon_grid_size = min(10, lat_grid_size/abs(numpy.sin(numpy.deg2rad(ref_llh[0]))))

tests/visualization/test_kmz_product_creation.py::test_create_kmz[True]
  /home/vscuser/repos/int_sarpy/sarpy/visualization/kmz_utils.py:169: RuntimeWarning: invalid value encountered in double_scalars
    + dir_z**2 * semiaxis_a**2 * semiaxis_b**2

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=================================================================== 463 passed, 14 skipped, 1 xfailed, 3 warnings in 29.16s ===================================================================
nox > Session test(version='3.6') was successful.
nox > Running session test(version='3.11')
nox > Creating conda env in .nox/test-version-3-11 with python
nox > conda install --yes --prefix /home/vscuser/repos/int_sarpy/.nox/test-version-3-11 python=3.11
nox > python -m pip install '.[all]'
nox > pytest tests
===================================================================================== test session starts =====================================================================================
platform linux -- Python 3.11.5, pytest-7.4.2, pluggy-1.3.0
rootdir: /home/vscuser/repos/int_sarpy
collected 478 items                                                                                                                                                                           

tests/test_class_string.py .                                                                                                                                                            [  0%]
tests/consistency/test_consistency.py ........                                                                                                                                          [  1%]
tests/consistency/test_cphd_consistency.py ..............................................................                                                                               [ 14%]
tests/geometry/test_geocoords.py ..........                                                                                                                                             [ 16%]
tests/geometry/test_geometry_elements.py ..........                                                                                                                                     [ 19%]
tests/geometry/test_latlon.py ...                                                                                                                                                       [ 19%]
tests/geometry/test_point_projection.py ............                                                                                                                                    [ 22%]
tests/io/test_kml.py .                                                                                                                                                                  [ 22%]
tests/io/DEM/test_geoid.py .                                                                                                                                                            [ 22%]
tests/io/DEM/test_geotiff1deg_list.py ....                                                                                                                                              [ 23%]
tests/io/DEM/test_geotiff1deg_reader.py ........                                                                                                                                        [ 25%]
tests/io/complex/test_reader.py .ssssssssss                                                                                                                                             [ 27%]
tests/io/complex/test_remote.py s                                                                                                                                                       [ 27%]
tests/io/complex/test_sicd.py .                                                                                                                                                         [ 27%]
tests/io/complex/test_utils.py .                                                                                                                                                        [ 28%]
tests/io/complex/sicd_elements/test_sicd_elements_antenna.py ...                                                                                                                        [ 28%]
tests/io/complex/sicd_elements/test_sicd_elements_base.py ...                                                                                                                           [ 29%]
tests/io/complex/sicd_elements/test_sicd_elements_blocks.py .....................                                                                                                       [ 33%]
tests/io/complex/sicd_elements/test_sicd_elements_collectioninfo.py ..                                                                                                                  [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_errorstatistics.py .                                                                                                                  [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_geodata.py ...                                                                                                                        [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_grid.py ..                                                                                                                            [ 35%]
tests/io/complex/sicd_elements/test_sicd_elements_imagecreation.py .                                                                                                                    [ 35%]
tests/io/complex/sicd_elements/test_sicd_elements_imagedata.py .                                                                                                                        [ 35%]
tests/io/complex/sicd_elements/test_sicd_elements_imageformation.py ......                                                                                                              [ 37%]
tests/io/complex/sicd_elements/test_sicd_elements_matchinfo.py .                                                                                                                        [ 37%]
tests/io/complex/sicd_elements/test_sicd_elements_pfa.py .                                                                                                                              [ 37%]
tests/io/complex/sicd_elements/test_sicd_elements_position.py ...                                                                                                                       [ 38%]
tests/io/complex/sicd_elements/test_sicd_elements_radarcollection.py ..............                                                                                                     [ 41%]
tests/io/complex/sicd_elements/test_sicd_elements_radiometric.py .                                                                                                                      [ 41%]
tests/io/complex/sicd_elements/test_sicd_elements_rgazcomp.py .                                                                                                                         [ 41%]
tests/io/complex/sicd_elements/test_sicd_elements_rma.py ...                                                                                                                            [ 42%]
tests/io/complex/sicd_elements/test_sicd_elements_scpcoa.py ...................                                                                                                         [ 46%]
tests/io/complex/sicd_elements/test_sicd_elements_sicd.py ..................................                                                                                            [ 53%]
tests/io/complex/sicd_elements/test_sicd_elements_timeline.py .....                                                                                                                     [ 54%]
tests/io/complex/sicd_elements/test_sicd_elements_utils.py ...                                                                                                                          [ 54%]
tests/io/general/test_base.py ...                                                                                                                                                       [ 55%]
tests/io/general/test_data_segment.py ..........                                                                                                                                        [ 57%]
tests/io/general/test_format_function.py .......                                                                                                                                        [ 58%]
tests/io/general/test_nitf_headers.py s                                                                                                                                                 [ 59%]
tests/io/general/test_tre.py .                                                                                                                                                          [ 59%]
tests/io/phase_history/test_cphd.py .                                                                                                                                                   [ 59%]
tests/io/phase_history/test_cphd_versions.py .....                                                                                                                                      [ 60%]
tests/io/phase_history/cphd1_elements/test_cphd.py ....                                                                                                                                 [ 61%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_antenna.py .....                                                                                                              [ 62%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_data.py .                                                                                                                     [ 62%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_geoinfo.py ...                                                                                                                [ 63%]
tests/io/phase_history/cphd1_elements/test_utils.py .                                                                                                                                   [ 63%]
tests/io/product/test_reader.py ..s                                                                                                                                                     [ 64%]
tests/io/product/test_sidd_schema.py .........                                                                                                                                          [ 66%]
tests/io/product/test_sidd_writing.py s                                                                                                                                                 [ 66%]
tests/io/product/sidd3_elements/test_exploitationfeatures.py .......................................................................................................................... [ 91%]
........                                                                                                                                                                                [ 93%]
tests/io/product/sidd3_elements/test_sidd3_elements.py .....                                                                                                                            [ 94%]
tests/io/received/test_crsd.py .                                                                                                                                                        [ 94%]
tests/visualization/test_cphd_kmz_product_creation.py ..                                                                                                                                [ 95%]
tests/visualization/test_crsd_kmz_product_creation.py .                                                                                                                                 [ 95%]
tests/visualization/test_kmz_product_creation.py .x                                                                                                                                     [ 95%]
tests/visualization/test_remap.py ....................                                                                                                                                  [100%]

====================================================================================== warnings summary =======================================================================================
tests/test_class_string.py::TestClassString::test_class_str
  /home/vscuser/repos/int_sarpy/sarpy/annotation/afrl_rde_schema/__init__.py:7: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
    import pkg_resources

tests/geometry/test_point_projection.py::test_image_to_ground_errors
tests/geometry/test_point_projection.py::test_image_to_ground_dem
  /home/vscuser/repos/int_sarpy/sarpy/geometry/point_projection.py:1903: RuntimeWarning: divide by zero encountered in scalar divide
    lon_grid_size = min(10, lat_grid_size/abs(numpy.sin(numpy.deg2rad(ref_llh[0]))))

tests/visualization/test_cphd_kmz_product_creation.py::test_create_kmz
tests/visualization/test_cphd_kmz_product_creation.py::test_create_kmz
tests/visualization/test_cphd_kmz_product_creation.py::test_create_kmz
tests/visualization/test_cphd_kmz_product_creation.py::test_create_kmz
tests/visualization/test_cphd_kmz_product_creation.py::test_create_kmz
tests/visualization/test_cphd_kmz_product_creation.py::test_create_kmz
  /home/vscuser/repos/int_sarpy/sarpy/visualization/kmz_utils.py:302: MatplotlibDeprecationWarning: The collections attribute was deprecated in Matplotlib 3.8 and will be removed two minor releases later.
    for path in contour_sets.collections[0].get_paths()

tests/visualization/test_kmz_product_creation.py::test_create_kmz[True]
  /home/vscuser/repos/int_sarpy/sarpy/visualization/kmz_utils.py:145: RuntimeWarning: invalid value encountered in scalar divide
    distance = (

tests/visualization/test_remap.py::TestRemap::test_LUTRemap_matplotlib
tests/visualization/test_remap.py::TestRemap::test_remap_names
tests/visualization/test_remap.py::TestRemap::test_remap_names
tests/visualization/test_remap.py::TestRemap::test_remap_names
tests/visualization/test_remap.py::TestRemap::test_remap_names
  /home/vscuser/repos/int_sarpy/sarpy/visualization/remap.py:1562: MatplotlibDeprecationWarning: The get_cmap function was deprecated in Matplotlib 3.7 and will be removed two minor releases later. Use ``matplotlib.colormaps[name]`` or ``matplotlib.colormaps.get_cmap(obj)`` instead.
    cmap = cm.get_cmap(value, max_out_size+1)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================== 463 passed, 14 skipped, 1 xfailed, 15 warnings in 22.06s ===================================================================
nox > Session test(version='3.11') was successful.
nox > Ran multiple sessions:
nox > * test(version='3.6'): success
nox > * test(version='3.11'): success


```

</details>