### PR TITLE
fix transpose error in point_projection._ric_ecf_mat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ release points are not being annotated in GitHub.
 - Fix `sarpy/io/complex/sicd_elements/Timeline.py` validation code to allow IPP T1End == T2Start
 - Properly close file objects in NITF and CPHD writers
 - SIDD file reading in `sarpy/consistency/sidd_consistency.py`
+- Application of adjustable parameter offsets in RIC frames during projection
 
 ## [1.3.58] - 2023-08-07
 ### Added

--- a/sarpy/geometry/point_projection.py
+++ b/sarpy/geometry/point_projection.py
@@ -151,7 +151,7 @@ def _ric_ecf_mat(
     c /= numpy.linalg.norm(c)  # NB: perpendicular to r
     i = numpy.cross(c, r)
     # this is the cross of two perpendicular normal vectors, so normal
-    return numpy.array([r, i, c], dtype='float64')
+    return numpy.stack([r, i, c], axis=-1).astype('float64')
 
 
 def _get_sicd_type_specific_projection(sicd) -> Callable:

--- a/tests/geometry/test_point_projection.py
+++ b/tests/geometry/test_point_projection.py
@@ -252,3 +252,23 @@ def test_validate_adjustment_param_error(sicd):
     coords = np.array(coords)
     with pytest.raises(ValueError, match=r"position must have shape \(3, \). Got \(4, 1\)"):
         point_projection._validate_adj_param(coords, 'position')
+
+
+def test_image_to_ground_adjustable_offsets(sicd):
+    # RIC_ECF and ECF frames give consistent results
+    delta_arp_radial = 1000
+    scp_perturb_ric = point_projection.image_to_ground(sicd['scp_pixel'], sicd['structure'],
+                                                       projection_type='PLANE',
+                                                       delta_arp=[delta_arp_radial, 0, 0],
+                                                       delta_varp=[0, 0, 0],
+                                                       adj_params_frame='RIC_ECF')
+
+    arppos = sicd['structure'].SCPCOA.ARPPos.get_array()
+    delta_arp_ecf = delta_arp_radial * (arppos / np.linalg.norm(arppos))
+    scp_perturb_ecf = point_projection.image_to_ground(sicd['scp_pixel'], sicd['structure'],
+                                                       projection_type='PLANE',
+                                                       delta_arp=delta_arp_ecf,
+                                                       delta_varp=[0, 0, 0],
+                                                       adj_params_frame='ECF')
+    assert np.allclose(scp_perturb_ric, scp_perturb_ecf)
+    assert not np.allclose(sicd['scp_ecf'], scp_perturb_ecf)


### PR DESCRIPTION
# Description
This PR addresses the transpose error identified in #490. I opted for `stack` instead of a trailing `.T` to _perhaps_ make it a bit more obvious at a glance what is happening.

The new unittest fails in the integration branch (demonstrating the bug):

<details><summary>example of failure with bug</summary>

```
pytest tests/geometry/test_point_projection.py::test_image_to_ground_adjustable_offsets
============================================================================================= test session starts ==============================================================================================
platform linux -- Python 3.11.5, pytest-7.4.0, pluggy-1.0.0
rootdir: /home/vscuser/git/glweb/software/third-party/sarpy
plugins: cov-4.1.0, anyio-3.5.0
collected 1 item                                                                                                                                                                                               

tests/geometry/test_point_projection.py F                                                                                                                                                                [100%]

=================================================================================================== FAILURES ===================================================================================================
___________________________________________________________________________________ test_image_to_ground_adjustable_offsets ____________________________________________________________________________________

sicd = {'scp_ecf': [6378137.0, 0.0, 0.0], 'scp_llh': [0.0, 0.0, 0.0], 'scp_pixel': [747, 861], 'structure': SICDType(**Ordere...1', 66.26816520546485), ('Krg2', 67.15614928898086), ('Kaz1', -0.445246556639635
7), ('Kaz2', 0.4452465566396357)]))]))}                                                                                                                                                                         
    def test_image_to_ground_adjustable_offsets(sicd):
        # RIC_ECF and ECF frames give consistent results
        delta_arp_radial = 1000
        scp_perturb_ric = point_projection.image_to_ground(sicd['scp_pixel'], sicd['structure'],
                                                           projection_type='PLANE',
                                                           delta_arp=[delta_arp_radial, 0, 0],
                                                           delta_varp=[0, 0, 0],
                                                           adj_params_frame='RIC_ECF')
    
        arppos = sicd['structure'].SCPCOA.ARPPos.get_array()
        delta_arp_ecf = delta_arp_radial * (arppos / np.linalg.norm(arppos))
        scp_perturb_ecf = point_projection.image_to_ground(sicd['scp_pixel'], sicd['structure'],
                                                           projection_type='PLANE',
                                                           delta_arp=delta_arp_ecf,
                                                           delta_varp=[0, 0, 0],
                                                           adj_params_frame='ECF')
>       assert np.allclose(scp_perturb_ric, scp_perturb_ecf)
E       assert False
E        +  where False = <function allclose at 0x7f4752da9030>(array([ 6.37813700e+06, -3.15747144e+01,  7.82887598e+02]), array([ 6.37813700e+06, -4.32120931e+01,  7.85298565e+02]))
E        +    where <function allclose at 0x7f4752da9030> = np.allclose

tests/geometry/test_point_projection.py:273: AssertionError
=========================================================================================== short test summary info ============================================================================================
FAILED tests/geometry/test_point_projection.py::test_image_to_ground_adjustable_offsets - assert False
============================================================================================== 1 failed in 0.92s ===============================================================================================
                                                                                                                                                                                                                

```

</details>

and succeeds (along with the rest of the tests) in this branch:

<details><summary>multi-environment test results</summary>

```
nox
nox > Running session test(version='3.6')
nox > Creating conda env in .nox/test-version-3-6 with python
nox > conda install --yes --prefix /home/vscuser/git/glweb/software/third-party/sarpy/.nox/test-version-3-6 python=3.6
nox > python -m pip install '.[all]'
nox > pytest tests
============================================================================================= test session starts ==============================================================================================
platform linux -- Python 3.6.13, pytest-7.0.1, pluggy-1.0.0
rootdir: /home/vscuser/git/glweb/software/third-party/sarpy
collected 554 items                                                                                                                                                                                            

tests/test_class_string.py .                                                                                                                                                                             [  0%]
tests/consistency/test_consistency.py ........                                                                                                                                                           [  1%]
tests/consistency/test_cphd_consistency.py ..............................................................                                                                                                [ 12%]
tests/consistency/test_sicd_consistency.py ...                                                                                                                                                           [ 13%]
tests/consistency/test_sidd_consistency.py ....                                                                                                                                                          [ 14%]
tests/geometry/test_geocoords.py ..........                                                                                                                                                              [ 15%]
tests/geometry/test_geometry_elements.py ..........                                                                                                                                                      [ 17%]
tests/geometry/test_latlon.py ...                                                                                                                                                                        [ 18%]
tests/geometry/test_point_projection.py .............                                                                                                                                                    [ 20%]
tests/io/test_kml.py .                                                                                                                                                                                   [ 20%]
tests/io/DEM/test_geoid.py .                                                                                                                                                                             [ 20%]
tests/io/DEM/test_geotiff1deg_list.py ....                                                                                                                                                               [ 21%]
tests/io/DEM/test_geotiff1deg_reader.py ........                                                                                                                                                         [ 23%]
tests/io/complex/test_other_nitf.py ...                                                                                                                                                                  [ 23%]
tests/io/complex/test_reader.py .ssssssssss                                                                                                                                                              [ 25%]
tests/io/complex/test_remote.py s                                                                                                                                                                        [ 25%]
tests/io/complex/test_sicd.py .                                                                                                                                                                          [ 25%]
tests/io/complex/test_utils.py .                                                                                                                                                                         [ 26%]
tests/io/complex/sicd_elements/test_sicd_elements_antenna.py ...                                                                                                                                         [ 26%]
tests/io/complex/sicd_elements/test_sicd_elements_base.py ...                                                                                                                                            [ 27%]
tests/io/complex/sicd_elements/test_sicd_elements_blocks.py .....................                                                                                                                        [ 31%]
tests/io/complex/sicd_elements/test_sicd_elements_collectioninfo.py ..                                                                                                                                   [ 31%]
tests/io/complex/sicd_elements/test_sicd_elements_errorstatistics.py .                                                                                                                                   [ 31%]
tests/io/complex/sicd_elements/test_sicd_elements_geodata.py ...                                                                                                                                         [ 32%]
tests/io/complex/sicd_elements/test_sicd_elements_grid.py ..                                                                                                                                             [ 32%]
tests/io/complex/sicd_elements/test_sicd_elements_imagecreation.py .                                                                                                                                     [ 32%]
tests/io/complex/sicd_elements/test_sicd_elements_imagedata.py .                                                                                                                                         [ 32%]
tests/io/complex/sicd_elements/test_sicd_elements_imageformation.py ......                                                                                                                               [ 33%]
tests/io/complex/sicd_elements/test_sicd_elements_matchinfo.py .                                                                                                                                         [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_pfa.py .                                                                                                                                               [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_position.py ...                                                                                                                                        [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_radarcollection.py ..............                                                                                                                      [ 37%]
tests/io/complex/sicd_elements/test_sicd_elements_radiometric.py .                                                                                                                                       [ 37%]
tests/io/complex/sicd_elements/test_sicd_elements_rgazcomp.py .                                                                                                                                          [ 37%]
tests/io/complex/sicd_elements/test_sicd_elements_rma.py ...                                                                                                                                             [ 38%]
tests/io/complex/sicd_elements/test_sicd_elements_scpcoa.py ...................                                                                                                                          [ 41%]
tests/io/complex/sicd_elements/test_sicd_elements_sicd.py ..................................                                                                                                             [ 47%]
tests/io/complex/sicd_elements/test_sicd_elements_timeline.py ..................                                                                                                                         [ 51%]
tests/io/complex/sicd_elements/test_sicd_elements_utils.py ...                                                                                                                                           [ 51%]
tests/io/general/test_base.py ...                                                                                                                                                                        [ 52%]
tests/io/general/test_data_segment.py ..........                                                                                                                                                         [ 53%]
tests/io/general/test_format_function.py .......                                                                                                                                                         [ 55%]
tests/io/general/test_nitf_headers.py .                                                                                                                                                                  [ 55%]
tests/io/general/test_tre.py .                                                                                                                                                                           [ 55%]
tests/io/phase_history/test_cphd.py .....                                                                                                                                                                [ 56%]
tests/io/phase_history/test_cphd_versions.py .....                                                                                                                                                       [ 57%]
tests/io/phase_history/cphd1_elements/test_cphd.py ....                                                                                                                                                  [ 58%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_antenna.py .....                                                                                                                               [ 59%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_blocks.py ....                                                                                                                                 [ 59%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_channel.py .                                                                                                                                   [ 59%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_data.py .                                                                                                                                      [ 60%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_dwell.py .                                                                                                                                     [ 60%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_geoinfo.py ...                                                                                                                                 [ 60%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_global.py ..                                                                                                                                   [ 61%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_pvp.py .                                                                                                                                       [ 61%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_referencegeometry.py .                                                                                                                         [ 61%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_supportarray.py ..                                                                                                                             [ 61%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_txrcv.py .                                                                                                                                     [ 62%]
tests/io/phase_history/cphd1_elements/test_utils.py .                                                                                                                                                    [ 62%]
tests/io/product/test_reader.py ..s                                                                                                                                                                      [ 62%]
tests/io/product/test_sidd_schema.py .........                                                                                                                                                           [ 64%]
tests/io/product/test_sidd_writing.py .                                                                                                                                                                  [ 64%]
tests/io/product/sidd3_elements/test_exploitationfeatures.py ..................................................................................................................................          [ 88%]
tests/io/product/sidd3_elements/test_sidd3_elements.py .....                                                                                                                                             [ 88%]
tests/io/received/test_crsd.py .                                                                                                                                                                         [ 89%]
tests/processing/sicd/test_spectral_taper.py ........ss...........                                                                                                                                       [ 92%]
tests/utils/test_sicd_sidelobe_control.py ..                                                                                                                                                             [ 93%]
tests/utils/test_sicd_to_sidd.py ............                                                                                                                                                            [ 95%]
tests/visualization/test_cphd_kmz_product_creation.py ..                                                                                                                                                 [ 95%]
tests/visualization/test_crsd_kmz_product_creation.py .                                                                                                                                                  [ 96%]
tests/visualization/test_kmz_product_creation.py .x                                                                                                                                                      [ 96%]
tests/visualization/test_remap.py ....................                                                                                                                                                   [100%]

=============================================================================================== warnings summary ===============================================================================================
tests/geometry/test_point_projection.py::test_image_to_ground_errors
tests/geometry/test_point_projection.py::test_image_to_ground_dem
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/geometry/point_projection.py:1903: RuntimeWarning: divide by zero encountered in double_scalars
    lon_grid_size = min(10, lat_grid_size/abs(numpy.sin(numpy.deg2rad(ref_llh[0]))))

tests/visualization/test_kmz_product_creation.py::test_create_kmz[True]
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/visualization/kmz_utils.py:169: RuntimeWarning: invalid value encountered in double_scalars
    + dir_z**2 * semiaxis_a**2 * semiaxis_b**2

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================================================================== 539 passed, 14 skipped, 1 xfailed, 3 warnings in 42.89s ============================================================================
nox > Session test(version='3.6') was successful.
nox > Running session test(version='3.11')
nox > Creating conda env in .nox/test-version-3-11 with python
nox > conda install --yes --prefix /home/vscuser/git/glweb/software/third-party/sarpy/.nox/test-version-3-11 python=3.11
nox > python -m pip install '.[all]'
nox > pytest tests
============================================================================================= test session starts ==============================================================================================
platform linux -- Python 3.11.7, pytest-7.4.4, pluggy-1.3.0
rootdir: /home/vscuser/git/glweb/software/third-party/sarpy
collected 554 items                                                                                                                                                                                            

tests/test_class_string.py .                                                                                                                                                                             [  0%]
tests/consistency/test_consistency.py ........                                                                                                                                                           [  1%]
tests/consistency/test_cphd_consistency.py ..............................................................                                                                                                [ 12%]
tests/consistency/test_sicd_consistency.py ...                                                                                                                                                           [ 13%]
tests/consistency/test_sidd_consistency.py ....                                                                                                                                                          [ 14%]
tests/geometry/test_geocoords.py ..........                                                                                                                                                              [ 15%]
tests/geometry/test_geometry_elements.py ..........                                                                                                                                                      [ 17%]
tests/geometry/test_latlon.py ...                                                                                                                                                                        [ 18%]
tests/geometry/test_point_projection.py .............                                                                                                                                                    [ 20%]
tests/io/test_kml.py .                                                                                                                                                                                   [ 20%]
tests/io/DEM/test_geoid.py .                                                                                                                                                                             [ 20%]
tests/io/DEM/test_geotiff1deg_list.py ....                                                                                                                                                               [ 21%]
tests/io/DEM/test_geotiff1deg_reader.py ........                                                                                                                                                         [ 23%]
tests/io/complex/test_other_nitf.py ...                                                                                                                                                                  [ 23%]
tests/io/complex/test_reader.py .ssssssssss                                                                                                                                                              [ 25%]
tests/io/complex/test_remote.py s                                                                                                                                                                        [ 25%]
tests/io/complex/test_sicd.py .                                                                                                                                                                          [ 25%]
tests/io/complex/test_utils.py .                                                                                                                                                                         [ 26%]
tests/io/complex/sicd_elements/test_sicd_elements_antenna.py ...                                                                                                                                         [ 26%]
tests/io/complex/sicd_elements/test_sicd_elements_base.py ...                                                                                                                                            [ 27%]
tests/io/complex/sicd_elements/test_sicd_elements_blocks.py .....................                                                                                                                        [ 31%]
tests/io/complex/sicd_elements/test_sicd_elements_collectioninfo.py ..                                                                                                                                   [ 31%]
tests/io/complex/sicd_elements/test_sicd_elements_errorstatistics.py .                                                                                                                                   [ 31%]
tests/io/complex/sicd_elements/test_sicd_elements_geodata.py ...                                                                                                                                         [ 32%]
tests/io/complex/sicd_elements/test_sicd_elements_grid.py ..                                                                                                                                             [ 32%]
tests/io/complex/sicd_elements/test_sicd_elements_imagecreation.py .                                                                                                                                     [ 32%]
tests/io/complex/sicd_elements/test_sicd_elements_imagedata.py .                                                                                                                                         [ 32%]
tests/io/complex/sicd_elements/test_sicd_elements_imageformation.py ......                                                                                                                               [ 33%]
tests/io/complex/sicd_elements/test_sicd_elements_matchinfo.py .                                                                                                                                         [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_pfa.py .                                                                                                                                               [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_position.py ...                                                                                                                                        [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_radarcollection.py ..............                                                                                                                      [ 37%]
tests/io/complex/sicd_elements/test_sicd_elements_radiometric.py .                                                                                                                                       [ 37%]
tests/io/complex/sicd_elements/test_sicd_elements_rgazcomp.py .                                                                                                                                          [ 37%]
tests/io/complex/sicd_elements/test_sicd_elements_rma.py ...                                                                                                                                             [ 38%]
tests/io/complex/sicd_elements/test_sicd_elements_scpcoa.py ...................                                                                                                                          [ 41%]
tests/io/complex/sicd_elements/test_sicd_elements_sicd.py ..................................                                                                                                             [ 47%]
tests/io/complex/sicd_elements/test_sicd_elements_timeline.py ..................                                                                                                                         [ 51%]
tests/io/complex/sicd_elements/test_sicd_elements_utils.py ...                                                                                                                                           [ 51%]
tests/io/general/test_base.py ...                                                                                                                                                                        [ 52%]
tests/io/general/test_data_segment.py ..........                                                                                                                                                         [ 53%]
tests/io/general/test_format_function.py .......                                                                                                                                                         [ 55%]
tests/io/general/test_nitf_headers.py .                                                                                                                                                                  [ 55%]
tests/io/general/test_tre.py .                                                                                                                                                                           [ 55%]
tests/io/phase_history/test_cphd.py .....                                                                                                                                                                [ 56%]
tests/io/phase_history/test_cphd_versions.py .....                                                                                                                                                       [ 57%]
tests/io/phase_history/cphd1_elements/test_cphd.py ....                                                                                                                                                  [ 58%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_antenna.py .....                                                                                                                               [ 59%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_blocks.py ....                                                                                                                                 [ 59%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_channel.py .                                                                                                                                   [ 59%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_data.py .                                                                                                                                      [ 60%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_dwell.py .                                                                                                                                     [ 60%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_geoinfo.py ...                                                                                                                                 [ 60%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_global.py ..                                                                                                                                   [ 61%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_pvp.py .                                                                                                                                       [ 61%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_referencegeometry.py .                                                                                                                         [ 61%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_supportarray.py ..                                                                                                                             [ 61%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_txrcv.py .                                                                                                                                     [ 62%]
tests/io/phase_history/cphd1_elements/test_utils.py .                                                                                                                                                    [ 62%]
tests/io/product/test_reader.py ..s                                                                                                                                                                      [ 62%]
tests/io/product/test_sidd_schema.py .........                                                                                                                                                           [ 64%]
tests/io/product/test_sidd_writing.py .                                                                                                                                                                  [ 64%]
tests/io/product/sidd3_elements/test_exploitationfeatures.py ..................................................................................................................................          [ 88%]
tests/io/product/sidd3_elements/test_sidd3_elements.py .....                                                                                                                                             [ 88%]
tests/io/received/test_crsd.py .                                                                                                                                                                         [ 89%]
tests/processing/sicd/test_spectral_taper.py .....................                                                                                                                                       [ 92%]
tests/utils/test_sicd_sidelobe_control.py ..                                                                                                                                                             [ 93%]
tests/utils/test_sicd_to_sidd.py ............                                                                                                                                                            [ 95%]
tests/visualization/test_cphd_kmz_product_creation.py ..                                                                                                                                                 [ 95%]
tests/visualization/test_crsd_kmz_product_creation.py .                                                                                                                                                  [ 96%]
tests/visualization/test_kmz_product_creation.py .x                                                                                                                                                      [ 96%]
tests/visualization/test_remap.py ....................                                                                                                                                                   [100%]

=============================================================================================== warnings summary ===============================================================================================
tests/test_class_string.py::TestClassString::test_class_str
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/annotation/afrl_rde_schema/__init__.py:7: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_res
ources.html                                                                                                                                                                                                         import pkg_resources

tests/consistency/test_sidd_consistency.py::test_main
tests/consistency/test_sidd_consistency.py::test_main
tests/consistency/test_sidd_consistency.py::test_main
tests/consistency/test_sidd_consistency.py::test_main
tests/visualization/test_remap.py::TestRemap::test_LUTRemap_matplotlib
tests/visualization/test_remap.py::TestRemap::test_remap_names
tests/visualization/test_remap.py::TestRemap::test_remap_names
tests/visualization/test_remap.py::TestRemap::test_remap_names
tests/visualization/test_remap.py::TestRemap::test_remap_names
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/visualization/remap.py:1751: MatplotlibDeprecationWarning: The get_cmap function was deprecated in Matplotlib 3.7 and will be removed two minor relea
ses later. Use ``matplotlib.colormaps[name]`` or ``matplotlib.colormaps.get_cmap(obj)`` instead.                                                                                                                    cmap = cm.get_cmap(value, max_out_size+1)

tests/geometry/test_point_projection.py::test_image_to_ground_errors
tests/geometry/test_point_projection.py::test_image_to_ground_dem
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/geometry/point_projection.py:1903: RuntimeWarning: divide by zero encountered in scalar divide
    lon_grid_size = min(10, lat_grid_size/abs(numpy.sin(numpy.deg2rad(ref_llh[0]))))

tests/visualization/test_cphd_kmz_product_creation.py::test_create_kmz
tests/visualization/test_cphd_kmz_product_creation.py::test_create_kmz
tests/visualization/test_cphd_kmz_product_creation.py::test_create_kmz
tests/visualization/test_cphd_kmz_product_creation.py::test_create_kmz
tests/visualization/test_cphd_kmz_product_creation.py::test_create_kmz
tests/visualization/test_cphd_kmz_product_creation.py::test_create_kmz
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/visualization/kmz_utils.py:302: MatplotlibDeprecationWarning: The collections attribute was deprecated in Matplotlib 3.8 and will be removed two mino
r releases later.                                                                                                                                                                                                   for path in contour_sets.collections[0].get_paths()

tests/visualization/test_kmz_product_creation.py::test_create_kmz[True]
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/visualization/kmz_utils.py:145: RuntimeWarning: invalid value encountered in scalar divide
    distance = (

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================================================================== 541 passed, 12 skipped, 1 xfailed, 19 warnings in 32.49s ===========================================================================
nox > Session test(version='3.11') was successful.
nox > Ran multiple sessions:
nox > * test(version='3.6'): success
nox > * test(version='3.11'): success

```

</details>