### PR TITLE
Unclosed file objects in NITF/CPHD writer close methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ release points are not being annotated in GitHub.
 - SIDD `TimeCOAPoly` calculation
 - Set SIDD Display/Interpolation/Operation values to CORRELATION
 - `sarpy.io.phase_history.cphd1_elements.PVP.PVPType.get_size()`
+- Properly close file objects in NITF and CPHD writers
 
 ## [1.3.58] - 2023-08-07
 ### Added

--- a/README.md
+++ b/README.md
@@ -155,11 +155,18 @@ end-of-life are unlikely to be considered.
 Information regarding any discovered bugs would be greatly appreciated, so please
 feel free to create a GitHub issue. If more appropriate, contact wade.c.schwartzkopf@nga.mil.
 
+Integration Branches
+--------------------
+Integration branches (branches prefixed with `integration/`) are used to stage content under
+consideration for inclusion in the `master` branch and future SarPy releases.
+These branches can be used to access features and bug fixes that have not been fully released.
+
 Pull Requests
 -------------
 Efforts at direct contribution to the project are certainly welcome, and please
-feel free to make a pull request. Note that any and all contributions to this 
-project will be released under the MIT license.
+feel free to make a pull request. Pull requests should be authored against the `master`
+branch but may be retargeted to a suitable integration branch upon review.
+Note that any and all contributions to this project will be released under the MIT license.
 
 Software source code previously released under an open source license and then 
 modified by NGA staff is considered a "joint work" (see 17 USC 101); it is partially 

--- a/sarpy/io/general/nitf.py
+++ b/sarpy/io/general/nitf.py
@@ -4175,4 +4175,4 @@ class NITFWriter(BaseWriter):
 
         self._nitf_writing_details = None
         self._image_segment_data_segments = None
-        self._file_object = None
+        self._file_object.close()

--- a/sarpy/io/phase_history/cphd.py
+++ b/sarpy/io/phase_history/cphd.py
@@ -1864,4 +1864,4 @@ class CPHDWriter1(BaseWriter):
         except AttributeError:
             pass
         self._writing_details = None
-        self._file_object = None
+        self._file_object.close()


### PR DESCRIPTION
# Description
Closes #404

This MR addresses #404 by adding a missing `_file_object.close()` to the `close` methods of the NITFWriter and CPHDWriter1.

I originally intended to keep the `_file_object = None` behavior intact, however when I did so, I found that the `close` methods were being called twice: the first time was explicitly in the code (or implicit in the case of a context manager) and a second time in a `__del__` method. We _could_ code around this, but nothing seemed to rely on this behavior and it seemed unecessary given that `close` is idempotent.

# Test Plan
I was able to reproduce the original issue in the unittests when run with `python -Wd`

<details><summary>current behavior</summary>

note all of the `ResourceWarning: unclosed file...`

