### PR TITLE
Restore PIL dependency to optional status

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,9 @@ message indicating the missing optional dependency.
   data in hdf5 format require the `h5py` package, this includes Cosmo-Skymed, ICEYE, 
   and NISAR data.
 
-- Reading an image segment in a NITF file using jpeg or jpeg 2000 compression 
-  and/or writing a kmz image overlay requires the `pillow` package.
+- Reading an image segment in a NITF file using jpeg or jpeg 2000 compression,
+  reading a GeoTIFF DEM, and/or writing a kmz image overlay requires the `pillow` 
+  package.
 
 - CPHD consistency checks, presented in the `sarpy.consistency` module, depend on 
   `lxml>=4.1.1`, `networkx>=2.5`, `shapely>=1.6.4`, and `pytest>=3.3.2`. Note that these


### PR DESCRIPTION
The README file identifies Pillow as an optional dependency. The current master branch will not import unless Pillow is installed. This updates the geotiff module to import regardless of Pillow installation status, and to fail gracefully if Pillow is not installed.