### PR TITLE
support reading CF8 CPHDs with AmpSF PVP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ release points are not being annotated in GitHub.
 - `sarpy/utils/sicd_to_sidd.py`
 - `GDM` to `sarpy/visualization/remap.py`
 - Unit tests for `sarpy/consistency/sicd_consistency.py`
+- Support reading CPHDs with an AmpSF PVP whose Data/SignalArrayFormat is CF8
 ### Fixed
 - `sarpy.io.kml.add_polygon` coordinate conditioning for older numpy versions
 - Replace unsupported `pillow` constant `Image.ANTIALIAS` with `Image.LANCZOS`

--- a/sarpy/io/phase_history/cphd.py
+++ b/sarpy/io/phase_history/cphd.py
@@ -11,6 +11,7 @@ import logging
 import os
 from typing import Union, List, Tuple, Dict, BinaryIO, Optional, Sequence
 from collections import OrderedDict
+import numbers
 
 import numpy
 
@@ -34,9 +35,6 @@ _unhandled_version_text = 'Got unhandled CPHD version number `{}`'
 _missing_channel_identifier_text = 'Cannot find CPHD channel for identifier `{}`'
 _index_range_text = 'index must be in the range `[0, {})`'
 
-
-#########
-# Helper object for initially parses CPHD elements
 
 class AmpScalingFunction(ComplexFormatFunction):
     __slots__ = (
@@ -66,9 +64,8 @@ class AmpScalingFunction(ComplexFormatFunction):
             Which band is the complex dimension, **after** the transpose operation.
         amplitude_scaling : None|numpy.ndarray
             This is here to support the presence of a scaling in CPHD or CRSD usage.
-            This requires that `raw_dtype` in `[int8, int16]`, `band_dimension`
-            is the final dimension and neither `reverse_axes` nor `transpose_axes`
-            is populated.
+            This requires that `band_dimension` is the final dimension and neither
+            `reverse_axes` nor `transpose_axes` is populated.
         """
 
         ComplexFormatFunction.__init__(
@@ -121,11 +118,6 @@ class AmpScalingFunction(ComplexFormatFunction):
         if array.dtype.name != 'float32':
             array = numpy.cast['float32'](array)
 
-        # NB: more validation as part of validate_shapes
-        if self._raw_dtype.name not in ['int8', 'int16']:
-            raise ValueError(
-                'A scaling multiplier has been supplied,\n\t'
-                'but the raw datatype is not `int8` or `int16`.')
         self._amplitude_scaling = array
         self._validate_amplitude_scaling()
 
@@ -162,7 +154,9 @@ class AmpScalingFunction(ComplexFormatFunction):
         # NB: subscript is in formatted coordinates, but we have verified that
         #   transpose_axes is None and band_dimension is the final dimension
         if self._amplitude_scaling is not None:
-            data = numpy.rint((1./self._amplitude_scaling[subscript[0]])[:, numpy.newaxis] * data)
+            data = (1./self._amplitude_scaling[subscript[0]])[:, numpy.newaxis] * data
+        if issubclass(self._raw_dtype.type, numbers.Integral):
+            data = numpy.rint(data)
 
         return ComplexFormatFunction._reverse_functional_step(self, data, subscript)
 

--- a/tests/io/phase_history/test_cphd.py
+++ b/tests/io/phase_history/test_cphd.py
@@ -1,135 +1,119 @@
-import logging
-import os
-import json
-import tempfile
-import unittest
-import shutil
+import copy
+import pathlib
 
+import numpy as np
 import numpy.testing
-from sarpy.io.phase_history.cphd import CPHDReader, CPHDReader0_3, CPHDReader1, CPHDWriter1
-from sarpy.io.phase_history.converter import open_phase_history
+import pytest
+
 import sarpy.consistency.cphd_consistency
+import sarpy.io.phase_history.converter
+from sarpy.io.phase_history.cphd import CPHDReader, CPHDReader0_3, CPHDWriter1
 
-from tests import parse_file_entry
-
-cphd_file_types = {}
-
-this_loc = os.path.abspath(__file__)
-file_reference = os.path.join(os.path.split(this_loc)[0], 'cphd_file_types.json')  # specifies file locations
-if os.path.isfile(file_reference):
-    with open(file_reference, 'r') as fi:
-        the_files = json.load(fi)
-        for the_type in the_files:
-            valid_entries = []
-            for entry in the_files[the_type]:
-                the_file = parse_file_entry(entry)
-                if the_file is not None:
-                    valid_entries.append(the_file)
-            cphd_file_types[the_type] = valid_entries
+import tests
 
 
-def generic_io_test(instance, test_file, reader_type_string, reader_type):
-    assert isinstance(instance, unittest.TestCase)
+CPHD_FILE_TYPES = tests.find_test_data_files(pathlib.Path(__file__).parent / 'cphd_file_types.json')
+for path in CPHD_FILE_TYPES.get('CPHD', []):
+    if pathlib.Path(path).name == 'dynamic_stripmap_ci2.cphd':
+        CI2_CPHD = path
+        break
+else:
+    CI2_CPHD = None
 
-    reader = None
-    with instance.subTest(msg='establish reader for type {} and file {}'.format(reader_type_string, test_file)):
-        reader = open_phase_history(test_file)
-        instance.assertTrue(reader is not None, msg='Returned None, so opening failed.')
 
-    if reader is None:
-        return  # remaining tests make no sense
-
+@pytest.mark.parametrize('cphd_path', CPHD_FILE_TYPES.get('CPHD',[]))
+def test_cphd_read(cphd_path):
+    reader = sarpy.io.phase_history.converter.open_phase_history(cphd_path)
     assert isinstance(reader, CPHDReader)
-    with instance.subTest(msg='Reader for type {} should be appropriate reader'):
-        instance.assertTrue(isinstance(reader, reader_type), msg='Returned reader should be of type {}'.format(
-            reader_type))
+    assert reader.reader_type == 'CPHD'
+    _assert_read_sizes(reader)
 
-    if not isinstance(reader, reader_type):
-        return  # remaining tests might be misleading
 
-    with instance.subTest(msg='Verify reader_type for type {} and file {}'.format(reader_type_string, test_file)):
-        instance.assertEqual(reader.reader_type, "CPHD", msg='reader.reader_type should be "CPHD"')
-
-    with instance.subTest(msg='Validity of cphd in reader of '
-                              'type {} for file {}'.format(reader_type_string, test_file)):
-        if not reader.cphd_meta.is_valid(recursive=True, stack=False):
-            logging.warning(
-                'cphd in reader of type {} for file {} not valid'.format(reader_type_string, test_file))
-
-    with instance.subTest(msg='Fetch data_sizes and sidds for type {} and file {}'.format(
-            reader_type_string, test_file)):
-        data_sizes = reader.get_data_size_as_tuple()
-        if isinstance(reader, CPHDReader1):
-            elements = reader.cphd_meta.Data.Channels
-        elif isinstance(reader, CPHDReader0_3):
-            elements = reader.cphd_meta.Data.ArraySize
-        else:
-            raise TypeError('Got unhandled reader type {}'.format(type(reader)))
-
+def _assert_read_sizes(reader):
+    data_sizes = reader.get_data_size_as_tuple()
+    elements = reader.cphd_meta.Data.ArraySize if isinstance(reader, CPHDReader0_3) else reader.cphd_meta.Data.Channels
     for i, (data_size, element) in enumerate(zip(data_sizes, elements)):
-        with instance.subTest(msg='Verify image size for sidd index {} in reader '
-                                  'of type {} for file {}'.format(i, reader_type_string, test_file)):
-            instance.assertEqual(data_size[0], element.NumVectors, msg='data_size[0] and NumVectors do not agree')
-            instance.assertEqual(data_size[1], element.NumSamples, msg='data_size[1] and NumSamples do not agree')
+        assert data_size == (element.NumVectors, element.NumSamples)
 
-        with instance.subTest(msg='Basic fetch test for cphd index {} in reader '
-                                  'of type {} for file {}'.format(i, reader_type_string, test_file)):
-            instance.assertEqual(reader[:2, :2, i].shape[:2], (2, 2), msg='upper left fetch')
-            instance.assertEqual(reader[-2:, :2, i].shape[:2], (2, 2), msg='lower left fetch')
-            instance.assertEqual(reader[-2:, -2:, i].shape[:2], (2, 2), msg='lower right fetch')
-            instance.assertEqual(reader[:2, -2:, i].shape[:2], (2, 2), msg='upper right fetch')
+        assert reader[:2, :2, i].shape[:2] == (2, 2)
+        assert reader[-2:, :2, i].shape[:2] == (2, 2)
+        assert reader[-2:, -2:, i].shape[:2] == (2, 2)
+        assert reader[:2, -2:, i].shape[:2] == (2, 2)
+        assert reader[:, :2, i].shape[:2] == (data_size[0], 2)
+        assert reader[:2, :, i].shape[:2] == (2, data_size[1])
 
-        with instance.subTest(msg='Verify fetching complete row(s) have correct size '
-                                  'for cphd index {} in reader of type {} and file {}'.format(
-                                    i, reader_type_string, test_file)):
-            test_data = reader[:, :2, i]
-            instance.assertEqual(test_data.shape[:2], (data_size[0], 2), msg='Complete row fetch size mismatch')
-
-        with instance.subTest(msg='Verify fetching complete columns(s) have correct size '
-                                  'for cphd index {} in reader of type {} file {}'.format(
-                                    i, reader_type_string, test_file)):
-            test_data = reader[:2, :, i]
-            instance.assertEqual(test_data.shape[:2], (2, data_size[1]), msg='Complete row fetch size mismatch')
-
-        with instance.subTest(msg='Verify fetching entire pvp data has correct size for cphd '
-                                  'index {} in reader of type {} file {}'.format(i, reader_type_string, test_file)):
-            test_pvp = reader.read_pvp_variable('TxTime', i, the_range=None)
-            instance.assertEqual(test_pvp.shape, (data_size[0], ), msg='Unexpected pvp total fetch size')
-
-        with instance.subTest(msg='Verify fetching pvp data for slice has correct size for cphd '
-                                  'index {} in reader of type {} file {}'.format(i, reader_type_string, test_file)):
-            test_pvp = reader.read_pvp_variable('TxTime', i, the_range=(0, 10, 2))
-            instance.assertEqual(test_pvp.shape, (5, ), msg='Unexpected pvp strided slice fetch size')
-
-    # create a temp directory
-    temp_directory = tempfile.mkdtemp()
-
-    if isinstance(reader, CPHDReader1):
-        with instance.subTest(msg='cphd writer test'):
-            generic_writer_test(reader, temp_directory)
-
-    shutil.rmtree(temp_directory)
-    del reader
+        assert reader.read_pvp_variable('TxTime', i, the_range=None).shape == (data_size[0], )
+        assert reader.read_pvp_variable('TxTime', i, the_range=(0, 10, 2)).shape == (5, )
 
 
-def generic_writer_test(cphd_reader, the_directory):
-    written_cphd_name = os.path.join(the_directory, 'example_cphd.cphd')
+@pytest.mark.parametrize('cphd_path', CPHD_FILE_TYPES.get('CPHD',[]))
+def test_cphd_read_write(cphd_path, tmp_path):
+    reader = sarpy.io.phase_history.converter.open_phase_history(cphd_path)
+    if isinstance(reader, CPHDReader0_3):
+        pytest.skip(reason='Writing CPHDs earlier than 1.0 is not supported')
 
-    read_support = cphd_reader.read_support_block()
-    read_pvp = cphd_reader.read_pvp_block()
-    read_signal = cphd_reader.read_signal_block()
+    written_cphd_name = tmp_path / 'example_cphd.cphd'
+
+    read_support = reader.read_support_block()
+    read_pvp = reader.read_pvp_block()
+    read_signal = reader.read_signal_block()
 
     # write the cphd file
-    with CPHDWriter1(written_cphd_name, cphd_reader.cphd_meta, check_existence=False) as writer:
+    with CPHDWriter1(str(written_cphd_name), reader.cphd_meta, check_existence=False) as writer:
         writer.write_file(read_pvp, read_signal, read_support)
 
     # reread the newly written data
-    rereader = CPHDReader(written_cphd_name)
+    rereader = CPHDReader(str(written_cphd_name))
     reread_support = rereader.read_support_block()
     reread_pvp = rereader.read_pvp_block()
     reread_signal = rereader.read_signal_block()
 
-    # byte compare that the original data and re-read data are identical
+    # compare the original data and re-read data
+    assert read_support.keys() == reread_support.keys(), 'Support keys are not identical'
+    for support_key in reread_support:
+        numpy.testing.assert_array_equal(read_support[support_key], reread_support[support_key])
+
+    assert reread_pvp.keys() == read_pvp.keys(), 'PVP keys are not identical'
+    for pvp_key in reread_pvp:
+        numpy.testing.assert_array_equal(read_pvp[pvp_key], reread_pvp[pvp_key])
+
+    assert read_signal.keys() == read_signal.keys(), 'Signal keys are not identical'
+    for signal_key in reread_signal:
+        numpy.testing.assert_allclose(read_signal[signal_key], reread_signal[signal_key], rtol=1e-6)
+
+    assert not sarpy.consistency.cphd_consistency.main([str(written_cphd_name), '--signal-data'])
+
+
+@pytest.mark.skipif(CI2_CPHD is None, reason="dynamic_stripmap_ci2.cphd not found")
+def test_cphd_read_write_cf8_ampsf(tmp_path):
+    reader = sarpy.io.phase_history.converter.open_phase_history(CI2_CPHD)
+    assert reader.cphd_meta.Data.SignalArrayFormat == 'CI2'
+    assert reader.cphd_meta.PVP.AmpSF is not None
+
+    written_cphd_name = tmp_path / 'example_cphd.cphd'
+
+    read_support = reader.read_support_block()
+    read_pvp = reader.read_pvp_block()
+    read_signal = reader.read_signal_block()
+    read_signal_raw = reader.read_signal_block_raw()
+
+    modified_meta = copy.deepcopy(reader.cphd_meta)
+    modified_meta.Data.SignalArrayFormat = 'CF8'
+    modified_signal = {k: v.astype(np.float32) for k, v in read_signal_raw.items()}
+
+    # write the cphd file
+    with CPHDWriter1(str(written_cphd_name), modified_meta, check_existence=False) as writer:
+        writer.write_file_raw(read_pvp, modified_signal, read_support)
+
+    # reread the newly written data
+    rereader = CPHDReader(str(written_cphd_name))
+    reread_support = rereader.read_support_block()
+    reread_pvp = rereader.read_pvp_block()
+    reread_signal = rereader.read_signal_block()
+
+    assert rereader.cphd_header.SIGNAL_BLOCK_SIZE == 4 * reader.cphd_header.SIGNAL_BLOCK_SIZE
+
+    # compare the original data and re-read data
     assert read_support.keys() == reread_support.keys(), 'Support keys are not identical'
     for support_key in reread_support:
         numpy.testing.assert_array_equal(read_support[support_key], reread_support[support_key])
@@ -142,11 +126,4 @@ def generic_writer_test(cphd_reader, the_directory):
     for signal_key in reread_signal:
         numpy.testing.assert_array_equal(read_signal[signal_key], reread_signal[signal_key])
 
-    assert not sarpy.consistency.cphd_consistency.main([written_cphd_name, '--signal-data'])
-
-
-class TestCPHD(unittest.TestCase):
-    @unittest.skipIf(len(cphd_file_types.get('CPHD', [])) == 0, 'No CPHD files specified or found')
-    def test_cphd_io(self):
-        for test_file in cphd_file_types['CPHD']:
-            generic_io_test(self, test_file, 'CPHD', CPHDReader)
+    assert not sarpy.consistency.cphd_consistency.main([str(written_cphd_name), '--signal-data'])


### PR DESCRIPTION
# Description
This PR addresses #474 and removes the restriction that CPHDs with AmpSF are only allowed to be integral-typed from SarPy's CPHD reader.

To do so, I propose:
- remove the check in `AmpScalingFunction` that raises a ValueError if not integral typed
- make rounding in `_reverse_functional_step` conditional on the dtype

# Test Plan
To demonstrate the new behavior, I added a new unittest (`test_cphd_read_write_cf8_ampsf`) to `tests/io/phase_history/test_cphd.py`. This test fails without these changes:

<details><summary>test results</summary>

```
==================================================================================================================================================================================================== test session starts =====================================================================================================================================================================================================
platform linux -- Python 3.11.5, pytest-7.4.2, pluggy-1.3.0
rootdir: /home/vscuser/git/glweb/software/third-party/sarpy
collected 1 item                                                                                                                                                                                                                                                                                                                                                                                                             

tests/io/phase_history/test_cphd.py F                                                                                                                                                                                                                                                                                                                                                                                  [100%]

========================================================================================================================================================================================================== FAILURES ==========================================================================================================================================================================================================
_______________________________________________________________________________________________________________________________________________________________________________________________ test_cphd_read_write_cf8_ampsf _______________________________________________________________________________________________________________________________________________________________________________________________

tmp_path = PosixPath('/data/tmp/pytest-of-vscuser/pytest-322/test_cphd_read_write_cf8_ampsf0')

    @pytest.mark.skipif(CI2_CPHD is None, reason="dynamic_stripmap_ci2.cphd not found")
    def test_cphd_read_write_cf8_ampsf(tmp_path):
        reader = sarpy.io.phase_history.converter.open_phase_history(CI2_CPHD)
        assert reader.cphd_meta.Data.SignalArrayFormat == 'CI2'
        assert reader.cphd_meta.PVP.AmpSF is not None
    
        written_cphd_name = tmp_path / 'example_cphd.cphd'
    
        read_support = reader.read_support_block()
        read_pvp = reader.read_pvp_block()
        read_signal = reader.read_signal_block()
        read_signal_raw = reader.read_signal_block_raw()
    
        modified_meta = copy.deepcopy(reader.cphd_meta)
        modified_meta.Data.SignalArrayFormat = 'CF8'
        modified_signal = {k: v.astype(np.float32) for k, v in read_signal_raw.items()}
    
        # write the cphd file
        with CPHDWriter1(str(written_cphd_name), modified_meta, check_existence=False) as writer:
>           writer.write_file_raw(read_pvp, modified_signal, read_support)

tests/io/phase_history/test_cphd.py:106: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
sarpy/io/phase_history/cphd.py:1776: in write_file_raw
    self.write_pvp_block(pvp_block)
sarpy/io/phase_history/cphd.py:1696: in write_pvp_block
    self.write_pvp_array(identifier, array)
sarpy/io/phase_history/cphd.py:1655: in write_pvp_array
    self._signal_data_segments[identifier].format_function.set_amplitude_scaling(amp_sf)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <sarpy.io.phase_history.cphd.AmpScalingFunction object at 0x7fc8943dbae0>, array = array([0.02092045, 0.02145306, 0.02579468, ..., 0.01824736, 0.02044585,
       0.01991271], dtype=float32)

    def set_amplitude_scaling(
            self,
            array: Optional[numpy.ndarray]) -> None:
        """
        Set the amplitude scaling array.
    
        Parameters
        ----------
        array : None|numpy.ndarray
    
        Returns
        -------
        None
        """
    
        if array is None:
            self._amplitude_scaling = None
            return
    
        if self.order != 'IQ':
            raise ValueError(
                'CPHD requires data in IQ order.')
    
        if not isinstance(array, numpy.ndarray):
            raise ValueError('requires a numpy.ndarray, got {}'.format(type(array)))
        if array.ndim != 1:
            raise ValueError('requires a one dimensional array')
        if array.dtype.name not in ['float32', 'float64']:
            raise ValueError('requires a numpy.ndarray of float32 or 64 dtype, got {}'.format(array.dtype))
        if array.dtype.name != 'float32':
            array = numpy.cast['float32'](array)
    
        # NB: more validation as part of validate_shapes
        if self._raw_dtype.name not in ['int8', 'int16']:
>           raise ValueError(
                'A scaling multiplier has been supplied,\n\t'
                'but the raw datatype is not `int8` or `int16`.')
E           ValueError: A scaling multiplier has been supplied,
E               but the raw datatype is not `int8` or `int16`.

sarpy/io/phase_history/cphd.py:126: ValueError
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- Captured log call ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
ERROR    sarpy.io.phase_history.cphd:cphd.py:1244 pvp data at index 0 not written
ERROR    sarpy.io.phase_history.cphd:cphd.py:1244 signal data at index 0 not written
ERROR    sarpy.io.general.base:base.py:886 The CPHDWriter1 file writer generated an exception during processing
================================================================================================================================================================================================== short test summary info ===================================================================================================================================================================================================
FAILED tests/io/phase_history/test_cphd.py::test_cphd_read_write_cf8_ampsf - ValueError: A scaling multiplier has been supplied,
===================================================================================================================================================================================================== 1 failed in 0.42s ======================================================================================================================================================================================================
                                                                                                                                                                                                                                                                                                                                                                                                                              

```

</details>

During the course of adding this test, I took the opportunity to refactor `tests/io/phase_history/test_cphd.py` to use `pytest`.