```
python -Wd -m pytest tests/
============================================================================================================================================================================ test session starts ============================================================================================================================================================================
platform linux -- Python 3.11.5, pytest-7.4.2, pluggy-1.3.0
rootdir: /home/vscuser/git/glweb/software/third-party/sarpy
collected 529 items                                                                                                                                                                                                                                                                                                                                                         

tests/test_class_string.py .                                                                                                                                                                                                                                                                                                                                          [  0%]
tests/visualization/test_remap.py ....................                                                                                                                                                                                                                                                                                                                [100%]

============================================================================================================================================================================= warnings summary ==============================================================================================================================================================================
tests/test_class_string.py::TestClassString::test_class_str
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/annotation/afrl_rde_schema/__init__.py:7: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
    import pkg_resources

tests/geometry/test_point_projection.py::test_image_to_ground_errors
tests/geometry/test_point_projection.py::test_image_to_ground_dem
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/geometry/point_projection.py:1903: RuntimeWarning: divide by zero encountered in scalar divide
    lon_grid_size = min(10, lat_grid_size/abs(numpy.sin(numpy.deg2rad(ref_llh[0]))))

tests/io/complex/test_sicd.py::TestSICDWriting::test_sicd_creation
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/io/general/nitf.py:4178: ResourceWarning: unclosed file <_io.BufferedWriter name='/data/tmp/tmp4oozhhsv/20160921f01p0009faradx0613_284_21114HH_001_164107_SL0005R_35N107W_001X___QHH_0101_SPY_SICD.nitf'>
    self._file_object = None
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

tests/io/complex/test_sicd.py::TestSICDWriting::test_sicd_creation
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/io/general/nitf.py:4178: ResourceWarning: unclosed file <_io.BufferedWriter name='/data/tmp/tmprr2m7a3u/20160921f01p0009faradx0613_284_21114HH_001_164107_SL0005R_35N107W_001X___QHH_0101_SPY_SICD.nitf'>
    self._file_object = None
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

tests/io/complex/test_sicd.py::TestSICDWriting::test_sicd_creation
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/io/general/nitf.py:4178: ResourceWarning: unclosed file <_io.BufferedWriter name='/data/tmp/tmp_z90puwt/C21_N93_D_SL_spot_072_R_2008-01-27T05_17_46.760537Z_001_051745_DS0139R_48N012E_001X___SHH_0101_SPY_SICD.nitf'>
    self._file_object = None
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

tests/io/complex/test_sicd.py::TestSICDWriting::test_sicd_creation
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/io/general/nitf.py:4178: ResourceWarning: unclosed file <_io.BufferedWriter name='/data/tmp/tmpc8sul32l/C21_N93_D_SL_spot_072_R_2008-01-27T05_17_46.760537Z_001_051745_DS0139R_48N012E_001X___SHH_0101_SPY_SICD.nitf'>
    self._file_object = None
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

tests/io/complex/test_sicd.py::TestSICDWriting::test_sicd_creation
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/io/general/nitf.py:4178: ResourceWarning: unclosed file <_io.BufferedWriter name='/data/tmp/tmpq7ozq4dt/C21_N93_D_SL_spot_072_R_2008-01-27T05_17_46.760537Z_001_051745_DS0139R_48N012E_001X___SHH_0101_SPY_SICD.nitf'>
    self._file_object = None
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

tests/io/complex/test_sicd.py::TestSICDWriting::test_sicd_creation
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/io/general/nitf.py:4178: ResourceWarning: unclosed file <_io.BufferedWriter name='/data/tmp/tmpd0zpf440/C21_N93_D_SL_spot_072_R_2008-01-27T05_17_46.760537Z_001_051745_DS0139R_48N012E_001X___SHH_0101_SPY_SICD.nitf'>
    self._file_object = None
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

tests/io/phase_history/test_cphd.py::TestCPHD::test_cphd_io
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/io/phase_history/cphd.py:1867: ResourceWarning: unclosed file <_io.BufferedWriter name='/data/tmp/tmpv3htkqpi/example_cphd.cphd'>
    self._file_object = None
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

tests/io/phase_history/test_cphd.py::TestCPHD::test_cphd_io
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/io/phase_history/cphd.py:1867: ResourceWarning: unclosed file <_io.BufferedWriter name='/data/tmp/tmpa6jr4e26/example_cphd.cphd'>
    self._file_object = None
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

tests/io/product/test_sidd_writing.py::TestSIDDWriting::test_sidd_creation
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/io/general/nitf.py:4178: ResourceWarning: unclosed file <_io.BufferedWriter name='/data/tmp/tmpntmcn3zk/di_1.nitf'>
    self._file_object = None
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

tests/io/product/test_sidd_writing.py::TestSIDDWriting::test_sidd_creation
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/io/general/nitf.py:4178: ResourceWarning: unclosed file <_io.BufferedWriter name='/data/tmp/tmpntmcn3zk/di_2.nitf'>
    self._file_object = None
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

tests/io/product/test_sidd_writing.py::TestSIDDWriting::test_sidd_creation
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/io/general/nitf.py:4178: ResourceWarning: unclosed file <_io.BufferedWriter name='/data/tmp/tmpntmcn3zk/di_3.nitf'>
    self._file_object = None
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

tests/io/product/test_sidd_writing.py::TestSIDDWriting::test_sidd_creation
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/io/general/nitf.py:4178: ResourceWarning: unclosed file <_io.BufferedWriter name='/data/tmp/tmpntmcn3zk/csi_1.nitf'>
    self._file_object = None
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

tests/io/product/test_sidd_writing.py::TestSIDDWriting::test_sidd_creation
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/io/general/nitf.py:4178: ResourceWarning: unclosed file <_io.BufferedWriter name='/data/tmp/tmpntmcn3zk/csi_2.nitf'>
    self._file_object = None
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

tests/io/product/test_sidd_writing.py::TestSIDDWriting::test_sidd_creation
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/io/general/nitf.py:4178: ResourceWarning: unclosed file <_io.BufferedWriter name='/data/tmp/tmpntmcn3zk/csi_3.nitf'>
    self._file_object = None
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

tests/io/product/test_sidd_writing.py::TestSIDDWriting::test_sidd_creation
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/io/general/nitf.py:4178: ResourceWarning: unclosed file <_io.BufferedWriter name='/data/tmp/tmpntmcn3zk/sast_1.nitf'>
    self._file_object = None
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

tests/io/product/test_sidd_writing.py::TestSIDDWriting::test_sidd_creation
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/io/general/nitf.py:4178: ResourceWarning: unclosed file <_io.BufferedWriter name='/data/tmp/tmpntmcn3zk/sast_2.nitf'>
    self._file_object = None
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

tests/io/product/test_sidd_writing.py::TestSIDDWriting::test_sidd_creation
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/io/general/nitf.py:4178: ResourceWarning: unclosed file <_io.BufferedWriter name='/data/tmp/tmpntmcn3zk/sast_3.nitf'>
    self._file_object = None
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

tests/io/received/test_crsd.py::TestCRSD::test_crsd_io
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/io/phase_history/cphd.py:1867: ResourceWarning: unclosed file <_io.BufferedWriter name='/data/tmp/tmpptbhcrme/example_crsd.crsd'>
    self._file_object = None
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

tests/utils/test_sicd_sidelobe_control.py::test_sicd_sidelobe_control_pars[/data/sarpy_test/sicd/sicd_example_1_PFA_RE32F_IM32F_HH.nitf]
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/io/general/nitf.py:4178: ResourceWarning: unclosed file <_io.BufferedWriter name='/data/tmp/tmp8do7ora6/sicd_taper.nitf'>
    self._file_object = None
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

tests/utils/test_sicd_to_sidd.py::test_sicd_to_sidd_help
tests/visualization/test_remap.py::TestRemap::test_LUTRemap_matplotlib
tests/visualization/test_remap.py::TestRemap::test_remap_names
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/visualization/remap.py:1751: MatplotlibDeprecationWarning: The get_cmap function was deprecated in Matplotlib 3.7 and will be removed two minor releases later. Use ``matplotlib.colormaps[name]`` or ``matplotlib.colormaps.get_cmap(obj)`` instead.
    cmap = cm.get_cmap(value, max_out_size+1)

tests/utils/test_sicd_to_sidd.py::test_sicd_to_sidd_without_taper[/data/sarpy_test/sicd/sicd_example_1_PFA_RE32F_IM32F_HH.nitf]
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/io/general/nitf.py:4178: ResourceWarning: unclosed file <_io.BufferedWriter name='/data/tmp/tmpbxftolm4/20160921f01p0009faradx0613_284_21114HH_000_164107_SL0005R_35N107W_001X___QHH_0101_SPY_IMG.nitf'>
    self._file_object = None
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

tests/utils/test_sicd_to_sidd.py::test_sicd_to_sidd_with_taper[/data/sarpy_test/sicd/sicd_example_1_PFA_RE32F_IM32F_HH.nitf]
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/io/general/nitf.py:4178: ResourceWarning: unclosed file <_io.BufferedWriter name='/data/tmp/tmpw_b3djsi/windowed_sicd.nitf'>
    self._file_object = None
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

tests/utils/test_sicd_to_sidd.py::test_sicd_to_sidd_with_taper[/data/sarpy_test/sicd/sicd_example_1_PFA_RE32F_IM32F_HH.nitf]
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/io/general/nitf.py:4178: ResourceWarning: unclosed file <_io.BufferedWriter name='/data/tmp/tmpih85xwf7/20160921f01p0009faradx0613_284_21114HH_000_164107_SL0007R_35N107W_001X___QHH_0101_SPY_IMG.nitf'>
    self._file_object = None
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

tests/utils/test_sicd_to_sidd.py::test_sicd_to_sidd_remap[density-/data/sarpy_test/sicd/sicd_example_1_PFA_RE32F_IM32F_HH.nitf]
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/io/general/nitf.py:4178: ResourceWarning: unclosed file <_io.BufferedWriter name='/data/tmp/tmpltd7fzsd/20160921f01p0009faradx0613_284_21114HH_000_164107_SL0005R_35N107W_001X___QHH_0101_SPY_IMG.nitf'>
    self._file_object = None
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

tests/utils/test_sicd_to_sidd.py::test_sicd_to_sidd_remap[high_contrast-/data/sarpy_test/sicd/sicd_example_1_PFA_RE32F_IM32F_HH.nitf]
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/io/general/nitf.py:4178: ResourceWarning: unclosed file <_io.BufferedWriter name='/data/tmp/tmpjvq82e46/20160921f01p0009faradx0613_284_21114HH_000_164107_SL0005R_35N107W_001X___QHH_0101_SPY_IMG.nitf'>
    self._file_object = None
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

tests/utils/test_sicd_to_sidd.py::test_sicd_to_sidd_remap[brighter-/data/sarpy_test/sicd/sicd_example_1_PFA_RE32F_IM32F_HH.nitf]
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/io/general/nitf.py:4178: ResourceWarning: unclosed file <_io.BufferedWriter name='/data/tmp/tmpz4rcgfgl/20160921f01p0009faradx0613_284_21114HH_000_164107_SL0005R_35N107W_001X___QHH_0101_SPY_IMG.nitf'>
    self._file_object = None
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

tests/utils/test_sicd_to_sidd.py::test_sicd_to_sidd_remap[darker-/data/sarpy_test/sicd/sicd_example_1_PFA_RE32F_IM32F_HH.nitf]
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/io/general/nitf.py:4178: ResourceWarning: unclosed file <_io.BufferedWriter name='/data/tmp/tmp0ftz_bwo/20160921f01p0009faradx0613_284_21114HH_000_164107_SL0005R_35N107W_001X___QHH_0101_SPY_IMG.nitf'>
    self._file_object = None
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

tests/utils/test_sicd_to_sidd.py::test_sicd_to_sidd_remap[pedf-/data/sarpy_test/sicd/sicd_example_1_PFA_RE32F_IM32F_HH.nitf]
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/io/general/nitf.py:4178: ResourceWarning: unclosed file <_io.BufferedWriter name='/data/tmp/tmpjydpv_ln/20160921f01p0009faradx0613_284_21114HH_000_164107_SL0005R_35N107W_001X___QHH_0101_SPY_IMG.nitf'>
    self._file_object = None
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

tests/utils/test_sicd_to_sidd.py::test_sicd_to_sidd_remap[gdm-/data/sarpy_test/sicd/sicd_example_1_PFA_RE32F_IM32F_HH.nitf]
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/io/general/nitf.py:4178: ResourceWarning: unclosed file <_io.BufferedWriter name='/data/tmp/tmp0raas4ii/20160921f01p0009faradx0613_284_21114HH_000_164107_SL0005R_35N107W_001X___QHH_0101_SPY_IMG.nitf'>
    self._file_object = None
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

tests/utils/test_sicd_to_sidd.py::test_sicd_to_sidd_remap[linear-/data/sarpy_test/sicd/sicd_example_1_PFA_RE32F_IM32F_HH.nitf]
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/io/general/nitf.py:4178: ResourceWarning: unclosed file <_io.BufferedWriter name='/data/tmp/tmp3z9rolfg/20160921f01p0009faradx0613_284_21114HH_000_164107_SL0005R_35N107W_001X___QHH_0101_SPY_IMG.nitf'>
    self._file_object = None
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

tests/utils/test_sicd_to_sidd.py::test_sicd_to_sidd_remap[log-/data/sarpy_test/sicd/sicd_example_1_PFA_RE32F_IM32F_HH.nitf]
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/io/general/nitf.py:4178: ResourceWarning: unclosed file <_io.BufferedWriter name='/data/tmp/tmp2qf2gqon/20160921f01p0009faradx0613_284_21114HH_000_164107_SL0005R_35N107W_001X___QHH_0101_SPY_IMG.nitf'>
    self._file_object = None
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

tests/utils/test_sicd_to_sidd.py::test_sicd_to_sidd_remap[nrl-/data/sarpy_test/sicd/sicd_example_1_PFA_RE32F_IM32F_HH.nitf]
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/io/general/nitf.py:4178: ResourceWarning: unclosed file <_io.BufferedWriter name='/data/tmp/tmprzzt54zu/20160921f01p0009faradx0613_284_21114HH_000_164107_SL0005R_35N107W_001X___QHH_0101_SPY_IMG.nitf'>
    self._file_object = None
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

tests/visualization/test_cphd_kmz_product_creation.py::test_create_kmz
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/visualization/kmz_utils.py:302: MatplotlibDeprecationWarning: The collections attribute was deprecated in Matplotlib 3.8 and will be removed two minor releases later.
    for path in contour_sets.collections[0].get_paths()

tests/visualization/test_crsd_kmz_product_creation.py::test_create_kmz
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/io/phase_history/cphd.py:1867: ResourceWarning: unclosed file <_io.BufferedWriter name='/data/tmp/pytest-of-vscuser/pytest-295/test_create_kmz1/receive_only.crsd'>
    self._file_object = None
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

tests/visualization/test_kmz_product_creation.py::test_create_kmz[True]
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/visualization/kmz_utils.py:145: RuntimeWarning: invalid value encountered in scalar divide
    distance = (

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
==================================================================================================================================================== 516 passed, 12 skipped, 1 xfailed, 40 warnings in 152.96s (0:02:32) ====================================================================================================================================================

```

