### PR TITLE
Bugfix: SingleLUTFormatFunction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ release points are not being annotated in GitHub.
 - NITF image subheader parsing when there are more than 9 bands
 - Population of SIDD ExploitationFeatures resolution metadata when processed from a SICD
 - Fix BANDSB implementation to parse correctly
+- SingleLUTFormatFunction application for LUT with more than one dimension
 
 ## [1.3.58] - 2023-08-07
 ### Added

--- a/sarpy/io/general/format_function.py
+++ b/sarpy/io/general/format_function.py
@@ -1043,7 +1043,7 @@ class SingleLUTFormatFunction(FormatFunction):
             array = array.take(
                 indices=numpy.arange(self.formatted_shape[-1])[subscript[-1]], axis=-1)
             # ensure shape is as expected - any squeeze handled consistently
-            out_shape = get_subscript_result_size(subscript, self.formatted_shape)
+            _, out_shape = get_subscript_result_size(subscript, self.formatted_shape)
             array = numpy.reshape(array, out_shape)
         if squeeze:
             return numpy.squeeze(array)

--- a/tests/io/general/test_format_function.py
+++ b/tests/io/general/test_format_function.py
@@ -1,7 +1,7 @@
 import unittest
 
 import numpy
-from sarpy.io.general.format_function import IdentityFunction, ComplexFormatFunction
+from sarpy.io.general.format_function import IdentityFunction, ComplexFormatFunction, SingleLUTFormatFunction
 
 
 class TestIdentityFunction(unittest.TestCase):
@@ -173,3 +173,17 @@ class TestComplexFunction(unittest.TestCase):
 
                 inv_data = func.inverse(out_data, (slice(0, 2, 1), slice(0, 3, 1)))
                 self.assertTrue(numpy.all(base_data == inv_data), msg='PM {} inverse'.format(raw_type))
+
+
+class TestSingleLUTFormatFunction(unittest.TestCase):
+    def test_forward(self):
+        lut_sizes = ((24248,), (1<<16, 3))
+        rng = numpy.random.default_rng()
+        for lut_size in lut_sizes:
+            with self.subTest(msg=f'LUT size:{lut_size}'):
+                base_data = rng.integers(lut_size[0], size=(51, 49), dtype=numpy.uint16)
+                lut = rng.integers(1<<8, size=lut_size, dtype=numpy.uint8)
+                out_shape = base_data.shape if len(lut_size) == 1 else base_data.shape + (lut_size[1],)
+                func = SingleLUTFormatFunction(lut, base_data.shape, out_shape)
+                out_data = func(base_data, (slice(0, 51, 1), slice(0, 49, 1)))
+                self.assertTrue(numpy.array_equal(out_data, lut[base_data]), msg='LUT forward')


### PR DESCRIPTION
# Description
This PR adds a unittest and changelog entry to the fix from #505. As that PR was written against a fork's `master, I've opted for creating a new PR instead of adding commits to that one.

As seen below, the new test fails in `integration/1.3.59-rc`,:

<details><summary>test failure summary</summary>

