### PR TITLE
Fix typo in SICD 1.3 date

### DIFF
--- a/sarpy/io/complex/sicd_schema/__init__.py
+++ b/sarpy/io/complex/sicd_schema/__init__.py
@@ -73,7 +73,7 @@ urn_mapping = {
         'tuple': (1, 3, 0),
         'version': '1.3.0',
         'release': '1.3.0',
-        'date': '2022-11-30T00:00:00Z',
+        'date': '2021-11-30T00:00:00Z',
         'schema': os.path.join(_the_directory, 'SICD_schema_V1.3.0_2021_11_30.xsd')}
 }
 WRITABLE_VERSIONS = tuple(entry['release'] for key, entry in urn_mapping.items() if entry['tuple'] >= (1, 0, 0))

--- a/tests/io/complex/sicd_elements/test_sicd_elements_sicd.py
+++ b/tests/io/complex/sicd_elements/test_sicd_elements_sicd.py
@@ -93,7 +93,7 @@ def test_sicd_smoke_tests(sicd, rma_sicd, tol):
     details = sicd_copy.get_des_details()
     assert details['DESSHSI'] == 'SICD Volume 1 Design & Implementation Description Document'
     assert details['DESSHSV'] == '1.3.0'
-    assert details['DESSHSD'] == '2022-11-30T00:00:00Z'
+    assert details['DESSHSD'] == '2021-11-30T00:00:00Z'
     assert details['DESSHTN'] == 'urn:SICD:1.3.0'
 
     xml_bytes = sicd.to_xml_bytes()


### PR DESCRIPTION
# Description
This MR corrects a typo in the SICD 1.3.0 date in two places in SarPy.

