### PR TITLE
Ignore first argument of returned tuple

### DIFF
--- a/sarpy/io/general/format_function.py
+++ b/sarpy/io/general/format_function.py
@@ -1043,7 +1043,7 @@ class SingleLUTFormatFunction(FormatFunction):
             array = array.take(
                 indices=numpy.arange(self.formatted_shape[-1])[subscript[-1]], axis=-1)
             # ensure shape is as expected - any squeeze handled consistently
-            out_shape = get_subscript_result_size(subscript, self.formatted_shape)
+            _, out_shape = get_subscript_result_size(subscript, self.formatted_shape)
             array = numpy.reshape(array, out_shape)
         if squeeze:
             return numpy.squeeze(array)


### PR DESCRIPTION
I was working with some data which had an RGB lookup table. When calling the default `read()` method on the `NITFReader`, it fails at this spot because `get_subscript_result_size()` returns a `tuple`, but the variable it's assigned to is used as an argument for `numpy.reshape()`

In this context, only the `out_shape` seems to be needed (2nd return value), and everywhere else `get_subscript_result_size()` is called, the code has been updated to deal with two return values. 