```
pytest tests/io/general/test_format_function.py
======================================================================== test session starts =========================================================================
platform linux -- Python 3.10.13, pytest-7.4.0, pluggy-1.0.0
rootdir: /home/vscuser/git/glweb/software/third-party/sarpy
plugins: anyio-4.2.0
collected 8 items                                                                                                                                                    

tests/io/general/test_format_function.py .......F                                                                                                              [100%]

============================================================================== FAILURES ==============================================================================
______________________________________________________________ TestSingleLUTFormatFunction.test_forward ______________________________________________________________

obj = array([[[116, 239, 153],
        [ 57, 164, 226],
        [163,  46,   5],
        ...,
        [176, 106,  34],
     ...[134,  12, 177],
        ...,
        [231, 213,  45],
        [ 92,  40,  89],
        [223,  48,  70]]], dtype=uint8)
method = 'reshape', args = (((slice(0, 51, 1), slice(0, 49, 1), slice(0, 3, 1)), (51, 49, 3)),), kwds = {'order': 'C'}
bound = <built-in method reshape of numpy.ndarray object at 0x7f4f11f79f50>

    def _wrapfunc(obj, method, *args, **kwds):
        bound = getattr(obj, method, None)
        if bound is None:
            return _wrapit(obj, method, *args, **kwds)
    
        try:
>           return bound(*args, **kwds)
E           TypeError: 'tuple' object cannot be interpreted as an integer

/home/vscuser/miniconda3/envs/sarpy/lib/python3.10/site-packages/numpy/core/fromnumeric.py:59: TypeError

During handling of the above exception, another exception occurred:

self = <tests.io.general.test_format_function.TestSingleLUTFormatFunction testMethod=test_forward>

    def test_forward(self):
        lut_sizes = ((24248,), (1<<16, 3))
        rng = numpy.random.default_rng()
        for lut_size in lut_sizes:
            with self.subTest(msg=f'LUT size:{lut_size}'):
                base_data = rng.integers(lut_size[0], size=(51, 49), dtype=numpy.uint16)
                lut = rng.integers(1<<8, size=lut_size, dtype=numpy.uint8)
                out_shape = base_data.shape if len(lut_size) == 1 else base_data.shape + (lut_size[1],)
                func = SingleLUTFormatFunction(lut, base_data.shape, out_shape)
>               out_data = func(base_data, (slice(0, 51, 1), slice(0, 49, 1)))

tests/io/general/test_format_function.py:188: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
sarpy/io/general/format_function.py:1047: in __call__
    array = numpy.reshape(array, out_shape)
/home/vscuser/miniconda3/envs/sarpy/lib/python3.10/site-packages/numpy/core/fromnumeric.py:285: in reshape
    return _wrapfunc(a, 'reshape', newshape, order=order)
/home/vscuser/miniconda3/envs/sarpy/lib/python3.10/site-packages/numpy/core/fromnumeric.py:68: in _wrapfunc
    return _wrapit(obj, method, *args, **kwds)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

obj = array([[[116, 239, 153],
        [ 57, 164, 226],
        [163,  46,   5],
        ...,
        [176, 106,  34],
     ...[134,  12, 177],
        ...,
        [231, 213,  45],
        [ 92,  40,  89],
        [223,  48,  70]]], dtype=uint8)
method = 'reshape', args = (((slice(0, 51, 1), slice(0, 49, 1), slice(0, 3, 1)), (51, 49, 3)),), kwds = {'order': 'C'}
wrap = <built-in method __array_wrap__ of numpy.ndarray object at 0x7f4f11f79f50>

    def _wrapit(obj, method, *args, **kwds):
        try:
            wrap = obj.__array_wrap__
        except AttributeError:
            wrap = None
>       result = getattr(asarray(obj), method)(*args, **kwds)
E       TypeError: 'tuple' object cannot be interpreted as an integer

/home/vscuser/miniconda3/envs/sarpy/lib/python3.10/site-packages/numpy/core/fromnumeric.py:45: TypeError
====================================================================== short test summary info =======================================================================
FAILED tests/io/general/test_format_function.py::TestSingleLUTFormatFunction::test_forward - TypeError: 'tuple' object cannot be interpreted as an integer
==================================================================== 1 failed, 7 passed in 0.23s =====================================================================
                                                                                                                                                                      

```

</details>

but works (along with the rest of the tests) when the fix is applied:

<details><summary>test results</summary>