</details>

<details><summary>proposed behavior</summary>

```
============================================================================================================================================================================ test session starts ============================================================================================================================================================================
platform linux -- Python 3.11.5, pytest-7.4.2, pluggy-1.3.0
rootdir: /home/vscuser/git/glweb/software/third-party/sarpy
collected 529 items                                                                                                                                                                                                                                                                                                                                                         

tests/test_class_string.py .                                                                                                                                                                                                                                                                                                                                          [  0%]
tests/visualization/test_remap.py ....................                                                                                                                                                                                                                                                                                                                [100%]

============================================================================================================================================================================= warnings summary ==============================================================================================================================================================================
tests/test_class_string.py::TestClassString::test_class_str
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/annotation/afrl_rde_schema/__init__.py:7: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
    import pkg_resources

tests/geometry/test_point_projection.py::test_image_to_ground_errors
tests/geometry/test_point_projection.py::test_image_to_ground_dem
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/geometry/point_projection.py:1903: RuntimeWarning: divide by zero encountered in scalar divide
    lon_grid_size = min(10, lat_grid_size/abs(numpy.sin(numpy.deg2rad(ref_llh[0]))))

tests/utils/test_sicd_to_sidd.py::test_sicd_to_sidd_help
tests/visualization/test_remap.py::TestRemap::test_LUTRemap_matplotlib
tests/visualization/test_remap.py::TestRemap::test_remap_names
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/visualization/remap.py:1751: MatplotlibDeprecationWarning: The get_cmap function was deprecated in Matplotlib 3.7 and will be removed two minor releases later. Use ``matplotlib.colormaps[name]`` or ``matplotlib.colormaps.get_cmap(obj)`` instead.
    cmap = cm.get_cmap(value, max_out_size+1)

tests/visualization/test_cphd_kmz_product_creation.py::test_create_kmz
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/visualization/kmz_utils.py:302: MatplotlibDeprecationWarning: The collections attribute was deprecated in Matplotlib 3.8 and will be removed two minor releases later.
    for path in contour_sets.collections[0].get_paths()

tests/visualization/test_kmz_product_creation.py::test_create_kmz[True]
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/visualization/kmz_utils.py:145: RuntimeWarning: invalid value encountered in scalar divide
    distance = (

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
==================================================================================================================================================== 516 passed, 12 skipped, 1 xfailed, 8 warnings in 151.73s (0:02:31) =====================================================================================================================================================

```

