### PR TITLE
Bugfix: SICD timeline checks

### DIFF
--- a/sarpy/io/complex/sicd_elements/Timeline.py
+++ b/sarpy/io/complex/sicd_elements/Timeline.py
@@ -92,16 +92,27 @@ class IPPSetType(Serializable):
                 'IPPStart ({}) >= IPPEnd ({})'.format(self.IPPStart, self.IPPEnd))
             condition = False
 
-        exp_ipp_start = self.IPPPoly(self.TStart)
-        exp_ipp_end = self.IPPPoly(self.TEnd)
-        if abs(exp_ipp_start - self.IPPStart) > 1:
+        ipp_start_from_poly = round(self.IPPPoly(self.TStart))
+        if self.IPPStart != ipp_start_from_poly:
             self.log_validity_error(
-                'IPPStart populated as {}, inconsistent with value ({}) '
-                'derived from IPPPoly and TStart'.format(exp_ipp_start, self.IPPStart))
-        if abs(exp_ipp_end - self.IPPEnd) > 1:
+                f'IPPStart ({self.IPPStart}) inconsistent with IPPPoly(TStart) ({ipp_start_from_poly})'
+            )
+            condition = False
+
+        ipp_end_from_poly = round(self.IPPPoly(self.TEnd) - 1)
+        if self.IPPEnd != ipp_end_from_poly:
             self.log_validity_error(
-                'IPPEnd populated as {}, inconsistent with value ({}) '
-                'derived from IPPPoly and TEnd'.format(self.IPPEnd, exp_ipp_end))
+                f'IPPEnd ({self.IPPEnd}) inconsistent with IPPPoly(TEnd) - 1 ({ipp_end_from_poly})'
+            )
+            condition = False
+
+        prf = self.IPPPoly.derivative_eval((self.TStart + self.TEnd)/2)
+        if prf < 0:
+            self.log_validity_error(f'IPPSet has a negative PRF: {prf}')
+            condition = False
+        if prf > 100e3:
+            self.log_validity_warning(f'IPPSet has an unreasonable PRF: {prf}')
+
         return condition
 
 
@@ -166,17 +177,48 @@ class TimelineType(Serializable):
         if self.IPP is None or len(self.IPP) < 2:
             return True
         cond = True
-        for i in range(len(self.IPP)-1):
-            el1 = self.IPP[i]
-            el2 = self.IPP[i+1]
-            if el1.IPPEnd + 1 != el2.IPPStart:
-                self.log_validity_error(
-                    'IPP entry {} IPPEnd ({}) is not consecutive with '
-                    'entry {} IPPStart ({})'.format(i, el1.IPPEnd, i+1, el2.IPPStart))
+
+        sorted_ipps = sorted(self.IPP, key=lambda x: x.index)
+        tstarts = [x.TStart for x in sorted_ipps]
+        tends = [x.TEnd for x in sorted_ipps]
+        ippstarts = [x.IPPStart for x in sorted_ipps]
+        ippends = [x.IPPEnd for x in sorted_ipps]
+        if tstarts != sorted(tstarts):
+            self.log_validity_error(f'The IPPSets are not in start time order. TStart: {tstarts}')
+            cond = False
+
+        if tends != sorted(tends):
+            self.log_validity_error(f'The IPPSets are not in end time order. TEnd: {tends}')
+            cond = False
+
+        actual_indices = [x.index for x in sorted_ipps]
+        if not numpy.array_equal(numpy.arange(1, len(self.IPP)+1), actual_indices):
+            self.log_validity_error(f'IPPSets indices ({actual_indices}) are not 1..size; '
+                                    'unable to perform adjacent IPPSet checks')
+            return False
+
+        tgaps = [ts - te for ts, te in zip(tstarts[1:], tends[:-1])]
+        for ig, g in enumerate(tgaps):
+            if g > 0:
+                self.log_validity_error(f'There is a gap between IPPSet[index={ig+1}] and '
+                                        f'IPPSet[index={ig+2}] of {g} seconds')
                 cond = False
-            if el1.TEnd > el2.TStart:
-                self.log_validity_error(
-                    'IPP entry {} TEnd ({}) is greater than entry {} TStart ({})'.format(i, el1.TEnd, i+1, el2.TStart))
+            if g < 0:
+                self.log_validity_error(f'There is overlap between IPPSet[index={ig+1}] and '
+                                        f'IPPSet[index={ig+2}] of {-g} seconds')
+                cond = False
+
+        igaps = [i_s - i_e for i_s, i_e in zip(ippstarts[1:], ippends[:-1])]
+        for ig, g in enumerate(igaps):
+            if g > 1:
+                self.log_validity_error(f'There is a gap between IPPSet[index={ig+1}] and '
+                                        f'IPPSet[index={ig+2}] of {g-1} IPPs')
+                cond = False
+            if g < 1:
+                self.log_validity_error(f'There is overlap between IPPSet[index={ig+1}] and '
+                                        f'IPPSet[index={ig+2}] of {1-g} IPPs')
+                cond = False
+
         return cond
 
     def _check_ipp_times(self) -> bool:
@@ -184,21 +226,12 @@ class TimelineType(Serializable):
             return True
 
         cond = True