```
SARPY_TEST_PATH=/data/sarpy_test nox
nox > Running session test(version='3.6')
nox > Creating conda env in .nox/test-version-3-6 with python
nox > conda install --yes --prefix /home/vscuser/git/glweb/software/third-party/sarpy/.nox/test-version-3-6 python=3.6
nox > python -m pip install '.[all]'
nox > pytest tests
======================================================================== test session starts ========================================================================
platform linux -- Python 3.6.13, pytest-7.0.1, pluggy-1.0.0
rootdir: /home/vscuser/git/glweb/software/third-party/sarpy
collected 550 items                                                                                                                                                 

tests/test_class_string.py .                                                                                                                                  [  0%]
tests/consistency/test_consistency.py ........                                                                                                                [  1%]
tests/consistency/test_cphd_consistency.py ..............................................................                                                     [ 12%]
tests/consistency/test_sicd_consistency.py ...                                                                                                                [ 13%]
tests/consistency/test_sidd_consistency.py ....                                                                                                               [ 14%]
tests/geometry/test_geocoords.py ..........                                                                                                                   [ 16%]
tests/geometry/test_geometry_elements.py ..........                                                                                                           [ 17%]
tests/geometry/test_latlon.py ...                                                                                                                             [ 18%]
tests/geometry/test_point_projection.py ..............                                                                                                        [ 20%]
tests/io/test_kml.py .                                                                                                                                        [ 21%]
tests/io/DEM/test_geoid.py .                                                                                                                                  [ 21%]
tests/io/DEM/test_geotiff1deg_list.py ....                                                                                                                    [ 22%]
tests/io/DEM/test_geotiff1deg_reader.py ........                                                                                                              [ 23%]
tests/io/complex/test_other_nitf.py ...                                                                                                                       [ 24%]
tests/io/complex/test_reader.py .ssssssssss                                                                                                                   [ 26%]
tests/io/complex/test_remote.py s                                                                                                                             [ 26%]
tests/io/complex/test_sicd.py .                                                                                                                               [ 26%]
tests/io/complex/test_utils.py .                                                                                                                              [ 26%]
tests/io/complex/sicd_elements/test_sicd_elements_antenna.py ...                                                                                              [ 27%]
tests/io/complex/sicd_elements/test_sicd_elements_base.py ...                                                                                                 [ 27%]
tests/io/complex/sicd_elements/test_sicd_elements_blocks.py .....................                                                                             [ 31%]
tests/io/complex/sicd_elements/test_sicd_elements_collectioninfo.py ..                                                                                        [ 31%]
tests/io/complex/sicd_elements/test_sicd_elements_errorstatistics.py .                                                                                        [ 32%]
tests/io/complex/sicd_elements/test_sicd_elements_geodata.py ...                                                                                              [ 32%]
tests/io/complex/sicd_elements/test_sicd_elements_grid.py ..                                                                                                  [ 32%]
tests/io/complex/sicd_elements/test_sicd_elements_imagecreation.py .                                                                                          [ 33%]
tests/io/complex/sicd_elements/test_sicd_elements_imagedata.py .                                                                                              [ 33%]
tests/io/complex/sicd_elements/test_sicd_elements_imageformation.py ......                                                                                    [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_matchinfo.py .                                                                                              [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_pfa.py .                                                                                                    [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_position.py ...                                                                                             [ 35%]
tests/io/complex/sicd_elements/test_sicd_elements_radarcollection.py ..............                                                                           [ 37%]
tests/io/complex/sicd_elements/test_sicd_elements_radiometric.py .                                                                                            [ 38%]
tests/io/complex/sicd_elements/test_sicd_elements_rgazcomp.py .                                                                                               [ 38%]
tests/io/complex/sicd_elements/test_sicd_elements_rma.py ...                                                                                                  [ 38%]
tests/io/complex/sicd_elements/test_sicd_elements_scpcoa.py ...................                                                                               [ 42%]
tests/io/complex/sicd_elements/test_sicd_elements_sicd.py ..................................                                                                  [ 48%]
tests/io/complex/sicd_elements/test_sicd_elements_timeline.py ..................                                                                              [ 51%]
tests/io/complex/sicd_elements/test_sicd_elements_utils.py ...                                                                                                [ 52%]
tests/io/general/test_base.py ...                                                                                                                             [ 52%]
tests/io/general/test_data_segment.py ..........                                                                                                              [ 54%]
tests/io/general/test_format_function.py ........                                                                                                             [ 56%]
tests/io/general/test_nitf_headers.py .                                                                                                                       [ 56%]
tests/io/general/test_nitf_image.py ....                                                                                                                      [ 56%]
tests/io/general/test_tre.py ...                                                                                                                              [ 57%]
tests/io/phase_history/test_cphd.py .....                                                                                                                     [ 58%]
tests/io/phase_history/test_cphd_versions.py .....                                                                                                            [ 59%]
tests/io/phase_history/cphd1_elements/test_cphd.py ....                                                                                                       [ 60%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_antenna.py .....                                                                                    [ 60%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_blocks.py ....                                                                                      [ 61%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_channel.py .                                                                                        [ 61%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_data.py .                                                                                           [ 62%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_dwell.py .                                                                                          [ 62%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_geoinfo.py ...                                                                                      [ 62%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_global.py ..                                                                                        [ 63%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_pvp.py .                                                                                            [ 63%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_referencegeometry.py .                                                                              [ 63%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_supportarray.py ..                                                                                  [ 63%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_txrcv.py .                                                                                          [ 64%]
tests/io/phase_history/cphd1_elements/test_utils.py .                                                                                                         [ 64%]
tests/io/product/test_reader.py ..s                                                                                                                           [ 64%]
tests/io/product/test_sidd_schema.py .........                                                                                                                [ 66%]
tests/io/product/test_sidd_writing.py .                                                                                                                       [ 66%]
tests/io/product/sidd3_elements/test_exploitationfeatures.py ................................................................................................ [ 84%]
..................................                                                                                                                            [ 90%]
tests/io/product/sidd3_elements/test_sidd3_elements.py .....                                                                                                  [ 91%]
tests/io/received/test_crsd.py .                                                                                                                              [ 91%]
tests/processing/sicd/test_spectral_taper.py ........ss...........                                                                                            [ 95%]
tests/utils/test_sicd_sidelobe_control.py ..                                                                                                                  [ 95%]
tests/visualization/test_cphd_kmz_product_creation.py ..                                                                                                      [ 95%]
tests/visualization/test_crsd_kmz_product_creation.py .                                                                                                       [ 96%]
tests/visualization/test_kmz_product_creation.py .x                                                                                                           [ 96%]
tests/visualization/test_remap.py ....................                                                                                                        [100%]

========================================================================= warnings summary ==========================================================================
tests/geometry/test_point_projection.py::test_image_to_ground_errors
tests/geometry/test_point_projection.py::test_image_to_ground_dem
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/geometry/point_projection.py:1903: RuntimeWarning: divide by zero encountered in double_scalars
    lon_grid_size = min(10, lat_grid_size/abs(numpy.sin(numpy.deg2rad(ref_llh[0]))))

tests/visualization/test_kmz_product_creation.py::test_create_kmz[True]
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/visualization/kmz_utils.py:169: RuntimeWarning: invalid value encountered in double_scalars
    + dir_z**2 * semiaxis_a**2 * semiaxis_b**2

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
====================================================== 535 passed, 14 skipped, 1 xfailed, 3 warnings in 46.65s ======================================================
nox > Session test(version='3.6') was successful.
nox > Running session test(version='3.11')
nox > Creating conda env in .nox/test-version-3-11 with python
nox > conda install --yes --prefix /home/vscuser/git/glweb/software/third-party/sarpy/.nox/test-version-3-11 python=3.11
nox > python -m pip install '.[all]'
nox > pytest tests
======================================================================== test session starts ========================================================================
platform linux -- Python 3.11.8, pytest-8.1.1, pluggy-1.4.0
rootdir: /home/vscuser/git/glweb/software/third-party/sarpy
collected 550 items                                                                                                                                                 

tests/consistency/test_consistency.py ........                                                                                                                [  1%]
tests/consistency/test_cphd_consistency.py ..............................................................                                                     [ 12%]
tests/consistency/test_sicd_consistency.py ...                                                                                                                [ 13%]
tests/consistency/test_sidd_consistency.py ....                                                                                                               [ 14%]
tests/geometry/test_geocoords.py ..........                                                                                                                   [ 15%]
tests/geometry/test_geometry_elements.py ..........                                                                                                           [ 17%]
tests/geometry/test_latlon.py ...                                                                                                                             [ 18%]
tests/geometry/test_point_projection.py ..............                                                                                                        [ 20%]
tests/io/DEM/test_geoid.py .                                                                                                                                  [ 20%]
tests/io/DEM/test_geotiff1deg_list.py ....                                                                                                                    [ 21%]
tests/io/DEM/test_geotiff1deg_reader.py ........                                                                                                              [ 23%]
tests/io/complex/sicd_elements/test_sicd_elements_antenna.py ...                                                                                              [ 23%]
tests/io/complex/sicd_elements/test_sicd_elements_base.py ...                                                                                                 [ 24%]
tests/io/complex/sicd_elements/test_sicd_elements_blocks.py .....................                                                                             [ 28%]
tests/io/complex/sicd_elements/test_sicd_elements_collectioninfo.py ..                                                                                        [ 28%]
tests/io/complex/sicd_elements/test_sicd_elements_errorstatistics.py .                                                                                        [ 28%]
tests/io/complex/sicd_elements/test_sicd_elements_geodata.py ...                                                                                              [ 29%]
tests/io/complex/sicd_elements/test_sicd_elements_grid.py ..                                                                                                  [ 29%]
tests/io/complex/sicd_elements/test_sicd_elements_imagecreation.py .                                                                                          [ 29%]
tests/io/complex/sicd_elements/test_sicd_elements_imagedata.py .                                                                                              [ 29%]
tests/io/complex/sicd_elements/test_sicd_elements_imageformation.py ......                                                                                    [ 30%]
tests/io/complex/sicd_elements/test_sicd_elements_matchinfo.py .                                                                                              [ 31%]
tests/io/complex/sicd_elements/test_sicd_elements_pfa.py .                                                                                                    [ 31%]
tests/io/complex/sicd_elements/test_sicd_elements_position.py ...                                                                                             [ 31%]
tests/io/complex/sicd_elements/test_sicd_elements_radarcollection.py ..............                                                                           [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_radiometric.py .                                                                                            [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_rgazcomp.py .                                                                                               [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_rma.py ...                                                                                                  [ 35%]
tests/io/complex/sicd_elements/test_sicd_elements_scpcoa.py ...................                                                                               [ 38%]
tests/io/complex/sicd_elements/test_sicd_elements_sicd.py ..................................                                                                  [ 44%]
tests/io/complex/sicd_elements/test_sicd_elements_timeline.py ..................                                                                              [ 48%]
tests/io/complex/sicd_elements/test_sicd_elements_utils.py ...                                                                                                [ 48%]
tests/io/complex/test_other_nitf.py ...                                                                                                                       [ 49%]
tests/io/complex/test_reader.py .ssssssssss                                                                                                                   [ 51%]
tests/io/complex/test_remote.py s                                                                                                                             [ 51%]
tests/io/complex/test_sicd.py .                                                                                                                               [ 51%]
tests/io/complex/test_utils.py .                                                                                                                              [ 51%]
tests/io/general/test_base.py ...                                                                                                                             [ 52%]
tests/io/general/test_data_segment.py ..........                                                                                                              [ 54%]
tests/io/general/test_format_function.py ........                                                                                                             [ 55%]
tests/io/general/test_nitf_headers.py .                                                                                                                       [ 55%]
tests/io/general/test_nitf_image.py ....                                                                                                                      [ 56%]
tests/io/general/test_tre.py ...                                                                                                                              [ 57%]
tests/io/phase_history/cphd1_elements/test_cphd.py ....                                                                                                       [ 57%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_antenna.py .....                                                                                    [ 58%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_blocks.py ....                                                                                      [ 59%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_channel.py .                                                                                        [ 59%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_data.py .                                                                                           [ 59%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_dwell.py .                                                                                          [ 60%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_geoinfo.py ...                                                                                      [ 60%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_global.py ..                                                                                        [ 60%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_pvp.py .                                                                                            [ 61%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_referencegeometry.py .                                                                              [ 61%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_supportarray.py ..                                                                                  [ 61%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_txrcv.py .                                                                                          [ 61%]
tests/io/phase_history/cphd1_elements/test_utils.py .                                                                                                         [ 62%]
tests/io/phase_history/test_cphd.py .....                                                                                                                     [ 62%]
tests/io/phase_history/test_cphd_versions.py .....                                                                                                            [ 63%]
tests/io/product/sidd3_elements/test_exploitationfeatures.py ................................................................................................ [ 81%]
..................................                                                                                                                            [ 87%]
tests/io/product/sidd3_elements/test_sidd3_elements.py .....                                                                                                  [ 88%]
tests/io/product/test_reader.py ..s                                                                                                                           [ 88%]
tests/io/product/test_sidd_schema.py .........                                                                                                                [ 90%]
tests/io/product/test_sidd_writing.py .                                                                                                                       [ 90%]
tests/io/received/test_crsd.py .                                                                                                                              [ 90%]
tests/io/test_kml.py .                                                                                                                                        [ 91%]
tests/processing/sicd/test_spectral_taper.py .....................                                                                                            [ 94%]
tests/test_class_string.py .                                                                                                                                  [ 95%]
tests/utils/test_sicd_sidelobe_control.py ..                                                                                                                  [ 95%]
tests/visualization/test_cphd_kmz_product_creation.py ..                                                                                                      [ 95%]
tests/visualization/test_crsd_kmz_product_creation.py .                                                                                                       [ 96%]
tests/visualization/test_kmz_product_creation.py .x                                                                                                           [ 96%]
tests/visualization/test_remap.py ....................                                                                                                        [100%]

========================================================================= warnings summary ==========================================================================
tests/consistency/test_sidd_consistency.py: 4 warnings
tests/visualization/test_remap.py: 13 warnings
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/visualization/remap.py:1751: MatplotlibDeprecationWarning: The get_cmap function was deprecated in Matplot
lib 3.7 and will be removed two minor releases later. Use ``matplotlib.colormaps[name]`` or ``matplotlib.colormaps.get_cmap(obj)`` instead.                              cmap = cm.get_cmap(value, max_out_size+1)

tests/geometry/test_point_projection.py::test_image_to_ground_errors
tests/geometry/test_point_projection.py::test_image_to_ground_dem
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/geometry/point_projection.py:1903: RuntimeWarning: divide by zero encountered in scalar divide
    lon_grid_size = min(10, lat_grid_size/abs(numpy.sin(numpy.deg2rad(ref_llh[0]))))

tests/test_class_string.py::TestClassString::test_class_str
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/annotation/afrl_rde_schema/__init__.py:7: DeprecationWarning: pkg_resources is deprecated as an API. See h
ttps://setuptools.pypa.io/en/latest/pkg_resources.html                                                                                                                   import pkg_resources

tests/visualization/test_cphd_kmz_product_creation.py::test_create_kmz
tests/visualization/test_cphd_kmz_product_creation.py::test_create_kmz
tests/visualization/test_cphd_kmz_product_creation.py::test_create_kmz
tests/visualization/test_cphd_kmz_product_creation.py::test_create_kmz
tests/visualization/test_cphd_kmz_product_creation.py::test_create_kmz
tests/visualization/test_cphd_kmz_product_creation.py::test_create_kmz
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/visualization/kmz_utils.py:302: MatplotlibDeprecationWarning: The collections attribute was deprecated in 
Matplotlib 3.8 and will be removed two minor releases later.                                                                                                             for path in contour_sets.collections[0].get_paths()

tests/visualization/test_kmz_product_creation.py::test_create_kmz[True]
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/visualization/kmz_utils.py:145: RuntimeWarning: invalid value encountered in scalar divide
    distance = (

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
===================================================== 537 passed, 12 skipped, 1 xfailed, 27 warnings in 29.56s ======================================================
nox > Session test(version='3.11') was successful.
nox > Ran multiple sessions:
nox > * test(version='3.6'): success
nox > * test(version='3.11'): success

```

</details>