### PR TITLE
Add unit tests for sicd_consistency and bugfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ release points are not being annotated in GitHub.
 - `--remap` argument to `sarpy/utils/create_product.py`
 - `sarpy/utils/sicd_to_sidd.py`
 - `GDM` to `sarpy/visualization/remap.py`
+- Unit tests for `sarpy/consistency/sicd_consistency.py`
 ### Fixed
 - `sarpy.io.kml.add_polygon` coordinate conditioning for older numpy versions
 - Replace unsupported `pillow` constant `Image.ANTIALIAS` with `Image.LANCZOS`
@@ -25,6 +26,9 @@ release points are not being annotated in GitHub.
 - SIDD `TimeCOAPoly` calculation
 - Set SIDD Display/Interpolation/Operation values to CORRELATION
 - `sarpy.io.phase_history.cphd1_elements.PVP.PVPType.get_size()`
+- SICD file reading in `sarpy/consistency/sicd_consistency.py`
+- Protect waveform validation from `waveform.TxFreqStart == None` in `sarpy/io/complex/sicd_elements/RadarCollection.py`
+- Fix `sarpy/io/complex/sicd_elements/Timeline.py` validation code to allow IPP T1End == T2Start
 
 ## [1.3.58] - 2023-08-07
 ### Added

--- a/sarpy/consistency/sicd_consistency.py
+++ b/sarpy/consistency/sicd_consistency.py
@@ -47,7 +47,6 @@ def evaluate_xml_versus_schema(xml_string, urn_string):
     -------
     None|bool
     """
-
     try:
         the_schema = get_schema_path(urn_string)
     except KeyError:
@@ -370,19 +369,20 @@ def check_file(file_name):
         with open(file_name, 'rb') as fi:
             initial_bits = fi.read(30)
             if initial_bits.startswith(b'<?xml') or initial_bits.startswith(b'<SICD'):
+                fi.seek(0)
                 sicd_xml = fi.read()
                 return _evaluate_xml_string_validity(sicd_xml)[0]
 
     return check_sicd_file(file_name)
 
 
-if __name__ == '__main__':
+def main(args=None):
     parser = argparse.ArgumentParser('SICD Consistency')
     parser.add_argument('file_name')
     parser.add_argument(
         '-l', '--level', default='WARNING',
         choices=['INFO', 'WARNING', 'ERROR'], help="Logging level")
-    config = parser.parse_args()
+    config = parser.parse_args(args)
 
     logging.basicConfig(level=config.level)
     logger.setLevel(config.level)
@@ -391,4 +391,8 @@ if __name__ == '__main__':
         logger.info('\nSICD: {} has been validated with no errors'.format(config.file_name))
     else:
         logger.error('\nSICD: {} has apparent errors'.format(config.file_name))
-    sys.exit(int(validity))
+    return int(validity)
+
+
+if __name__ == '__main__':
+    sys.exit(main())    # pragma: no cover

--- a/sarpy/io/complex/sicd_elements/RadarCollection.py
+++ b/sarpy/io/complex/sicd_elements/RadarCollection.py
@@ -1090,7 +1090,7 @@ class RadarCollectionType(Serializable):
                     'be the same.'.format(waveform.RcvFMRate, waveform.TxFMRate, index+1))
 
             if self.RefFreqIndex is None:
-                if waveform.TxFreqStart <= 0:
+                if waveform.TxFreqStart is not None and waveform.TxFreqStart <= 0:
                     self.log_validity_error(
                         'TxFreqStart is negative in Waveform entry {}, but RefFreqIndex '
                         'is not populated.'.format(index+1))

--- a/sarpy/io/complex/sicd_elements/Timeline.py
+++ b/sarpy/io/complex/sicd_elements/Timeline.py
@@ -174,7 +174,7 @@ class TimelineType(Serializable):
                     'IPP entry {} IPPEnd ({}) is not consecutive with '
                     'entry {} IPPStart ({})'.format(i, el1.IPPEnd, i+1, el2.IPPStart))
                 cond = False
-            if el1.TEnd >= el2.TStart:
+            if el1.TEnd > el2.TStart:
                 self.log_validity_error(
                     'IPP entry {} TEnd ({}) is greater than entry {} TStart ({})'.format(i, el1.TEnd, i+1, el2.TStart))
         return cond

--- a/tests/consistency/consistency_file_types.json
+++ b/tests/consistency/consistency_file_types.json
@@ -1,0 +1,5 @@
+{
+  "inconsistent_sicd":  [
+    {"path":  "sicd/sicd_example_1_PFA_RE32F_IM32F_HH.nitf", "path_type":  "relative"}
+  ]
+}

--- a/tests/consistency/test_sicd_consistency.py
+++ b/tests/consistency/test_sicd_consistency.py
@@ -1,0 +1,58 @@
+#
+# Copyright 2023 Valkyrie Systems Corporation
+#
+# Licensed under MIT License.  See LICENSE.
+#
+import os
+import pathlib
+
+import pytest
+
+import sarpy.consistency.sicd_consistency as sc
+from tests import find_test_data_files
+
+TEST_FILE_PATHS = {}
+TEST_FILE_ROOT = os.environ.get('SARPY_TEST_PATH', None)
+if TEST_FILE_ROOT is not None:
+    TEST_FILE_PATHS = find_test_data_files(pathlib.Path(__file__).parent / 'consistency_file_types.json')
+
+
+@pytest.fixture(scope="module")
+def bad_sicd():
+    file_path = TEST_FILE_PATHS.get("inconsistent_sicd", None)
+    if file_path in [None, []]:
+        pytest.skip("simple_bad sicd test file not found")
+    else:
+        return file_path[0]
+
+
+@pytest.fixture(scope="module")
+def good_sicd_xml():
+    return str(pathlib.Path(__file__).parent / "../data/example.sicd.xml")
+
+
+def test_main(bad_sicd, good_sicd_xml):
+    assert not sc.main([str(bad_sicd)])
+    assert sc.main([good_sicd_xml])
+
+
+def test_check_file(bad_sicd, good_sicd_xml):
+    assert not sc.check_file(bad_sicd)
+    assert sc.check_file(good_sicd_xml)
+
+    with pytest.raises(ValueError, match="Got string input, but it is not a valid path"):
+        sc.check_file("bad_string")
+
+
+def test_evaluate_xml_versus_schema(good_sicd_xml, caplog):
+    valid_urn = "urn:SICD:1.2.1"
+
+    with open(good_sicd_xml, "rb") as fi:
+        sicd_xml = fi.read()
+
+    assert sc.evaluate_xml_versus_schema(sicd_xml, valid_urn)
+
+    invalid_urn = "urn:SICD:1.2.3"
+    assert not sc.evaluate_xml_versus_schema(sicd_xml, invalid_urn)
+    assert "SICD: Failed getting the schema for urn" in caplog.text
+    caplog.clear()


### PR DESCRIPTION
Add unit tests for `sicd_consistency` and fix bugs that were uncovered

In this MR:
- Added new tests in `test_sicd_consistency.py`
- Fix bug in `sicd_consistency.py` where the reading of the SICD file in `check_file` fails
- Added `main()` to `sicd_consistency.py` to facilitate calls
- Fix `RadarCollection.py` waveform validation to protect from empty XML fields

<details>
<summary>The error that was fixed in RadarCollection.py</summary>

```

    def validate_entry(index, waveform):
        # type: (int, WaveformParametersType) -> bool
        this_cond = True
        try:
            if abs(waveform.TxRFBandwidth/(waveform.TxPulseLength*waveform.TxFMRate) - 1) > 1e-3:
                self.log_validity_error(
                    'The TxRFBandwidth, TxPulseLength, and TxFMRate parameters of Waveform '
                    'entry {} are inconsistent'.format(index+1))
                this_cond = False
        except (AttributeError, ValueError, TypeError):
            pass
    
        if waveform.RcvDemodType == 'CHIRP' and waveform.RcvFMRate != 0:
            self.log_validity_error(
                'RcvDemodType == "CHIRP" and RcvFMRate != 0 in Waveform entry {}'.format(index+1))
            this_cond = False
        if waveform.RcvDemodType == 'STRETCH' and \
                waveform.RcvFMRate is not None and waveform.TxFMRate is not None and \
                abs(waveform.RcvFMRate/waveform.TxFMRate - 1) > 1e-3:
            self.log_validity_warning(
                'RcvDemodType = "STRETCH", RcvFMRate = {}, and TxFMRate = {} in '
                'Waveform entry {}. The RcvFMRate and TxFMRate should very likely '
                'be the same.'.format(waveform.RcvFMRate, waveform.TxFMRate, index+1))
    
        if self.RefFreqIndex is None:
>           if waveform.TxFreqStart <= 0:
E           TypeError: '<=' not supported between instances of 'NoneType' and 'int'

sarpy/io/complex/sicd_elements/RadarCollection.py:1093: TypeError

```

</details>

<details>
<summary>The error that was fixed in sicd_consistency.py</summary>

```

    def XML(text, parser=None):
        """Parse XML document from string constant.
    
        This function can be used to embed "XML Literals" in Python code.
    
        *text* is a string containing XML data, *parser* is an
        optional parser instance, defaulting to the standard XMLParser.
    
        Returns an Element instance.
    
        """
        if not parser:
            parser = XMLParser(target=TreeBuilder())
>       parser.feed(text)
E       xml.etree.ElementTree.ParseError: junk after document element: line 9, column 2

../../miniconda3/envs/sarpy/lib/python3.10/xml/etree/ElementTree.py:1342: ParseError


```

</details>

<details>
<summary>Coverage Data</summary>

**_Main Branch_**

`pytest tests/ --cov=sarpy.consistency.sicd_consistency --cov-report term-missing`

|Name|Stmts|Miss|Cover|Missing|
|----|-----|----|-----|-------|
|sarpy/consistency/sicd_consistency.py|194|174|10%|51-60, 76-104, 122-194, 211-348, 365-376, 380-394|
|TOTAL|194|174|10%||

**_This Branch_**

`pytest tests/ --cov=sarpy.consistency.sicd_consistency --cov-report term-missing`

|Name|Stmts|Miss|Cover|Missing|
|----|-----|----|-----|-------|
|sarpy/consistency/sicd_consistency.py|196|58|70%|58-59, 77, 82, 90-92, 98, 127-128, 134-136, 146-149, 160, 169-172, 177, 182, 220-224, 227, 231, 235, 242, 246-248, 251, 253, 267-274, 280-281, 286-287, 292-293, 299-302, 305-307, 314-315, 325, 329, 343-344|
|TOTAL|196|58|70%||

</details>

</details>

<details>
<summary>Multi-environment tests results</summary>

```

[vscuser@dev-vm sarpy]$ nox
nox > Running session test(version='3.6')
nox > Creating conda env in .nox/test-version-3-6 with python
nox > conda install --yes --prefix /home/vscuser/repos/sarpy/.nox/test-version-3-6 python=3.6
nox > python -m pip install '.[all]'
nox > pytest tests
=================================================================== test session starts ====================================================================
platform linux -- Python 3.6.13, pytest-7.0.1, pluggy-1.0.0
rootdir: /home/vscuser/repos/sarpy
collected 530 items                                                                                                                                        

tests/test_class_string.py .                                                                                                                         [  0%]
tests/consistency/test_consistency.py ........                                                                                                       [  1%]
tests/consistency/test_cphd_consistency.py ..............................................................                                            [ 13%]
tests/consistency/test_sicd_consistency.py ...                                                                                                       [ 13%]
tests/geometry/test_geocoords.py ..........                                                                                                          [ 15%]
tests/geometry/test_geometry_elements.py ..........                                                                                                  [ 17%]
tests/geometry/test_latlon.py ...                                                                                                                    [ 18%]
tests/geometry/test_point_projection.py ............                                                                                                 [ 20%]
tests/io/test_kml.py .                                                                                                                               [ 20%]
tests/io/DEM/test_geoid.py .                                                                                                                         [ 20%]
tests/io/DEM/test_geotiff1deg_list.py ....                                                                                                           [ 21%]
tests/io/DEM/test_geotiff1deg_reader.py ........                                                                                                     [ 23%]
tests/io/complex/test_other_nitf.py .                                                                                                                [ 23%]
tests/io/complex/test_reader.py .ssssssssss                                                                                                          [ 25%]
tests/io/complex/test_remote.py s                                                                                                                    [ 25%]
tests/io/complex/test_sicd.py .                                                                                                                      [ 25%]
tests/io/complex/test_utils.py .                                                                                                                     [ 26%]
tests/io/complex/sicd_elements/test_sicd_elements_antenna.py ...                                                                                     [ 26%]
tests/io/complex/sicd_elements/test_sicd_elements_base.py ...                                                                                        [ 27%]
tests/io/complex/sicd_elements/test_sicd_elements_blocks.py .....................                                                                    [ 31%]
tests/io/complex/sicd_elements/test_sicd_elements_collectioninfo.py ..                                                                               [ 31%]
tests/io/complex/sicd_elements/test_sicd_elements_errorstatistics.py .                                                                               [ 31%]
tests/io/complex/sicd_elements/test_sicd_elements_geodata.py ...                                                                                     [ 32%]
tests/io/complex/sicd_elements/test_sicd_elements_grid.py ..                                                                                         [ 32%]
tests/io/complex/sicd_elements/test_sicd_elements_imagecreation.py .                                                                                 [ 32%]
tests/io/complex/sicd_elements/test_sicd_elements_imagedata.py .                                                                                     [ 33%]
tests/io/complex/sicd_elements/test_sicd_elements_imageformation.py ......                                                                           [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_matchinfo.py .                                                                                     [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_pfa.py .                                                                                           [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_position.py ...                                                                                    [ 35%]
tests/io/complex/sicd_elements/test_sicd_elements_radarcollection.py ..............                                                                  [ 37%]
tests/io/complex/sicd_elements/test_sicd_elements_radiometric.py .                                                                                   [ 37%]
tests/io/complex/sicd_elements/test_sicd_elements_rgazcomp.py .                                                                                      [ 38%]
tests/io/complex/sicd_elements/test_sicd_elements_rma.py ...                                                                                         [ 38%]
tests/io/complex/sicd_elements/test_sicd_elements_scpcoa.py ...................                                                                      [ 42%]
tests/io/complex/sicd_elements/test_sicd_elements_sicd.py ..................................                                                         [ 48%]
tests/io/complex/sicd_elements/test_sicd_elements_timeline.py .....                                                                                  [ 49%]
tests/io/complex/sicd_elements/test_sicd_elements_utils.py ...                                                                                       [ 50%]
tests/io/general/test_base.py ...                                                                                                                    [ 50%]
tests/io/general/test_data_segment.py ..........                                                                                                     [ 52%]
tests/io/general/test_format_function.py .......                                                                                                     [ 53%]
tests/io/general/test_nitf_headers.py s                                                                                                              [ 54%]
tests/io/general/test_tre.py .                                                                                                                       [ 54%]
tests/io/phase_history/test_cphd.py .                                                                                                                [ 54%]
tests/io/phase_history/test_cphd_versions.py .....                                                                                                   [ 55%]
tests/io/phase_history/cphd1_elements/test_cphd.py ....                                                                                              [ 56%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_antenna.py .....                                                                           [ 57%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_blocks.py ....                                                                             [ 57%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_channel.py .                                                                               [ 58%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_data.py .                                                                                  [ 58%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_dwell.py .                                                                                 [ 58%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_geoinfo.py ...                                                                             [ 59%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_global.py ..                                                                               [ 59%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_pvp.py .                                                                                   [ 59%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_referencegeometry.py .                                                                     [ 59%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_supportarray.py ..                                                                         [ 60%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_txrcv.py .                                                                                 [ 60%]
tests/io/phase_history/cphd1_elements/test_utils.py .                                                                                                [ 60%]
tests/io/product/test_reader.py ..s                                                                                                                  [ 61%]
tests/io/product/test_sidd_schema.py .........                                                                                                       [ 62%]
tests/io/product/test_sidd_writing.py s                                                                                                              [ 63%]
tests/io/product/sidd3_elements/test_exploitationfeatures.py ....................................................................................... [ 79%]
...........................................                                                                                                          [ 87%]
tests/io/product/sidd3_elements/test_sidd3_elements.py .....                                                                                         [ 88%]
tests/io/received/test_crsd.py .                                                                                                                     [ 88%]
tests/processing/sicd/test_spectral_taper.py ........ss...........                                                                                   [ 92%]
tests/utils/test_sicd_sidelobe_control.py ..                                                                                                         [ 93%]
tests/utils/test_sicd_to_sidd.py ............                                                                                                        [ 95%]
tests/visualization/test_cphd_kmz_product_creation.py ..                                                                                             [ 95%]
tests/visualization/test_crsd_kmz_product_creation.py .                                                                                              [ 95%]
tests/visualization/test_kmz_product_creation.py .x                                                                                                  [ 96%]
tests/visualization/test_remap.py ....................                                                                                               [100%]

===================================================================== warnings summary =====================================================================
tests/geometry/test_point_projection.py::test_image_to_ground_errors
tests/geometry/test_point_projection.py::test_image_to_ground_dem
  /home/vscuser/repos/sarpy/sarpy/geometry/point_projection.py:1903: RuntimeWarning: divide by zero encountered in double_scalars
    lon_grid_size = min(10, lat_grid_size/abs(numpy.sin(numpy.deg2rad(ref_llh[0]))))

tests/visualization/test_kmz_product_creation.py::test_create_kmz[True]
  /home/vscuser/repos/sarpy/sarpy/visualization/kmz_utils.py:169: RuntimeWarning: invalid value encountered in double_scalars
    + dir_z**2 * semiaxis_a**2 * semiaxis_b**2

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================ 513 passed, 16 skipped, 1 xfailed, 3 warnings in 131.39s (0:02:11) ============================================
nox > Session test(version='3.6') was successful.
nox > Running session test(version='3.11')
nox > Creating conda env in .nox/test-version-3-11 with python
nox > conda install --yes --prefix /home/vscuser/repos/sarpy/.nox/test-version-3-11 python=3.11
nox > python -m pip install '.[all]'
nox > pytest tests
=================================================================== test session starts ====================================================================
platform linux -- Python 3.11.5, pytest-7.4.3, pluggy-1.3.0
rootdir: /home/vscuser/repos/sarpy
collected 530 items                                                                                                                                        

tests/test_class_string.py .                                                                                                                         [  0%]
tests/consistency/test_consistency.py ........                                                                                                       [  1%]
tests/consistency/test_cphd_consistency.py ..............................................................                                            [ 13%]
tests/consistency/test_sicd_consistency.py ...                                                                                                       [ 13%]
tests/geometry/test_geocoords.py ..........                                                                                                          [ 15%]
tests/geometry/test_geometry_elements.py ..........                                                                                                  [ 17%]
tests/geometry/test_latlon.py ...                                                                                                                    [ 18%]
tests/geometry/test_point_projection.py ............                                                                                                 [ 20%]
tests/io/test_kml.py .                                                                                                                               [ 20%]
tests/io/DEM/test_geoid.py .                                                                                                                         [ 20%]
tests/io/DEM/test_geotiff1deg_list.py ....                                                                                                           [ 21%]
tests/io/DEM/test_geotiff1deg_reader.py ........                                                                                                     [ 23%]
tests/io/complex/test_other_nitf.py .                                                                                                                [ 23%]
tests/io/complex/test_reader.py .ssssssssss                                                                                                          [ 25%]
tests/io/complex/test_remote.py s                                                                                                                    [ 25%]
tests/io/complex/test_sicd.py .                                                                                                                      [ 25%]
tests/io/complex/test_utils.py .                                                                                                                     [ 26%]
tests/io/complex/sicd_elements/test_sicd_elements_antenna.py ...                                                                                     [ 26%]
tests/io/complex/sicd_elements/test_sicd_elements_base.py ...                                                                                        [ 27%]
tests/io/complex/sicd_elements/test_sicd_elements_blocks.py .....................                                                                    [ 31%]
tests/io/complex/sicd_elements/test_sicd_elements_collectioninfo.py ..                                                                               [ 31%]
tests/io/complex/sicd_elements/test_sicd_elements_errorstatistics.py .                                                                               [ 31%]
tests/io/complex/sicd_elements/test_sicd_elements_geodata.py ...                                                                                     [ 32%]
tests/io/complex/sicd_elements/test_sicd_elements_grid.py ..                                                                                         [ 32%]
tests/io/complex/sicd_elements/test_sicd_elements_imagecreation.py .                                                                                 [ 32%]
tests/io/complex/sicd_elements/test_sicd_elements_imagedata.py .                                                                                     [ 33%]
tests/io/complex/sicd_elements/test_sicd_elements_imageformation.py ......                                                                           [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_matchinfo.py .                                                                                     [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_pfa.py .                                                                                           [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_position.py ...                                                                                    [ 35%]
tests/io/complex/sicd_elements/test_sicd_elements_radarcollection.py ..............                                                                  [ 37%]
tests/io/complex/sicd_elements/test_sicd_elements_radiometric.py .                                                                                   [ 37%]
tests/io/complex/sicd_elements/test_sicd_elements_rgazcomp.py .                                                                                      [ 38%]
tests/io/complex/sicd_elements/test_sicd_elements_rma.py ...                                                                                         [ 38%]
tests/io/complex/sicd_elements/test_sicd_elements_scpcoa.py ...................                                                                      [ 42%]
tests/io/complex/sicd_elements/test_sicd_elements_sicd.py ..................................                                                         [ 48%]
tests/io/complex/sicd_elements/test_sicd_elements_timeline.py .....                                                                                  [ 49%]
tests/io/complex/sicd_elements/test_sicd_elements_utils.py ...                                                                                       [ 50%]
tests/io/general/test_base.py ...                                                                                                                    [ 50%]
tests/io/general/test_data_segment.py ..........                                                                                                     [ 52%]
tests/io/general/test_format_function.py .......                                                                                                     [ 53%]
tests/io/general/test_nitf_headers.py s                                                                                                              [ 54%]
tests/io/general/test_tre.py .                                                                                                                       [ 54%]
tests/io/phase_history/test_cphd.py .                                                                                                                [ 54%]
tests/io/phase_history/test_cphd_versions.py .....                                                                                                   [ 55%]
tests/io/phase_history/cphd1_elements/test_cphd.py ....                                                                                              [ 56%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_antenna.py .....                                                                           [ 57%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_blocks.py ....                                                                             [ 57%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_channel.py .                                                                               [ 58%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_data.py .                                                                                  [ 58%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_dwell.py .                                                                                 [ 58%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_geoinfo.py ...                                                                             [ 59%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_global.py ..                                                                               [ 59%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_pvp.py .                                                                                   [ 59%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_referencegeometry.py .                                                                     [ 59%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_supportarray.py ..                                                                         [ 60%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_txrcv.py .                                                                                 [ 60%]
tests/io/phase_history/cphd1_elements/test_utils.py .                                                                                                [ 60%]
tests/io/product/test_reader.py ..s                                                                                                                  [ 61%]
tests/io/product/test_sidd_schema.py .........                                                                                                       [ 62%]
tests/io/product/test_sidd_writing.py s                                                                                                              [ 63%]
tests/io/product/sidd3_elements/test_exploitationfeatures.py ....................................................................................... [ 79%]
...........................................                                                                                                          [ 87%]
tests/io/product/sidd3_elements/test_sidd3_elements.py .....                                                                                         [ 88%]
tests/io/received/test_crsd.py .                                                                                                                     [ 88%]
tests/processing/sicd/test_spectral_taper.py .....................                                                                                   [ 92%]
tests/utils/test_sicd_sidelobe_control.py ..                                                                                                         [ 93%]
tests/utils/test_sicd_to_sidd.py ............                                                                                                        [ 95%]
tests/visualization/test_cphd_kmz_product_creation.py ..                                                                                             [ 95%]
tests/visualization/test_crsd_kmz_product_creation.py .                                                                                              [ 95%]
tests/visualization/test_kmz_product_creation.py .x                                                                                                  [ 96%]
tests/visualization/test_remap.py ....................                                                                                               [100%]

===================================================================== warnings summary =====================================================================
tests/test_class_string.py::TestClassString::test_class_str
  /home/vscuser/repos/sarpy/sarpy/annotation/afrl_rde_schema/__init__.py:7: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
    import pkg_resources

tests/geometry/test_point_projection.py::test_image_to_ground_errors
tests/geometry/test_point_projection.py::test_image_to_ground_dem
  /home/vscuser/repos/sarpy/sarpy/geometry/point_projection.py:1903: RuntimeWarning: divide by zero encountered in scalar divide
    lon_grid_size = min(10, lat_grid_size/abs(numpy.sin(numpy.deg2rad(ref_llh[0]))))

tests/utils/test_sicd_to_sidd.py::test_sicd_to_sidd_help
tests/utils/test_sicd_to_sidd.py::test_sicd_to_sidd_help
tests/utils/test_sicd_to_sidd.py::test_sicd_to_sidd_help
tests/utils/test_sicd_to_sidd.py::test_sicd_to_sidd_help
tests/visualization/test_remap.py::TestRemap::test_LUTRemap_matplotlib
tests/visualization/test_remap.py::TestRemap::test_remap_names
tests/visualization/test_remap.py::TestRemap::test_remap_names
tests/visualization/test_remap.py::TestRemap::test_remap_names
tests/visualization/test_remap.py::TestRemap::test_remap_names
  /home/vscuser/repos/sarpy/sarpy/visualization/remap.py:1751: MatplotlibDeprecationWarning: The get_cmap function was deprecated in Matplotlib 3.7 and will be removed two minor releases later. Use ``matplotlib.colormaps[name]`` or ``matplotlib.colormaps.get_cmap(obj)`` instead.
    cmap = cm.get_cmap(value, max_out_size+1)

tests/visualization/test_cphd_kmz_product_creation.py::test_create_kmz
tests/visualization/test_cphd_kmz_product_creation.py::test_create_kmz
tests/visualization/test_cphd_kmz_product_creation.py::test_create_kmz
tests/visualization/test_cphd_kmz_product_creation.py::test_create_kmz
tests/visualization/test_cphd_kmz_product_creation.py::test_create_kmz
tests/visualization/test_cphd_kmz_product_creation.py::test_create_kmz
  /home/vscuser/repos/sarpy/sarpy/visualization/kmz_utils.py:302: MatplotlibDeprecationWarning: The collections attribute was deprecated in Matplotlib 3.8 and will be removed two minor releases later.
    for path in contour_sets.collections[0].get_paths()

tests/visualization/test_kmz_product_creation.py::test_create_kmz[True]
  /home/vscuser/repos/sarpy/sarpy/visualization/kmz_utils.py:145: RuntimeWarning: invalid value encountered in scalar divide
    distance = (

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================================== 515 passed, 14 skipped, 1 xfailed, 19 warnings in 109.74s (0:01:49) ============================================
nox > Session test(version='3.11') was successful.
nox > Ran multiple sessions:
nox > * test(version='3.6'): success
nox > * test(version='3.11'): success

```

</details>