-        min_time = self.IPP[0].TStart
-        max_time = self.IPP[0].TEnd
-        for i in range(len(self.IPP)):
-            entry = self.IPP[i]
-            if entry.TStart < 0:
-                self.log_validity_error('IPP entry {} has negative TStart ({})'.format(i, entry.TStart))
-                cond = False
-            if entry.TEnd > self.CollectDuration + 1e-2:
-                self.log_validity_error(
-                    'IPP entry {} has TEnd ({}) appreciably larger than '
-                    'CollectDuration ({})'.format(i, entry.TEnd, self.CollectDuration))
-                cond = False
-            min_time = min(min_time, entry.TStart)
-            max_time = max(max_time, entry.TEnd)
-        if abs(max_time - min_time - self.CollectDuration) > 1e-2:
+        min_time = min(x.TStart for x in self.IPP)
+        max_time = max(x.TEnd for x in self.IPP)
+        if min_time < 0:
+            self.log_validity_error(f'Earliest TStart is negative: {min_time}')
+            cond = False
+        if not numpy.isclose(max_time - min_time, self.CollectDuration, atol=1e-2):
             self.log_validity_error(
                 'time range in IPP entries ({}) not in keeping with populated '
                 'CollectDuration ({})'.format(max_time-min_time, self.CollectDuration))

--- a/sarpy/io/complex/sicd_elements/validation_checks.py
+++ b/sarpy/io/complex/sicd_elements/validation_checks.py
@@ -1142,86 +1142,6 @@ def _validate_antenna(the_sicd) -> bool:
     return valid
 
 
