### PR TITLE
fix parsing when number of bands > 9

### DIFF
--- a/sarpy/io/general/nitf_elements/image.py
+++ b/sarpy/io/general/nitf_elements/image.py
@@ -167,6 +167,8 @@ class ImageBands(NITFLoop):
     _child_class = ImageBand
     _count_size = 1
 
+    XBANDS_LEN = 5
+
     @classmethod
     def _parse_count(cls, value, start):
         loc = start
@@ -174,9 +176,15 @@ class ImageBands(NITFLoop):
         loc += cls._count_size
         if count == 0:
             # (only) if there are more than 9, a longer field is used
-            count = int(value[loc:loc + 5])
-            loc += 5
+            count = int(value[loc:loc + ImageBands.XBANDS_LEN])
+            loc += ImageBands.XBANDS_LEN
         return count, loc
+
+    def get_bytes_length(self):
+        if len(self._values) > 9:
+            return self._count_size + ImageBands.XBANDS_LEN + sum(entry.get_bytes_length() for entry in self._values)
+        else:
+            return self._count_size + sum(entry.get_bytes_length() for entry in self._values)
 
     def _counts_bytes(self):
         siz = len(self.values)


### PR DESCRIPTION
When parsing one of the SNIP Reference Implementation Products, I hit this:

```
$ python -m sarpy.utils.nitf_utils --output=dump.out ~/Downloads/07APR2005_Hyperion_331406N0442000E_SWIR172_1p2A_L1R-BIP.ntf
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/home/bradh/coding/sarpy/sarpy/utils/nitf_utils.py", line 483, in <module>
    dump_nitf_file(args.input_file, args.output)
  File "/home/bradh/coding/sarpy/sarpy/utils/nitf_utils.py", line 441, in dump_nitf_file
    print_nitf(file_name, dest=the_file)
  File "/home/bradh/coding/sarpy/sarpy/utils/nitf_utils.py", line 321, in print_nitf
    hdr = details.parse_image_subheader(img_subhead_num)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/bradh/coding/sarpy/sarpy/io/general/nitf.py", line 794, in parse_image_subheader
    out = ImageSegmentHeader.from_bytes(ih, 0)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/bradh/coding/sarpy/sarpy/io/general/nitf_elements/base.py", line 648, in from_bytes
    loc = cls._parse_attribute(fields, fld, value, loc)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/bradh/coding/sarpy/sarpy/io/general/nitf_elements/image.py", line 812, in _parse_attribute
    return super(ImageSegmentHeader, cls)._parse_attribute(fields, attribute, value, start)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/bradh/coding/sarpy/sarpy/io/general/nitf_elements/base.py", line 623, in _parse_attribute
    the_value = the_typ.from_bytes(value, start)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/bradh/coding/sarpy/sarpy/io/general/nitf_elements/base.py", line 648, in from_bytes
    loc = cls._parse_attribute(fields, fld, value, loc)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/bradh/coding/sarpy/sarpy/io/general/nitf_elements/base.py", line 1217, in _parse_attribute
    length = int(value[start:start + cls._size_len])
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: invalid literal for int() with base 10: b'01.0 '
```

The source data can be download from https://nsgreg.nga.mil/doc/view?i=5520 (no direct link because they expire).

That happens when parsing what should be the IMAG entry, but the problem occurs earlier. It looks like the default length calculation does not work correctly for the ImageBands case, when XBANDS is used (which is the case for the RIPs - 172 bands).

The proposed fix adds a constant for the XBANDS length, and overrides the byte length calculation to return the correct value.