</details>

<details><summary>multi-environment tests pass</summary>

```
nox
nox > Running session test(version='3.6')
nox > Creating conda env in .nox/test-version-3-6 with python
nox > conda install --yes --prefix /home/vscuser/git/glweb/software/third-party/sarpy/.nox/test-version-3-6 python=3.6
nox > python -m pip install '.[all]'
nox > pytest tests
============================================================================================================================================================================ test session starts ============================================================================================================================================================================
platform linux -- Python 3.6.13, pytest-7.0.1, pluggy-1.0.0
rootdir: /home/vscuser/git/glweb/software/third-party/sarpy
collected 529 items                                                                                                                                                                                                                                                                                                                                                         

tests/test_class_string.py .                                                                                                                                                                                                                                                                                                                                          [  0%]
...
tests/visualization/test_remap.py ....................                                                                                                                                                                                                                                                                                                                [100%]

============================================================================================================================================================================= warnings summary ==============================================================================================================================================================================
tests/geometry/test_point_projection.py::test_image_to_ground_errors
tests/geometry/test_point_projection.py::test_image_to_ground_dem
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/geometry/point_projection.py:1903: RuntimeWarning: divide by zero encountered in double_scalars
    lon_grid_size = min(10, lat_grid_size/abs(numpy.sin(numpy.deg2rad(ref_llh[0]))))

tests/visualization/test_kmz_product_creation.py::test_create_kmz[True]
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/visualization/kmz_utils.py:169: RuntimeWarning: invalid value encountered in double_scalars
    + dir_z**2 * semiaxis_a**2 * semiaxis_b**2

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
==================================================================================================================================================== 514 passed, 14 skipped, 1 xfailed, 3 warnings in 169.14s (0:02:49) =====================================================================================================================================================
nox > Session test(version='3.6') was successful.
nox > Running session test(version='3.11')
nox > Creating conda env in .nox/test-version-3-11 with python
nox > conda install --yes --prefix /home/vscuser/git/glweb/software/third-party/sarpy/.nox/test-version-3-11 python=3.11
nox > python -m pip install '.[all]'
nox > pytest tests
============================================================================================================================================================================ test session starts ============================================================================================================================================================================
platform linux -- Python 3.11.5, pytest-7.4.3, pluggy-1.3.0
rootdir: /home/vscuser/git/glweb/software/third-party/sarpy
collected 529 items                                                                                                                                                                                                                                                                                                                                                         

tests/test_class_string.py .                                                                                                                                                                                                                                                                                                                                          [  0%]
tests/consistency/test_consistency.py ........                                                                                                                                                                                                                                                                                                                        [  1%]
tests/consistency/test_cphd_consistency.py ..............................................................                                                                                                                                                                                                                                                             [ 13%]
tests/geometry/test_geocoords.py ..........                                                                                                                                                                                                                                                                                                                           [ 15%]
tests/geometry/test_geometry_elements.py ..........                                                                                                                                                                                                                                                                                                                   [ 17%]
tests/geometry/test_latlon.py ...                                                                                                                                                                                                                                                                                                                                     [ 17%]
tests/geometry/test_point_projection.py ............                                                                                                                                                                                                                                                                                                                  [ 20%]
tests/io/test_kml.py .                                                                                                                                                                                                                                                                                                                                                [ 20%]
tests/io/DEM/test_geoid.py .                                                                                                                                                                                                                                                                                                                                          [ 20%]
tests/io/DEM/test_geotiff1deg_list.py ....                                                                                                                                                                                                                                                                                                                            [ 21%]
tests/io/DEM/test_geotiff1deg_reader.py ........                                                                                                                                                                                                                                                                                                                      [ 22%]
tests/io/complex/test_other_nitf.py ...                                                                                                                                                                                                                                                                                                                               [ 23%]
tests/io/complex/test_reader.py .ssssssssss                                                                                                                                                                                                                                                                                                                           [ 25%]
tests/io/complex/test_remote.py s                                                                                                                                                                                                                                                                                                                                     [ 25%]
tests/io/complex/test_sicd.py .                                                                                                                                                                                                                                                                                                                                       [ 25%]
tests/io/complex/test_utils.py .                                                                                                                                                                                                                                                                                                                                      [ 25%]
tests/io/complex/sicd_elements/test_sicd_elements_antenna.py ...                                                                                                                                                                                                                                                                                                      [ 26%]
tests/io/complex/sicd_elements/test_sicd_elements_base.py ...                                                                                                                                                                                                                                                                                                         [ 27%]
tests/io/complex/sicd_elements/test_sicd_elements_blocks.py .....................                                                                                                                                                                                                                                                                                     [ 31%]
tests/io/complex/sicd_elements/test_sicd_elements_collectioninfo.py ..                                                                                                                                                                                                                                                                                                [ 31%]
tests/io/complex/sicd_elements/test_sicd_elements_errorstatistics.py .                                                                                                                                                                                                                                                                                                [ 31%]
tests/io/complex/sicd_elements/test_sicd_elements_geodata.py ...                                                                                                                                                                                                                                                                                                      [ 32%]
tests/io/complex/sicd_elements/test_sicd_elements_grid.py ..                                                                                                                                                                                                                                                                                                          [ 32%]
tests/io/complex/sicd_elements/test_sicd_elements_imagecreation.py .                                                                                                                                                                                                                                                                                                  [ 32%]
tests/io/complex/sicd_elements/test_sicd_elements_imagedata.py .                                                                                                                                                                                                                                                                                                      [ 32%]
tests/io/complex/sicd_elements/test_sicd_elements_imageformation.py ......                                                                                                                                                                                                                                                                                            [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_matchinfo.py .                                                                                                                                                                                                                                                                                                      [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_pfa.py .                                                                                                                                                                                                                                                                                                            [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_position.py ...                                                                                                                                                                                                                                                                                                     [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_radarcollection.py ..............                                                                                                                                                                                                                                                                                   [ 37%]
tests/io/complex/sicd_elements/test_sicd_elements_radiometric.py .                                                                                                                                                                                                                                                                                                    [ 37%]
tests/io/complex/sicd_elements/test_sicd_elements_rgazcomp.py .                                                                                                                                                                                                                                                                                                       [ 37%]
tests/io/complex/sicd_elements/test_sicd_elements_rma.py ...                                                                                                                                                                                                                                                                                                          [ 38%]
tests/io/complex/sicd_elements/test_sicd_elements_scpcoa.py ...................                                                                                                                                                                                                                                                                                       [ 42%]
tests/io/complex/sicd_elements/test_sicd_elements_sicd.py ..................................                                                                                                                                                                                                                                                                          [ 48%]
tests/io/complex/sicd_elements/test_sicd_elements_timeline.py .....                                                                                                                                                                                                                                                                                                   [ 49%]
tests/io/complex/sicd_elements/test_sicd_elements_utils.py ...                                                                                                                                                                                                                                                                                                        [ 50%]
tests/io/general/test_base.py ...                                                                                                                                                                                                                                                                                                                                     [ 50%]
tests/io/general/test_data_segment.py ..........                                                                                                                                                                                                                                                                                                                      [ 52%]
tests/io/general/test_format_function.py .......                                                                                                                                                                                                                                                                                                                      [ 53%]
tests/io/general/test_nitf_headers.py .                                                                                                                                                                                                                                                                                                                               [ 54%]
tests/io/general/test_tre.py .                                                                                                                                                                                                                                                                                                                                        [ 54%]
tests/io/phase_history/test_cphd.py .                                                                                                                                                                                                                                                                                                                                 [ 54%]
tests/io/phase_history/test_cphd_versions.py .....                                                                                                                                                                                                                                                                                                                    [ 55%]
tests/io/phase_history/cphd1_elements/test_cphd.py ....                                                                                                                                                                                                                                                                                                               [ 56%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_antenna.py .....                                                                                                                                                                                                                                                                                            [ 57%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_blocks.py ....                                                                                                                                                                                                                                                                                              [ 57%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_channel.py .                                                                                                                                                                                                                                                                                                [ 58%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_data.py .                                                                                                                                                                                                                                                                                                   [ 58%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_dwell.py .                                                                                                                                                                                                                                                                                                  [ 58%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_geoinfo.py ...                                                                                                                                                                                                                                                                                              [ 58%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_global.py ..                                                                                                                                                                                                                                                                                                [ 59%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_pvp.py .                                                                                                                                                                                                                                                                                                    [ 59%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_referencegeometry.py .                                                                                                                                                                                                                                                                                      [ 59%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_supportarray.py ..                                                                                                                                                                                                                                                                                          [ 60%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_txrcv.py .                                                                                                                                                                                                                                                                                                  [ 60%]
tests/io/phase_history/cphd1_elements/test_utils.py .                                                                                                                                                                                                                                                                                                                 [ 60%]
tests/io/product/test_reader.py ..s                                                                                                                                                                                                                                                                                                                                   [ 61%]
tests/io/product/test_sidd_schema.py .........                                                                                                                                                                                                                                                                                                                        [ 62%]
tests/io/product/test_sidd_writing.py .                                                                                                                                                                                                                                                                                                                               [ 62%]
tests/io/product/sidd3_elements/test_exploitationfeatures.py ..................................................................................................................................                                                                                                                                                                       [ 87%]
tests/io/product/sidd3_elements/test_sidd3_elements.py .....                                                                                                                                                                                                                                                                                                          [ 88%]
tests/io/received/test_crsd.py .                                                                                                                                                                                                                                                                                                                                      [ 88%]
tests/processing/sicd/test_spectral_taper.py .....................                                                                                                                                                                                                                                                                                                    [ 92%]
tests/utils/test_sicd_sidelobe_control.py ..                                                                                                                                                                                                                                                                                                                          [ 93%]
tests/utils/test_sicd_to_sidd.py ............                                                                                                                                                                                                                                                                                                                         [ 95%]
tests/visualization/test_cphd_kmz_product_creation.py ..                                                                                                                                                                                                                                                                                                              [ 95%]
tests/visualization/test_crsd_kmz_product_creation.py .                                                                                                                                                                                                                                                                                                               [ 95%]
tests/visualization/test_kmz_product_creation.py .x                                                                                                                                                                                                                                                                                                                   [ 96%]
tests/visualization/test_remap.py ....................                                                                                                                                                                                                                                                                                                                [100%]

============================================================================================================================================================================= warnings summary ==============================================================================================================================================================================
tests/test_class_string.py::TestClassString::test_class_str
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/annotation/afrl_rde_schema/__init__.py:7: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
    import pkg_resources

tests/geometry/test_point_projection.py::test_image_to_ground_errors
tests/geometry/test_point_projection.py::test_image_to_ground_dem
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/geometry/point_projection.py:1903: RuntimeWarning: divide by zero encountered in scalar divide
    lon_grid_size = min(10, lat_grid_size/abs(numpy.sin(numpy.deg2rad(ref_llh[0]))))

tests/utils/test_sicd_to_sidd.py::test_sicd_to_sidd_help
tests/utils/test_sicd_to_sidd.py::test_sicd_to_sidd_help
tests/utils/test_sicd_to_sidd.py::test_sicd_to_sidd_help
tests/utils/test_sicd_to_sidd.py::test_sicd_to_sidd_help
tests/visualization/test_remap.py::TestRemap::test_LUTRemap_matplotlib
tests/visualization/test_remap.py::TestRemap::test_remap_names
tests/visualization/test_remap.py::TestRemap::test_remap_names
tests/visualization/test_remap.py::TestRemap::test_remap_names
tests/visualization/test_remap.py::TestRemap::test_remap_names
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/visualization/remap.py:1751: MatplotlibDeprecationWarning: The get_cmap function was deprecated in Matplotlib 3.7 and will be removed two minor releases later. Use ``matplotlib.colormaps[name]`` or ``matplotlib.colormaps.get_cmap(obj)`` instead.
    cmap = cm.get_cmap(value, max_out_size+1)

tests/visualization/test_cphd_kmz_product_creation.py::test_create_kmz
tests/visualization/test_cphd_kmz_product_creation.py::test_create_kmz
tests/visualization/test_cphd_kmz_product_creation.py::test_create_kmz
tests/visualization/test_cphd_kmz_product_creation.py::test_create_kmz
tests/visualization/test_cphd_kmz_product_creation.py::test_create_kmz
tests/visualization/test_cphd_kmz_product_creation.py::test_create_kmz
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/visualization/kmz_utils.py:302: MatplotlibDeprecationWarning: The collections attribute was deprecated in Matplotlib 3.8 and will be removed two minor releases later.
    for path in contour_sets.collections[0].get_paths()

tests/visualization/test_kmz_product_creation.py::test_create_kmz[True]
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/visualization/kmz_utils.py:145: RuntimeWarning: invalid value encountered in scalar divide
    distance = (

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
==================================================================================================================================================== 516 passed, 12 skipped, 1 xfailed, 19 warnings in 151.73s (0:02:31) ====================================================================================================================================================
nox > Session test(version='3.11') was successful.
nox > Ran multiple sessions:
nox > * test(version='3.6'): success
nox > * test(version='3.11'): success

```

</details>