Per, [nsgreg](https://nsgreg.nga.mil/doc/view?i=5381&month=12&day=11&year=2023):

![image](https://github.com/ngageoint/sarpy/assets/78438270/c1979d95-f13e-4497-9c58-70dc15aad633)


# Multi-environment test
<details><summary>tests pass</summary>

```
nox
nox > Running session test(version='3.6')
nox > Creating conda env in .nox/test-version-3-6 with python
nox > conda install --yes --prefix /home/vscuser/git/glweb/software/third-party/sarpy/.nox/test-version-3-6 python=3.6
nox > python -m pip install '.[all]'
nox > pytest tests
======================================================================================================================================================================= test session starts =======================================================================================================================================================================
platform linux -- Python 3.6.13, pytest-7.0.1, pluggy-1.0.0
rootdir: /home/vscuser/git/glweb/software/third-party/sarpy
collected 536 items                                                                                                                                                                                                                                                                                                                                               

tests/test_class_string.py .                                                                                                                                                                                                                                                                                                                                [  0%]
tests/consistency/test_consistency.py ........                                                                                                                                                                                                                                                                                                              [  1%]
tests/consistency/test_cphd_consistency.py ..............................................................                                                                                                                                                                                                                                                   [ 13%]
tests/consistency/test_sicd_consistency.py ...                                                                                                                                                                                                                                                                                                              [ 13%]
tests/geometry/test_geocoords.py ..........                                                                                                                                                                                                                                                                                                                 [ 15%]
tests/geometry/test_geometry_elements.py ..........                                                                                                                                                                                                                                                                                                         [ 17%]
tests/geometry/test_latlon.py ...                                                                                                                                                                                                                                                                                                                           [ 18%]
tests/geometry/test_point_projection.py ............                                                                                                                                                                                                                                                                                                        [ 20%]
tests/io/test_kml.py .                                                                                                                                                                                                                                                                                                                                      [ 20%]
tests/io/DEM/test_geoid.py .                                                                                                                                                                                                                                                                                                                                [ 20%]
tests/io/DEM/test_geotiff1deg_list.py ....                                                                                                                                                                                                                                                                                                                  [ 21%]
tests/io/DEM/test_geotiff1deg_reader.py ........                                                                                                                                                                                                                                                                                                            [ 22%]
tests/io/complex/test_other_nitf.py ...                                                                                                                                                                                                                                                                                                                     [ 23%]
tests/io/complex/test_reader.py .ssssssssss                                                                                                                                                                                                                                                                                                                 [ 25%]
tests/io/complex/test_remote.py s                                                                                                                                                                                                                                                                                                                           [ 25%]
tests/io/complex/test_sicd.py .                                                                                                                                                                                                                                                                                                                             [ 25%]
tests/io/complex/test_utils.py .                                                                                                                                                                                                                                                                                                                            [ 26%]
tests/io/complex/sicd_elements/test_sicd_elements_antenna.py ...                                                                                                                                                                                                                                                                                            [ 26%]
tests/io/complex/sicd_elements/test_sicd_elements_base.py ...                                                                                                                                                                                                                                                                                               [ 27%]
tests/io/complex/sicd_elements/test_sicd_elements_blocks.py .....................                                                                                                                                                                                                                                                                           [ 31%]
tests/io/complex/sicd_elements/test_sicd_elements_collectioninfo.py ..                                                                                                                                                                                                                                                                                      [ 31%]
tests/io/complex/sicd_elements/test_sicd_elements_errorstatistics.py .                                                                                                                                                                                                                                                                                      [ 31%]
tests/io/complex/sicd_elements/test_sicd_elements_geodata.py ...                                                                                                                                                                                                                                                                                            [ 32%]
tests/io/complex/sicd_elements/test_sicd_elements_grid.py ..                                                                                                                                                                                                                                                                                                [ 32%]
tests/io/complex/sicd_elements/test_sicd_elements_imagecreation.py .                                                                                                                                                                                                                                                                                        [ 32%]
tests/io/complex/sicd_elements/test_sicd_elements_imagedata.py .                                                                                                                                                                                                                                                                                            [ 33%]
tests/io/complex/sicd_elements/test_sicd_elements_imageformation.py ......                                                                                                                                                                                                                                                                                  [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_matchinfo.py .                                                                                                                                                                                                                                                                                            [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_pfa.py .                                                                                                                                                                                                                                                                                                  [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_position.py ...                                                                                                                                                                                                                                                                                           [ 35%]
tests/io/complex/sicd_elements/test_sicd_elements_radarcollection.py ..............                                                                                                                                                                                                                                                                         [ 37%]
tests/io/complex/sicd_elements/test_sicd_elements_radiometric.py .                                                                                                                                                                                                                                                                                          [ 37%]
tests/io/complex/sicd_elements/test_sicd_elements_rgazcomp.py .                                                                                                                                                                                                                                                                                             [ 38%]
tests/io/complex/sicd_elements/test_sicd_elements_rma.py ...                                                                                                                                                                                                                                                                                                [ 38%]
tests/io/complex/sicd_elements/test_sicd_elements_scpcoa.py ...................                                                                                                                                                                                                                                                                             [ 42%]
tests/io/complex/sicd_elements/test_sicd_elements_sicd.py ..................................                                                                                                                                                                                                                                                                [ 48%]
tests/io/complex/sicd_elements/test_sicd_elements_timeline.py .....                                                                                                                                                                                                                                                                                         [ 49%]
tests/io/complex/sicd_elements/test_sicd_elements_utils.py ...                                                                                                                                                                                                                                                                                              [ 50%]
tests/io/general/test_base.py ...                                                                                                                                                                                                                                                                                                                           [ 50%]
tests/io/general/test_data_segment.py ..........                                                                                                                                                                                                                                                                                                            [ 52%]
tests/io/general/test_format_function.py .......                                                                                                                                                                                                                                                                                                            [ 53%]
tests/io/general/test_nitf_headers.py .                                                                                                                                                                                                                                                                                                                     [ 53%]
tests/io/general/test_tre.py .                                                                                                                                                                                                                                                                                                                              [ 54%]
tests/io/phase_history/test_cphd.py .....                                                                                                                                                                                                                                                                                                                   [ 55%]
tests/io/phase_history/test_cphd_versions.py .....                                                                                                                                                                                                                                                                                                          [ 55%]
tests/io/phase_history/cphd1_elements/test_cphd.py ....                                                                                                                                                                                                                                                                                                     [ 56%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_antenna.py .....                                                                                                                                                                                                                                                                                  [ 57%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_blocks.py ....                                                                                                                                                                                                                                                                                    [ 58%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_channel.py .                                                                                                                                                                                                                                                                                      [ 58%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_data.py .                                                                                                                                                                                                                                                                                         [ 58%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_dwell.py .                                                                                                                                                                                                                                                                                        [ 58%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_geoinfo.py ...                                                                                                                                                                                                                                                                                    [ 59%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_global.py ..                                                                                                                                                                                                                                                                                      [ 59%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_pvp.py .                                                                                                                                                                                                                                                                                          [ 60%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_referencegeometry.py .                                                                                                                                                                                                                                                                            [ 60%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_supportarray.py ..                                                                                                                                                                                                                                                                                [ 60%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_txrcv.py .                                                                                                                                                                                                                                                                                        [ 60%]
tests/io/phase_history/cphd1_elements/test_utils.py .                                                                                                                                                                                                                                                                                                       [ 61%]
tests/io/product/test_reader.py ..s                                                                                                                                                                                                                                                                                                                         [ 61%]
tests/io/product/test_sidd_schema.py .........                                                                                                                                                                                                                                                                                                              [ 63%]
tests/io/product/test_sidd_writing.py .                                                                                                                                                                                                                                                                                                                     [ 63%]
tests/io/product/sidd3_elements/test_exploitationfeatures.py ..................................................................................................................................                                                                                                                                                             [ 87%]
tests/io/product/sidd3_elements/test_sidd3_elements.py .....                                                                                                                                                                                                                                                                                                [ 88%]
tests/io/received/test_crsd.py .                                                                                                                                                                                                                                                                                                                            [ 88%]
tests/processing/sicd/test_spectral_taper.py ........ss...........                                                                                                                                                                                                                                                                                          [ 92%]
tests/utils/test_sicd_sidelobe_control.py ..                                                                                                                                                                                                                                                                                                                [ 93%]
tests/utils/test_sicd_to_sidd.py ............                                                                                                                                                                                                                                                                                                               [ 95%]
tests/visualization/test_cphd_kmz_product_creation.py ..                                                                                                                                                                                                                                                                                                    [ 95%]
tests/visualization/test_crsd_kmz_product_creation.py .                                                                                                                                                                                                                                                                                                     [ 95%]
tests/visualization/test_kmz_product_creation.py .x                                                                                                                                                                                                                                                                                                         [ 96%]
tests/visualization/test_remap.py ....................                                                                                                                                                                                                                                                                                                      [100%]

======================================================================================================================================================================== warnings summary =========================================================================================================================================================================
tests/geometry/test_point_projection.py::test_image_to_ground_errors
tests/geometry/test_point_projection.py::test_image_to_ground_dem
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/geometry/point_projection.py:1903: RuntimeWarning: divide by zero encountered in double_scalars
    lon_grid_size = min(10, lat_grid_size/abs(numpy.sin(numpy.deg2rad(ref_llh[0]))))

tests/visualization/test_kmz_product_creation.py::test_create_kmz[True]
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/visualization/kmz_utils.py:169: RuntimeWarning: invalid value encountered in double_scalars
    + dir_z**2 * semiaxis_a**2 * semiaxis_b**2

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
===================================================================================================================================================== 521 passed, 14 skipped, 1 xfailed, 3 warnings in 43.77s =====================================================================================================================================================
nox > Session test(version='3.6') was successful.
nox > Running session test(version='3.11')
nox > Creating conda env in .nox/test-version-3-11 with python
nox > conda install --yes --prefix /home/vscuser/git/glweb/software/third-party/sarpy/.nox/test-version-3-11 python=3.11
nox > python -m pip install '.[all]'
nox > pytest tests
======================================================================================================================================================================= test session starts =======================================================================================================================================================================
platform linux -- Python 3.11.5, pytest-7.4.3, pluggy-1.3.0
rootdir: /home/vscuser/git/glweb/software/third-party/sarpy
collected 536 items                                                                                                                                                                                                                                                                                                                                               

tests/test_class_string.py .                                                                                                                                                                                                                                                                                                                                [  0%]
tests/consistency/test_consistency.py ........                                                                                                                                                                                                                                                                                                              [  1%]
tests/consistency/test_cphd_consistency.py ..............................................................                                                                                                                                                                                                                                                   [ 13%]
tests/consistency/test_sicd_consistency.py ...                                                                                                                                                                                                                                                                                                              [ 13%]
tests/geometry/test_geocoords.py ..........                                                                                                                                                                                                                                                                                                                 [ 15%]
tests/geometry/test_geometry_elements.py ..........                                                                                                                                                                                                                                                                                                         [ 17%]
tests/geometry/test_latlon.py ...                                                                                                                                                                                                                                                                                                                           [ 18%]
tests/geometry/test_point_projection.py ............                                                                                                                                                                                                                                                                                                        [ 20%]
tests/io/test_kml.py .                                                                                                                                                                                                                                                                                                                                      [ 20%]
tests/io/DEM/test_geoid.py .                                                                                                                                                                                                                                                                                                                                [ 20%]
tests/io/DEM/test_geotiff1deg_list.py ....                                                                                                                                                                                                                                                                                                                  [ 21%]
tests/io/DEM/test_geotiff1deg_reader.py ........                                                                                                                                                                                                                                                                                                            [ 22%]
tests/io/complex/test_other_nitf.py ...                                                                                                                                                                                                                                                                                                                     [ 23%]
tests/io/complex/test_reader.py .ssssssssss                                                                                                                                                                                                                                                                                                                 [ 25%]
tests/io/complex/test_remote.py s                                                                                                                                                                                                                                                                                                                           [ 25%]
tests/io/complex/test_sicd.py .                                                                                                                                                                                                                                                                                                                             [ 25%]
tests/io/complex/test_utils.py .                                                                                                                                                                                                                                                                                                                            [ 26%]
tests/io/complex/sicd_elements/test_sicd_elements_antenna.py ...                                                                                                                                                                                                                                                                                            [ 26%]
tests/io/complex/sicd_elements/test_sicd_elements_base.py ...                                                                                                                                                                                                                                                                                               [ 27%]
tests/io/complex/sicd_elements/test_sicd_elements_blocks.py .....................                                                                                                                                                                                                                                                                           [ 31%]
tests/io/complex/sicd_elements/test_sicd_elements_collectioninfo.py ..                                                                                                                                                                                                                                                                                      [ 31%]
tests/io/complex/sicd_elements/test_sicd_elements_errorstatistics.py .                                                                                                                                                                                                                                                                                      [ 31%]
tests/io/complex/sicd_elements/test_sicd_elements_geodata.py ...                                                                                                                                                                                                                                                                                            [ 32%]
tests/io/complex/sicd_elements/test_sicd_elements_grid.py ..                                                                                                                                                                                                                                                                                                [ 32%]
tests/io/complex/sicd_elements/test_sicd_elements_imagecreation.py .                                                                                                                                                                                                                                                                                        [ 32%]
tests/io/complex/sicd_elements/test_sicd_elements_imagedata.py .                                                                                                                                                                                                                                                                                            [ 33%]
tests/io/complex/sicd_elements/test_sicd_elements_imageformation.py ......                                                                                                                                                                                                                                                                                  [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_matchinfo.py .                                                                                                                                                                                                                                                                                            [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_pfa.py .                                                                                                                                                                                                                                                                                                  [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_position.py ...                                                                                                                                                                                                                                                                                           [ 35%]
tests/io/complex/sicd_elements/test_sicd_elements_radarcollection.py ..............                                                                                                                                                                                                                                                                         [ 37%]
tests/io/complex/sicd_elements/test_sicd_elements_radiometric.py .                                                                                                                                                                                                                                                                                          [ 37%]
tests/io/complex/sicd_elements/test_sicd_elements_rgazcomp.py .                                                                                                                                                                                                                                                                                             [ 38%]
tests/io/complex/sicd_elements/test_sicd_elements_rma.py ...                                                                                                                                                                                                                                                                                                [ 38%]
tests/io/complex/sicd_elements/test_sicd_elements_scpcoa.py ...................                                                                                                                                                                                                                                                                             [ 42%]
tests/io/complex/sicd_elements/test_sicd_elements_sicd.py ..................................                                                                                                                                                                                                                                                                [ 48%]
tests/io/complex/sicd_elements/test_sicd_elements_timeline.py .....                                                                                                                                                                                                                                                                                         [ 49%]
tests/io/complex/sicd_elements/test_sicd_elements_utils.py ...                                                                                                                                                                                                                                                                                              [ 50%]
tests/io/general/test_base.py ...                                                                                                                                                                                                                                                                                                                           [ 50%]
tests/io/general/test_data_segment.py ..........                                                                                                                                                                                                                                                                                                            [ 52%]
tests/io/general/test_format_function.py .......                                                                                                                                                                                                                                                                                                            [ 53%]
tests/io/general/test_nitf_headers.py .                                                                                                                                                                                                                                                                                                                     [ 53%]
tests/io/general/test_tre.py .                                                                                                                                                                                                                                                                                                                              [ 54%]
tests/io/phase_history/test_cphd.py .....                                                                                                                                                                                                                                                                                                                   [ 55%]
tests/io/phase_history/test_cphd_versions.py .....                                                                                                                                                                                                                                                                                                          [ 55%]
tests/io/phase_history/cphd1_elements/test_cphd.py ....                                                                                                                                                                                                                                                                                                     [ 56%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_antenna.py .....                                                                                                                                                                                                                                                                                  [ 57%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_blocks.py ....                                                                                                                                                                                                                                                                                    [ 58%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_channel.py .                                                                                                                                                                                                                                                                                      [ 58%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_data.py .                                                                                                                                                                                                                                                                                         [ 58%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_dwell.py .                                                                                                                                                                                                                                                                                        [ 58%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_geoinfo.py ...                                                                                                                                                                                                                                                                                    [ 59%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_global.py ..                                                                                                                                                                                                                                                                                      [ 59%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_pvp.py .                                                                                                                                                                                                                                                                                          [ 60%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_referencegeometry.py .                                                                                                                                                                                                                                                                            [ 60%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_supportarray.py ..                                                                                                                                                                                                                                                                                [ 60%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_txrcv.py .                                                                                                                                                                                                                                                                                        [ 60%]
tests/io/phase_history/cphd1_elements/test_utils.py .                                                                                                                                                                                                                                                                                                       [ 61%]
tests/io/product/test_reader.py ..s                                                                                                                                                                                                                                                                                                                         [ 61%]
tests/io/product/test_sidd_schema.py .........                                                                                                                                                                                                                                                                                                              [ 63%]
tests/io/product/test_sidd_writing.py .                                                                                                                                                                                                                                                                                                                     [ 63%]
tests/io/product/sidd3_elements/test_exploitationfeatures.py ..................................................................................................................................                                                                                                                                                             [ 87%]
tests/io/product/sidd3_elements/test_sidd3_elements.py .....                                                                                                                                                                                                                                                                                                [ 88%]
tests/io/received/test_crsd.py .                                                                                                                                                                                                                                                                                                                            [ 88%]
tests/processing/sicd/test_spectral_taper.py .....................                                                                                                                                                                                                                                                                                          [ 92%]
tests/utils/test_sicd_sidelobe_control.py ..                                                                                                                                                                                                                                                                                                                [ 93%]
tests/utils/test_sicd_to_sidd.py ............                                                                                                                                                                                                                                                                                                               [ 95%]
tests/visualization/test_cphd_kmz_product_creation.py ..                                                                                                                                                                                                                                                                                                    [ 95%]
tests/visualization/test_crsd_kmz_product_creation.py .                                                                                                                                                                                                                                                                                                     [ 95%]
tests/visualization/test_kmz_product_creation.py .x                                                                                                                                                                                                                                                                                                         [ 96%]
tests/visualization/test_remap.py ....................                                                                                                                                                                                                                                                                                                      [100%]

======================================================================================================================================================================== warnings summary =========================================================================================================================================================================
tests/test_class_string.py::TestClassString::test_class_str
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/annotation/afrl_rde_schema/__init__.py:7: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
    import pkg_resources

tests/geometry/test_point_projection.py::test_image_to_ground_errors
tests/geometry/test_point_projection.py::test_image_to_ground_dem
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/geometry/point_projection.py:1903: RuntimeWarning: divide by zero encountered in scalar divide
    lon_grid_size = min(10, lat_grid_size/abs(numpy.sin(numpy.deg2rad(ref_llh[0]))))

tests/utils/test_sicd_to_sidd.py::test_sicd_to_sidd_help
tests/utils/test_sicd_to_sidd.py::test_sicd_to_sidd_help
tests/utils/test_sicd_to_sidd.py::test_sicd_to_sidd_help
tests/utils/test_sicd_to_sidd.py::test_sicd_to_sidd_help
tests/visualization/test_remap.py::TestRemap::test_LUTRemap_matplotlib
tests/visualization/test_remap.py::TestRemap::test_remap_names
tests/visualization/test_remap.py::TestRemap::test_remap_names
tests/visualization/test_remap.py::TestRemap::test_remap_names
tests/visualization/test_remap.py::TestRemap::test_remap_names
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/visualization/remap.py:1751: MatplotlibDeprecationWarning: The get_cmap function was deprecated in Matplotlib 3.7 and will be removed two minor releases later. Use ``matplotlib.colormaps[name]`` or ``matplotlib.colormaps.get_cmap(obj)`` instead.
    cmap = cm.get_cmap(value, max_out_size+1)

tests/visualization/test_cphd_kmz_product_creation.py::test_create_kmz
tests/visualization/test_cphd_kmz_product_creation.py::test_create_kmz
tests/visualization/test_cphd_kmz_product_creation.py::test_create_kmz
tests/visualization/test_cphd_kmz_product_creation.py::test_create_kmz
tests/visualization/test_cphd_kmz_product_creation.py::test_create_kmz
tests/visualization/test_cphd_kmz_product_creation.py::test_create_kmz
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/visualization/kmz_utils.py:302: MatplotlibDeprecationWarning: The collections attribute was deprecated in Matplotlib 3.8 and will be removed two minor releases later.
    for path in contour_sets.collections[0].get_paths()

tests/visualization/test_kmz_product_creation.py::test_create_kmz[True]
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/visualization/kmz_utils.py:145: RuntimeWarning: invalid value encountered in scalar divide
    distance = (

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
==================================================================================================================================================== 523 passed, 12 skipped, 1 xfailed, 19 warnings in 32.79s =====================================================================================================================================================
nox > Session test(version='3.11') was successful.
nox > Ran multiple sessions:
nox > * test(version='3.6'): success
nox > * test(version='3.11'): success

```

</details>