-def _validate_ippsets(the_sicd) -> bool:
-    """
-    Validate IPP sets
-
-    Parameters
-    ----------
-    the_sicd : sarpy.io.complex.sicd_elements.SICD.SICDType
-
-    Returns
-    -------
-    bool
-    """
-    if the_sicd.Timeline is None:
-        return True
-    if the_sicd.Timeline.IPP is None:
-        return True
-    ippsets = the_sicd.Timeline.IPP
-    tstarts = [x.TStart for x in ippsets]
-    tends = [x.TEnd for x in ippsets]
-    ippstarts = [x.IPPStart for x in ippsets]
-    ippends = [x.IPPEnd for x in ippsets]
-    ipppolys = [x.IPPPoly for x in ippsets]
-    ippstart_from_poly = [round(x.IPPPoly(x.TStart)) for x in ippsets]
-    ippend_from_poly = [round(x.IPPPoly(x.TEnd) - 1) for x in ippsets]
-
-    valid = True
-    if tstarts != sorted(tstarts):
-        the_sicd.Timeline.log_validity_error(f'The IPPSets are not in start time order. TStart: {tstarts}')
-        valid = False
-    if ippstarts != ippstart_from_poly:
-        the_sicd.Timeline.log_validity_error(f'The IPPSet IPPStart do not match the polynomials. IPPStart: {ippstarts}'
-                                             f'IPPPoly(TStart): {ippstart_from_poly}')
-    if ippends != ippend_from_poly:
-        the_sicd.Timeline.log_validity_error(f'The IPPSet IPPEnd do not match the polynomials. IPPEnd: {ippends} '
-                                             f'IPPPoly(TEnd) - 1: {ippend_from_poly}')
-    if tends != sorted(tends):
-        the_sicd.Timeline.log_validity_error(f'The IPPSets are not in end time order. TEnd: {tends}')
-        valid = False
-    for iset in range(len(ippsets)):
-        if tstarts[iset] > tends[iset]:
-            the_sicd.Timeline.log_validity_error(f'IPPSet[index={iset+1}] ends ({tends[iset]}) '
-                                                 f'before it starts ({tstarts[iset]}) in time')
-            valid = False
-        if ippstarts[iset] > ippends[iset]:
-            the_sicd.Timeline.log_validity_error(f'IPPSet[index={iset+1}] ends ({ippends[iset]}) '
-                                                 f'before it starts ({ippstarts[iset]}) in index')
-            valid = False
-        prf = ipppolys[iset].derivative_eval((tstarts[iset] + tends[iset])/2)
-        if prf < 0:
-            the_sicd.Timeline.log_validity_error(f'IPPSet[index={iset+1}] has a negative PRF: {prf}')
-            valid = False
-        if prf > 100e3:
-            the_sicd.Timeline.log_validity_warning(f'IPPSet[index={iset+1}] has an unreasonable PRF: {prf}')
-            valid = False
-    if len(ippsets) > 1:
-        tgaps = [ts - te for ts, te in zip(tstarts[1:], tends[:-1])]
-        for ig, g in enumerate(tgaps):
-            if g > 0:
-                the_sicd.Timeline.log_validity_error(f'There is a gap between IPPSet[index={ig+1}] and '
-                                                     f'IPPSet[index={ig+2}] of {g} seconds')
-                valid = False
-            if g < 0:
-                the_sicd.Timeline.log_validity_error(f'There is overlap between IPPSet[index={ig+1}] and '
-                                                     f'IPPSet[index={ig+2}] of {-g} seconds')
-                valid = False
-
-        igaps = [i_s - i_e for i_s, i_e in zip(ippstarts[1:], ippends[:-1])]
-        for ig, g in enumerate(igaps):
-            if g > 1:
-                the_sicd.Timeline.log_validity_error(f'There is a gap between IPPSet[index={ig+1}] and '
-                                                     f'IPPSet[index={ig+2}] of {g-1} IPPs')
-                valid = False
-            if g < 1:
-                the_sicd.Timeline.log_validity_error(f'There is overlap between IPPSet[index={ig+1}] and '
-                                                     f'IPPSet[index={ig+2}] of {1-g} IPPs')
-                valid = False
-
-    return valid
-
-
 def _validate_acp(the_sicd) -> bool:
     """
     Validate the RadarCollection/Area/Corner/ACP nodes
@@ -1680,7 +1600,6 @@ def detailed_validation_checks(the_sicd) -> bool:
     out &= _validate_polarization(the_sicd)
     out &= _check_deltak(the_sicd)
     out &= _validate_acp(the_sicd)
-    out &= _validate_ippsets(the_sicd)
     out &= _validate_antenna(the_sicd)
 
     if the_sicd.SCPCOA is not None:

--- a/tests/io/complex/sicd_elements/test_sicd_elements_timeline.py
+++ b/tests/io/complex/sicd_elements/test_sicd_elements_timeline.py
@@ -3,20 +3,20 @@
 #
 # Licensed under MIT License.  See LICENSE.
 #
+import re
+
 import numpy as np
+import numpy.polynomial.polynomial as npp
+import pytest
 
 from sarpy.io.complex.sicd_elements import Timeline
 
 
 def test_timeline(sicd, kwargs):
     def get_ipp_set(ipp, idx, **kwargs):
-        return Timeline.IPPSetType(ipp.TStart,
-                                   ipp.TEnd,
-                                   ipp.IPPStart,
-                                   ipp.IPPEnd,
-                                   ipp.IPPPoly,
-                                   idx,
-                                   **kwargs)
+        return Timeline.IPPSetType(
+            ipp.TStart, ipp.TEnd, ipp.IPPStart, ipp.IPPEnd, ipp.IPPPoly, idx, **kwargs
+        )
 
     ippset1 = get_ipp_set(sicd.Timeline.IPP[0], 1, **kwargs)
     assert ippset1.TStart == sicd.Timeline.IPP[0].TStart
@@ -29,9 +29,9 @@ def test_timeline(sicd, kwargs):
     ippset2 = get_ipp_set(sicd.Timeline.IPP[1], 2, **kwargs)
     ipp_list = [ippset1, ippset2]
 
-    timeline = Timeline.TimelineType(sicd.Timeline.CollectStart,
-                                     sicd.Timeline.CollectDuration,
-                                     ipp_list)
+    timeline = Timeline.TimelineType(
+        sicd.Timeline.CollectStart, sicd.Timeline.CollectDuration, ipp_list
+    )
     assert timeline.CollectStart == sicd.Timeline.CollectStart
     assert timeline.CollectDuration == sicd.Timeline.CollectDuration
 
@@ -42,68 +42,226 @@ def test_timeline(sicd, kwargs):
         assert timeline.IPP[idx].IPPEnd == ipp_list[idx].IPPEnd
         assert timeline.IPP[idx].IPPPoly == ipp_list[idx].IPPPoly
 
-    assert timeline.CollectEnd == timeline.CollectStart + np.timedelta64(int(timeline.CollectDuration*1e6), 'us')
+    assert timeline.CollectEnd == timeline.CollectStart + np.timedelta64(
+        int(timeline.CollectDuration * 1e6), "us"
+    )
     assert timeline._check_ipp_consecutive()
     assert timeline._check_ipp_times()
     assert timeline._basic_validity_check()
 
     # Check bail out for IPP consecutive with a single IPP set
-    timeline = Timeline.TimelineType(sicd.Timeline.CollectStart,
-                                     sicd.Timeline.CollectDuration,
-                                     ipp_list[0])
+    timeline = Timeline.TimelineType(
+        sicd.Timeline.CollectStart, sicd.Timeline.CollectDuration, ipp_list[0]
+    )
     assert timeline._check_ipp_consecutive()
 
 
-def test_timeline_start_end_mismatches(sicd, kwargs, caplog):
-    # Swap Tstart and TEnd along with IPPStart and IPPEnd
-    ipp0 = sicd.Timeline.IPP[0]
-    bad_ippset = Timeline.IPPSetType(ipp0.TEnd,
-                                     ipp0.TStart,
-                                     ipp0.IPPEnd,
-                                     ipp0.IPPStart,
-                                     ipp0.IPPPoly,
-                                     1,
-                                     **kwargs)
-    bad_ippset._basic_validity_check()
-    assert 'TStart ({}) >= TEnd ({})'.format(ipp0.TEnd, ipp0.TStart) in caplog.text
-    assert 'IPPStart ({}) >= IPPEnd ({})'.format(ipp0.IPPEnd, ipp0.IPPStart) in caplog.text
+def test_valid_ippset():
+    ippset = Timeline.IPPSetType(
+        TStart=0,
+        TEnd=1.234,
+        IPPStart=8,
+        IPPEnd=24,
+        IPPPoly=[8, (24 - 8 + 1) / 1.234],
+        index=0,
+    )
+    assert ippset.is_valid()
 
-    # CollectEnd is None with no CollectStart
-    bad_timeline = Timeline.TimelineType(None, sicd.Timeline.CollectDuration, bad_ippset)
+
+def test_ippset_unreasonable_prf(caplog):
+    ippset = Timeline.IPPSetType(
+        TStart=0,
+        TEnd=1.234,
+        IPPStart=8,
+        IPPEnd=24e6,
+        IPPPoly=[8, (24e6 - 8 + 1) / 1.234],
+        index=0,
+    )
+    assert ippset.is_valid()  # valid but with a warning
+    assert any(
+        re.search(r"IPPSet has an unreasonable PRF", x.message) for x in caplog.records
+    )
+
+
+def test_ippset_decreasing_t(caplog):
+    ippset = Timeline.IPPSetType(
+        TStart=1.234,
+        TEnd=0,
+        IPPStart=8,
+        IPPEnd=24,
+        IPPPoly=[24 + 1, -(24 - 8 + 1) / 1.234],
+        index=0,
+    )
+    assert not ippset.is_valid()
+    assert any(re.search(r"TStart \(.+\) >= TEnd", x.message) for x in caplog.records)
+    assert any(
+        re.search(r"IPPSet has a negative PRF", x.message) for x in caplog.records
+    )
+
+
+def test_ippset_decreasing_ipp(caplog):
+    ippset = Timeline.IPPSetType(
+        TStart=0,
+        TEnd=1.234,
+        IPPStart=24,
+        IPPEnd=8,
+        IPPPoly=[24, (8 - 24 + 1) / 1.234],
+        index=0,
+    )
+    assert not ippset.is_valid()
+    assert any(
+        re.search(r"IPPStart \(.+\) >= IPPEnd", x.message) for x in caplog.records
+    )
+    assert any(
+        re.search(r"IPPSet has a negative PRF", x.message) for x in caplog.records
+    )
+
+
+def test_ippset_start_mismatch(caplog):
+    ippset = Timeline.IPPSetType(
+        TStart=0,
+        TEnd=1.234,
+        IPPStart=8,
+        IPPEnd=24,
+        IPPPoly=[7, (24 - 7 + 1) / 1.234],
+        index=0,
+    )
+    assert not ippset.is_valid()
+    assert any(
+        re.search(r"IPPStart \(.+\) inconsistent with IPPPoly", x.message)
+        for x in caplog.records
+    )
+
+
+def test_ippset_end_mismatch(caplog):
+    ippset = Timeline.IPPSetType(
+        TStart=0,
+        TEnd=1.234,
+        IPPStart=8,
+        IPPEnd=24,
+        IPPPoly=[8, (24 - 8) / 1.234],
+        index=0,
+    )
+    assert not ippset.is_valid()
+    assert any(
+        re.search(r"IPPEnd \(.+\) inconsistent with IPPPoly", x.message)
+        for x in caplog.records
+    )
+
+
+def test_timeline_no_collect_start():
+    bad_timeline = Timeline.TimelineType(CollectStart=None, CollectDuration=2.4)
     assert bad_timeline.CollectEnd is None
+    assert not bad_timeline.is_valid()
 
 
-def test_timeline_negative_tstart(sicd, kwargs, caplog):
-    # Negative TStart
-    ipp0 = sicd.Timeline.IPP[0]
-    bad_ippset = Timeline.IPPSetType(-ipp0.TStart,
-                                     ipp0.TEnd,
-                                     ipp0.IPPStart,
-                                     ipp0.IPPEnd,
-                                     ipp0.IPPPoly,
-                                     1,
-                                     **kwargs)
-    bad_timeline = Timeline.TimelineType(None, sicd.Timeline.CollectDuration, bad_ippset)
-    bad_timeline._check_ipp_times()
-    assert 'IPP entry 0 has negative TStart' in caplog.text
+def test_timeline_no_collect_duration():
+    bad_timeline = Timeline.TimelineType(
+        CollectStart=np.datetime64("2010-03-14T15:00:00.00"), CollectDuration=None
+    )
+    assert bad_timeline.CollectEnd is None
+    assert not bad_timeline.is_valid()
 
 
-def test_timeline_bad_tend(sicd, kwargs, caplog):
-    # TEnd too large
-    ipp0 = sicd.Timeline.IPP[0]
-    bad_ippset = Timeline.IPPSetType(ipp0.TStart,
-                                     sicd.Timeline.CollectDuration+1,
-                                     ipp0.IPPStart,
-                                     ipp0.IPPEnd,
-                                     ipp0.IPPPoly,
-                                     1,
-                                     **kwargs)
-    bad_timeline = Timeline.TimelineType(None, sicd.Timeline.CollectDuration, bad_ippset)
-    bad_timeline._check_ipp_times()
-    assert 'appreciably larger than CollectDuration' in caplog.text
+def test_timeline_no_ipp():
+    timeline = Timeline.TimelineType(
+        CollectStart=np.datetime64("2010-03-14T15:00:00.00"), CollectDuration=2.4
+    )
+    assert timeline.CollectEnd is not None
+    assert timeline.is_valid()
 
 
-def test_timeline_unset_ipp(sicd):
-    # Check times is True with no IPP set
-    bad_timeline = Timeline.TimelineType(sicd.Timeline.CollectStart, sicd.Timeline.CollectDuration, None)
-    assert bad_timeline._check_ipp_times()
+@pytest.fixture
+def timeline():
+    timeline = Timeline.TimelineType(
+        CollectStart=np.datetime64("2010-03-14T15:00:00.00"),
+        CollectDuration=2.4,
+        IPP=[
+            Timeline.IPPSetType(
+                TStart=0,
+                TEnd=1.2,
+                IPPStart=0,
+                IPPEnd=1e3,
+                IPPPoly=[0, (1e3 + 1) / 1.2],
+                index=1,
+            ),
+            Timeline.IPPSetType(
+                TStart=1.2,
+                TEnd=2.4,
+                IPPStart=1e3 + 1,
+                IPPEnd=3e3,
+                IPPPoly=npp.polyfit([1.2, 2.4], [1e3 + 1, 3e3 + 1], deg=1),
+                index=2,
+            ),
+        ],
+    )
+    assert timeline.is_valid(recursive=True)
+    return timeline
+
+
+def test_timeline_swap_indices(timeline, caplog):
+    for ipp in timeline.IPP:
+        ipp.index = len(timeline.IPP) - ipp.index + 1
+    assert not timeline.is_valid()
+    assert any(
+        re.search(r"The IPPSets are not in start time order", x.message)
+        for x in caplog.records
+    )
+    assert any(
+        re.search(r"The IPPSets are not in end time order", x.message)
+        for x in caplog.records
+    )
+
+
+def test_timeline_nonconsecutive_index(timeline, caplog):
+    for ipp in timeline.IPP:
+        ipp.index *= 2
+    assert not timeline.is_valid()
+    assert any(
+        re.search(r"IPPSets indices \(.+\) are not 1..size", x.message)
+        for x in caplog.records
+    )
+
+
+@pytest.mark.parametrize("modifier,expected_behavior", ((+1, "overlap"), (-1, "a gap")))
+def test_timeline_consecutive_times(timeline, caplog, modifier, expected_behavior):
+    timeline.IPP[0].TEnd += modifier
+    assert not timeline.is_valid()
+    assert any(
+        re.search(
+            rf"There is {expected_behavior} between IPPSet.+ of .+ seconds", x.message
+        )
+        for x in caplog.records
+    )
+
+
+@pytest.mark.parametrize("modifier,expected_behavior", ((+1, "overlap"), (-1, "a gap")))
+def test_timeline_consecutive_indices(timeline, caplog, modifier, expected_behavior):
+    timeline.IPP[0].IPPEnd += modifier
+    assert not timeline.is_valid()
+    assert any(
+        re.search(
+            rf"There is {expected_behavior} between IPPSet.+ of .+ IPPs", x.message
+        )
+        for x in caplog.records
+    )
+
+
+def test_timeline_negative_tstart(timeline, caplog):
+    timeline.IPP[0].TStart = -1e-3
+    assert not timeline.is_valid()
+    assert any(
+        re.search(r"Earliest TStart is negative", x.message) for x in caplog.records
+    )
+
+
+def test_timeline_large_tend(timeline, caplog):
+    timeline.IPP[-1].TEnd = timeline.CollectDuration * 10
+    assert not timeline.is_valid()
+    assert any(
+        re.search(
+            r"time range in IPP entries \(.+\) not in keeping with populated CollectDuration",
+            x.message,
+        )
+        for x in caplog.records
+    )


### PR DESCRIPTION
# Description
This PR addresses an inconsistency in SarPy's SICD Timeline validation which currently differs in two places:
1. `sarpy/io/complex/sicd_elements/validation_checks.py`
1. `sarpy/io/complex/sicd_elements/Timeline.py`

To remove the redundant and inconsistent checks, this PR proposes:
- migrating `_validate_ippsets` from `sarpy/io/complex/sicd_elements/validation_checks.py` into appropriate validation methods inside `sarpy/io/complex/sicd_elements/Timeline.py`
  - de-duplicate inconsistent checks for `IPPPoly`
  - sort based on `index` attribute prior to performing consecutive `IPP/Set` validation
- update`tests/io/complex/sicd_elements/test_sicd_elements_timeline.py` to test the migrated functionality
  - I ran `black` afterwards, so the changes hopefully appear larger than they actually are to review

# Test Plan
<details><summary>multi-environment tests pass</summary>

```
nox
nox > Running session test(version='3.6')
nox > Creating conda env in .nox/test-version-3-6 with python
nox > conda install --yes --prefix /home/vscuser/git/glweb/software/third-party/sarpy/.nox/test-version-3-6 python=3.6
nox > python -m pip install '.[all]'
nox > pytest tests
======================================================================== test session starts =========================================================================
platform linux -- Python 3.6.13, pytest-7.0.1, pluggy-1.0.0
rootdir: /home/vscuser/git/glweb/software/third-party/sarpy
collected 553 items                                                                                                                                                  

tests/test_class_string.py .                                                                                                                                   [  0%]
tests/consistency/test_consistency.py ........                                                                                                                 [  1%]
tests/consistency/test_cphd_consistency.py ..............................................................                                                      [ 12%]
tests/consistency/test_sicd_consistency.py ...                                                                                                                 [ 13%]
tests/consistency/test_sidd_consistency.py ....                                                                                                                [ 14%]
tests/geometry/test_geocoords.py ..........                                                                                                                    [ 15%]
tests/geometry/test_geometry_elements.py ..........                                                                                                            [ 17%]
tests/geometry/test_latlon.py ...                                                                                                                              [ 18%]
tests/geometry/test_point_projection.py ............                                                                                                           [ 20%]
tests/io/test_kml.py .                                                                                                                                         [ 20%]
tests/io/DEM/test_geoid.py .                                                                                                                                   [ 20%]
tests/io/DEM/test_geotiff1deg_list.py ....                                                                                                                     [ 21%]
tests/io/DEM/test_geotiff1deg_reader.py ........                                                                                                               [ 22%]
tests/io/complex/test_other_nitf.py ...                                                                                                                        [ 23%]
tests/io/complex/test_reader.py .ssssssssss                                                                                                                    [ 25%]
tests/io/complex/test_remote.py s                                                                                                                              [ 25%]
tests/io/complex/test_sicd.py .                                                                                                                                [ 25%]
tests/io/complex/test_utils.py .                                                                                                                               [ 26%]
tests/io/complex/sicd_elements/test_sicd_elements_antenna.py ...                                                                                               [ 26%]
tests/io/complex/sicd_elements/test_sicd_elements_base.py ...                                                                                                  [ 27%]
tests/io/complex/sicd_elements/test_sicd_elements_blocks.py .....................                                                                              [ 30%]
tests/io/complex/sicd_elements/test_sicd_elements_collectioninfo.py ..                                                                                         [ 31%]
tests/io/complex/sicd_elements/test_sicd_elements_errorstatistics.py .                                                                                         [ 31%]
tests/io/complex/sicd_elements/test_sicd_elements_geodata.py ...                                                                                               [ 32%]
tests/io/complex/sicd_elements/test_sicd_elements_grid.py ..                                                                                                   [ 32%]
tests/io/complex/sicd_elements/test_sicd_elements_imagecreation.py .                                                                                           [ 32%]
tests/io/complex/sicd_elements/test_sicd_elements_imagedata.py .                                                                                               [ 32%]
tests/io/complex/sicd_elements/test_sicd_elements_imageformation.py ......                                                                                     [ 33%]
tests/io/complex/sicd_elements/test_sicd_elements_matchinfo.py .                                                                                               [ 33%]
tests/io/complex/sicd_elements/test_sicd_elements_pfa.py .                                                                                                     [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_position.py ...                                                                                              [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_radarcollection.py ..............                                                                            [ 37%]
tests/io/complex/sicd_elements/test_sicd_elements_radiometric.py .                                                                                             [ 37%]
tests/io/complex/sicd_elements/test_sicd_elements_rgazcomp.py .                                                                                                [ 37%]
tests/io/complex/sicd_elements/test_sicd_elements_rma.py ...                                                                                                   [ 38%]
tests/io/complex/sicd_elements/test_sicd_elements_scpcoa.py ...................                                                                                [ 41%]
tests/io/complex/sicd_elements/test_sicd_elements_sicd.py ..................................                                                                   [ 47%]
tests/io/complex/sicd_elements/test_sicd_elements_timeline.py ..................                                                                               [ 50%]
tests/io/complex/sicd_elements/test_sicd_elements_utils.py ...                                                                                                 [ 51%]
tests/io/general/test_base.py ...                                                                                                                              [ 52%]
tests/io/general/test_data_segment.py ..........                                                                                                               [ 53%]
tests/io/general/test_format_function.py .......                                                                                                               [ 55%]
tests/io/general/test_nitf_headers.py .                                                                                                                        [ 55%]
tests/io/general/test_tre.py .                                                                                                                                 [ 55%]
tests/io/phase_history/test_cphd.py .....                                                                                                                      [ 56%]
tests/io/phase_history/test_cphd_versions.py .....                                                                                                             [ 57%]
tests/io/phase_history/cphd1_elements/test_cphd.py ....                                                                                                        [ 58%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_antenna.py .....                                                                                     [ 58%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_blocks.py ....                                                                                       [ 59%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_channel.py .                                                                                         [ 59%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_data.py .                                                                                            [ 60%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_dwell.py .                                                                                           [ 60%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_geoinfo.py ...                                                                                       [ 60%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_global.py ..                                                                                         [ 61%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_pvp.py .                                                                                             [ 61%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_referencegeometry.py .                                                                               [ 61%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_supportarray.py ..                                                                                   [ 61%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_txrcv.py .                                                                                           [ 62%]
tests/io/phase_history/cphd1_elements/test_utils.py .                                                                                                          [ 62%]
tests/io/product/test_reader.py ..s                                                                                                                            [ 62%]
tests/io/product/test_sidd_schema.py .........                                                                                                                 [ 64%]
tests/io/product/test_sidd_writing.py .                                                                                                                        [ 64%]
tests/io/product/sidd3_elements/test_exploitationfeatures.py ................................................................................................. [ 82%]
.................................                                                                                                                              [ 88%]
tests/io/product/sidd3_elements/test_sidd3_elements.py .....                                                                                                   [ 88%]
tests/io/received/test_crsd.py .                                                                                                                               [ 89%]
tests/processing/sicd/test_spectral_taper.py ........ss...........                                                                                             [ 92%]
tests/utils/test_sicd_sidelobe_control.py ..                                                                                                                   [ 93%]
tests/utils/test_sicd_to_sidd.py ............                                                                                                                  [ 95%]
tests/visualization/test_cphd_kmz_product_creation.py ..                                                                                                       [ 95%]
tests/visualization/test_crsd_kmz_product_creation.py .                                                                                                        [ 96%]
tests/visualization/test_kmz_product_creation.py .x                                                                                                            [ 96%]
tests/visualization/test_remap.py ....................                                                                                                         [100%]

========================================================================== warnings summary ==========================================================================
tests/geometry/test_point_projection.py::test_image_to_ground_errors
tests/geometry/test_point_projection.py::test_image_to_ground_dem
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/geometry/point_projection.py:1903: RuntimeWarning: divide by zero encountered in double_scalars
    lon_grid_size = min(10, lat_grid_size/abs(numpy.sin(numpy.deg2rad(ref_llh[0]))))

tests/visualization/test_kmz_product_creation.py::test_create_kmz[True]
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/visualization/kmz_utils.py:169: RuntimeWarning: invalid value encountered in double_scalars
    + dir_z**2 * semiaxis_a**2 * semiaxis_b**2

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
====================================================== 538 passed, 14 skipped, 1 xfailed, 3 warnings in 45.03s =======================================================
nox > Session test(version='3.6') was successful.
nox > Running session test(version='3.11')
nox > Creating conda env in .nox/test-version-3-11 with python
nox > conda install --yes --prefix /home/vscuser/git/glweb/software/third-party/sarpy/.nox/test-version-3-11 python=3.11
nox > python -m pip install '.[all]'
nox > pytest tests
======================================================================== test session starts =========================================================================
platform linux -- Python 3.11.5, pytest-7.4.3, pluggy-1.3.0
rootdir: /home/vscuser/git/glweb/software/third-party/sarpy
collected 553 items                                                                                                                                                  

tests/test_class_string.py .                                                                                                                                   [  0%]
tests/consistency/test_consistency.py ........                                                                                                                 [  1%]
tests/consistency/test_cphd_consistency.py ..............................................................                                                      [ 12%]
tests/consistency/test_sicd_consistency.py ...                                                                                                                 [ 13%]
tests/consistency/test_sidd_consistency.py ....                                                                                                                [ 14%]
tests/geometry/test_geocoords.py ..........                                                                                                                    [ 15%]
tests/geometry/test_geometry_elements.py ..........                                                                                                            [ 17%]
tests/geometry/test_latlon.py ...                                                                                                                              [ 18%]
tests/geometry/test_point_projection.py ............                                                                                                           [ 20%]
tests/io/test_kml.py .                                                                                                                                         [ 20%]
tests/io/DEM/test_geoid.py .                                                                                                                                   [ 20%]
tests/io/DEM/test_geotiff1deg_list.py ....                                                                                                                     [ 21%]
tests/io/DEM/test_geotiff1deg_reader.py ........                                                                                                               [ 22%]
tests/io/complex/test_other_nitf.py ...                                                                                                                        [ 23%]
tests/io/complex/test_reader.py .ssssssssss                                                                                                                    [ 25%]
tests/io/complex/test_remote.py s                                                                                                                              [ 25%]
tests/io/complex/test_sicd.py .                                                                                                                                [ 25%]
tests/io/complex/test_utils.py .                                                                                                                               [ 26%]
tests/io/complex/sicd_elements/test_sicd_elements_antenna.py ...                                                                                               [ 26%]
tests/io/complex/sicd_elements/test_sicd_elements_base.py ...                                                                                                  [ 27%]
tests/io/complex/sicd_elements/test_sicd_elements_blocks.py .....................                                                                              [ 30%]
tests/io/complex/sicd_elements/test_sicd_elements_collectioninfo.py ..                                                                                         [ 31%]
tests/io/complex/sicd_elements/test_sicd_elements_errorstatistics.py .                                                                                         [ 31%]
tests/io/complex/sicd_elements/test_sicd_elements_geodata.py ...                                                                                               [ 32%]
tests/io/complex/sicd_elements/test_sicd_elements_grid.py ..                                                                                                   [ 32%]
tests/io/complex/sicd_elements/test_sicd_elements_imagecreation.py .                                                                                           [ 32%]
tests/io/complex/sicd_elements/test_sicd_elements_imagedata.py .                                                                                               [ 32%]
tests/io/complex/sicd_elements/test_sicd_elements_imageformation.py ......                                                                                     [ 33%]
tests/io/complex/sicd_elements/test_sicd_elements_matchinfo.py .                                                                                               [ 33%]
tests/io/complex/sicd_elements/test_sicd_elements_pfa.py .                                                                                                     [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_position.py ...                                                                                              [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_radarcollection.py ..............                                                                            [ 37%]
tests/io/complex/sicd_elements/test_sicd_elements_radiometric.py .                                                                                             [ 37%]
tests/io/complex/sicd_elements/test_sicd_elements_rgazcomp.py .                                                                                                [ 37%]
tests/io/complex/sicd_elements/test_sicd_elements_rma.py ...                                                                                                   [ 38%]
tests/io/complex/sicd_elements/test_sicd_elements_scpcoa.py ...................                                                                                [ 41%]
tests/io/complex/sicd_elements/test_sicd_elements_sicd.py ..................................                                                                   [ 47%]
tests/io/complex/sicd_elements/test_sicd_elements_timeline.py ..................                                                                               [ 50%]
tests/io/complex/sicd_elements/test_sicd_elements_utils.py ...                                                                                                 [ 51%]
tests/io/general/test_base.py ...                                                                                                                              [ 52%]
tests/io/general/test_data_segment.py ..........                                                                                                               [ 53%]
tests/io/general/test_format_function.py .......                                                                                                               [ 55%]
tests/io/general/test_nitf_headers.py .                                                                                                                        [ 55%]
tests/io/general/test_tre.py .                                                                                                                                 [ 55%]
tests/io/phase_history/test_cphd.py .....                                                                                                                      [ 56%]
tests/io/phase_history/test_cphd_versions.py .....                                                                                                             [ 57%]
tests/io/phase_history/cphd1_elements/test_cphd.py ....                                                                                                        [ 58%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_antenna.py .....                                                                                     [ 58%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_blocks.py ....                                                                                       [ 59%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_channel.py .                                                                                         [ 59%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_data.py .                                                                                            [ 60%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_dwell.py .                                                                                           [ 60%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_geoinfo.py ...                                                                                       [ 60%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_global.py ..                                                                                         [ 61%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_pvp.py .                                                                                             [ 61%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_referencegeometry.py .                                                                               [ 61%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_supportarray.py ..                                                                                   [ 61%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_txrcv.py .                                                                                           [ 62%]
tests/io/phase_history/cphd1_elements/test_utils.py .                                                                                                          [ 62%]
tests/io/product/test_reader.py ..s                                                                                                                            [ 62%]
tests/io/product/test_sidd_schema.py .........                                                                                                                 [ 64%]
tests/io/product/test_sidd_writing.py .                                                                                                                        [ 64%]
tests/io/product/sidd3_elements/test_exploitationfeatures.py ................................................................................................. [ 82%]
.................................                                                                                                                              [ 88%]
tests/io/product/sidd3_elements/test_sidd3_elements.py .....                                                                                                   [ 88%]
tests/io/received/test_crsd.py .                                                                                                                               [ 89%]
tests/processing/sicd/test_spectral_taper.py .....................                                                                                             [ 92%]
tests/utils/test_sicd_sidelobe_control.py ..                                                                                                                   [ 93%]
tests/utils/test_sicd_to_sidd.py ............                                                                                                                  [ 95%]
tests/visualization/test_cphd_kmz_product_creation.py ..                                                                                                       [ 95%]
tests/visualization/test_crsd_kmz_product_creation.py .                                                                                                        [ 96%]
tests/visualization/test_kmz_product_creation.py .x                                                                                                            [ 96%]
tests/visualization/test_remap.py ....................                                                                                                         [100%]

========================================================================== warnings summary ==========================================================================
tests/test_class_string.py::TestClassString::test_class_str
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/annotation/afrl_rde_schema/__init__.py:7: DeprecationWarning: pkg_resources is deprecated as an API. See ht
tps://setuptools.pypa.io/en/latest/pkg_resources.html                                                                                                                     import pkg_resources

tests/consistency/test_sidd_consistency.py::test_main
tests/consistency/test_sidd_consistency.py::test_main
tests/consistency/test_sidd_consistency.py::test_main
tests/consistency/test_sidd_consistency.py::test_main
tests/visualization/test_remap.py::TestRemap::test_LUTRemap_matplotlib
tests/visualization/test_remap.py::TestRemap::test_remap_names
tests/visualization/test_remap.py::TestRemap::test_remap_names
tests/visualization/test_remap.py::TestRemap::test_remap_names
tests/visualization/test_remap.py::TestRemap::test_remap_names
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/visualization/remap.py:1751: MatplotlibDeprecationWarning: The get_cmap function was deprecated in Matplotl
ib 3.7 and will be removed two minor releases later. Use ``matplotlib.colormaps[name]`` or ``matplotlib.colormaps.get_cmap(obj)`` instead.                                cmap = cm.get_cmap(value, max_out_size+1)

tests/geometry/test_point_projection.py::test_image_to_ground_errors
tests/geometry/test_point_projection.py::test_image_to_ground_dem
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/geometry/point_projection.py:1903: RuntimeWarning: divide by zero encountered in scalar divide
    lon_grid_size = min(10, lat_grid_size/abs(numpy.sin(numpy.deg2rad(ref_llh[0]))))

tests/visualization/test_cphd_kmz_product_creation.py::test_create_kmz
tests/visualization/test_cphd_kmz_product_creation.py::test_create_kmz
tests/visualization/test_cphd_kmz_product_creation.py::test_create_kmz
tests/visualization/test_cphd_kmz_product_creation.py::test_create_kmz
tests/visualization/test_cphd_kmz_product_creation.py::test_create_kmz
tests/visualization/test_cphd_kmz_product_creation.py::test_create_kmz
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/visualization/kmz_utils.py:302: MatplotlibDeprecationWarning: The collections attribute was deprecated in M
atplotlib 3.8 and will be removed two minor releases later.                                                                                                               for path in contour_sets.collections[0].get_paths()

tests/visualization/test_kmz_product_creation.py::test_create_kmz[True]
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/visualization/kmz_utils.py:145: RuntimeWarning: invalid value encountered in scalar divide
    distance = (

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
====================================================== 540 passed, 12 skipped, 1 xfailed, 19 warnings in 34.17s ======================================================
nox > Session test(version='3.11') was successful.
nox > Ran multiple sessions:
nox > * test(version='3.6'): success
nox > * test(version='3.11'): success

```

</details>