### PR TITLE
fix parsing when number of bands > 9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ release points are not being annotated in GitHub.
 - SIDD file reading in `sarpy/consistency/sidd_consistency.py`
 - Application of adjustable parameter offsets in RIC frames during projection
 - Overflow bug in `ComplexFormatFunction` magnitude/phase -> real/imag
+- Parsing of XBANDS, used when number of image bands > 9
 
 ## [1.3.58] - 2023-08-07
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ release points are not being annotated in GitHub.
 - SIDD file reading in `sarpy/consistency/sidd_consistency.py`
 - Application of adjustable parameter offsets in RIC frames during projection
 - Overflow bug in `ComplexFormatFunction` magnitude/phase -> real/imag
-- Parsing of XBANDS, used when number of image bands > 9
+- NITF image subheader parsing when there are more than 9 bands
 
 ## [1.3.58] - 2023-08-07
 ### Added

--- a/sarpy/io/general/nitf_elements/image.py
+++ b/sarpy/io/general/nitf_elements/image.py
@@ -166,6 +166,8 @@ class ImageBand(NITFElement):
 class ImageBands(NITFLoop):
     _child_class = ImageBand
     _count_size = 1
+    
+    XBANDS_LEN = 5
 
     @classmethod
     def _parse_count(cls, value, start):
@@ -174,10 +176,16 @@ class ImageBands(NITFLoop):
         loc += cls._count_size
         if count == 0:
             # (only) if there are more than 9, a longer field is used
-            count = int(value[loc:loc + 5])
-            loc += 5
+            count = int(value[loc:loc + ImageBands.XBANDS_LEN])
+            loc += ImageBands.XBANDS_LEN
         return count, loc
 
+    def get_bytes_length(self):
+        if len(self._values) > 9:
+            return self._count_size + ImageBands.XBANDS_LEN + sum(entry.get_bytes_length() for entry in self._values)
+        else:
+            return self._count_size + sum(entry.get_bytes_length() for entry in self._values)
+    
     def _counts_bytes(self):
         siz = len(self.values)
         if siz <= 9:

--- a/tests/io/general/test_nitf_image.py
+++ b/tests/io/general/test_nitf_image.py
@@ -1,0 +1,47 @@
+#
+# Copyright 2024 Valkyrie Systems Corporation
+#
+# Licensed under MIT License.  See LICENSE.
+#
+import pytest
+
+import sarpy.io.general.nitf_elements.image
+
+
+def __make_band_bytes(numbands):
+    banddef = {
+        'NBANDS': f'{numbands}'.encode() if numbands < 10 else b'0',
+        'XBANDS': b'' if numbands < 10 else f'{numbands:05d}'.encode(),
+    }
+    for n in range(numbands):
+        banddef.update({
+            f'IREPBAND{n:06d}': b'  ',
+            f'ISUBCAT{n:06d}': f'cat{n:03d}'.encode(),
+            f'IFC{n:06d}': b'N',
+            f'IMFLT{n:06d}': b'   ',
+            f'NLUTS{n:06d}': b'0',
+        })
+    return b''.join(banddef.values())
+
+
+def test_imagebands_minlength():
+    assert sarpy.io.general.nitf_elements.image.ImageBands.minimum_length() == len(__make_band_bytes(1))
+
+
+@pytest.mark.parametrize('num_bands', (1, 24))
+def test_imagebands(num_bands):
+    band_bytes = __make_band_bytes(num_bands)
+    parsed_bands = sarpy.io.general.nitf_elements.image.ImageBands.from_bytes(band_bytes, 0)
+    assert len(parsed_bands.values) == num_bands
+    assert all(int(x.ISUBCAT[3:]) == n for n, x in enumerate(parsed_bands.values))
+    assert parsed_bands.get_bytes_length() == len(band_bytes)
+    assert parsed_bands.to_bytes() == band_bytes
+
+
+def test_imagebands_values_update():
+    parsed_bands = sarpy.io.general.nitf_elements.image.ImageBands.from_bytes(__make_band_bytes(1), 0)
+    for nbands in range(1, 11):
+        parsed_bands.values = [parsed_bands.values[0]] * nbands
+        orig_bytes = parsed_bands.to_bytes()
+        round_trip_bytes = sarpy.io.general.nitf_elements.image.ImageBands.from_bytes(orig_bytes, 0).to_bytes()
+        assert orig_bytes == round_trip_bytes


### PR DESCRIPTION
(Rebased from #498)

When parsing one of the SNIP Reference Implementation Products (in master branch) I hit this:

```
$ python -m sarpy.utils.nitf_utils --output=dump.out ~/Downloads/07APR2005_Hyperion_331406N0442000E_SWIR172_1p2A_L1R-BIP.ntf
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/home/bradh/coding/sarpy/sarpy/utils/nitf_utils.py", line 483, in <module>
    dump_nitf_file(args.input_file, args.output)
  File "/home/bradh/coding/sarpy/sarpy/utils/nitf_utils.py", line 441, in dump_nitf_file
    print_nitf(file_name, dest=the_file)
  File "/home/bradh/coding/sarpy/sarpy/utils/nitf_utils.py", line 321, in print_nitf
    hdr = details.parse_image_subheader(img_subhead_num)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/bradh/coding/sarpy/sarpy/io/general/nitf.py", line 794, in parse_image_subheader
    out = ImageSegmentHeader.from_bytes(ih, 0)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/bradh/coding/sarpy/sarpy/io/general/nitf_elements/base.py", line 648, in from_bytes
    loc = cls._parse_attribute(fields, fld, value, loc)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/bradh/coding/sarpy/sarpy/io/general/nitf_elements/image.py", line 812, in _parse_attribute
    return super(ImageSegmentHeader, cls)._parse_attribute(fields, attribute, value, start)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/bradh/coding/sarpy/sarpy/io/general/nitf_elements/base.py", line 623, in _parse_attribute
    the_value = the_typ.from_bytes(value, start)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/bradh/coding/sarpy/sarpy/io/general/nitf_elements/base.py", line 648, in from_bytes
    loc = cls._parse_attribute(fields, fld, value, loc)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/bradh/coding/sarpy/sarpy/io/general/nitf_elements/base.py", line 1217, in _parse_attribute
    length = int(value[start:start + cls._size_len])
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: invalid literal for int() with base 10: b'01.0 '
```

The source data can be download from https://nsgreg.nga.mil/doc/view?i=5520 (no direct link because they expire).

That happens when parsing what should be the IMAG entry, but the problem occurs earlier. It looks like the default length calculation does not work correctly for the ImageBands case, when XBANDS is used (which is the case for the RIPs - 172 bands).

The proposed fix adds a constant for the XBANDS length, and overrides the byte length calculation to return the correct value.
