### PR TITLE
Bugfix: SIDD NITF IALVL/IDLVL for NITFs consisting of multiple images/segments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ release points are not being annotated in GitHub.
 - Population of SIDD ExploitationFeatures resolution metadata when processed from a SICD
 - Fix BANDSB implementation to parse correctly
 - SingleLUTFormatFunction application for LUT with more than one dimension
+- SIDD NITF IALVL/IDLVL for NITFs consisting of multiple image segments and/or product images
 
 ## [1.3.58] - 2023-08-07
 ### Added

--- a/sarpy/io/general/nitf.py
+++ b/sarpy/io/general/nitf.py
@@ -13,7 +13,7 @@ import os
 
 from typing import Union, List, Tuple, BinaryIO, Sequence, Optional
 from tempfile import mkstemp
-from collections import OrderedDict
+from collections import OrderedDict, namedtuple
 import struct
 from io import BytesIO
 
@@ -438,7 +438,7 @@ def _verify_image_segment_compatibility(
 def _correctly_order_image_segment_collection(
             image_headers: Sequence[Union[ImageSegmentHeader, ImageSegmentHeader0]]) -> Tuple[int, ...]:
     """
-    Determines the proper order, based on IALVL, for a collection of entries
+    Determines the proper order, based on IALVL and IDLVL, for a collection of entries
     which will be assembled into a composite image.
 
     Parameters
@@ -455,20 +455,19 @@ def _correctly_order_image_segment_collection(
         If incompatible IALVL values collection
     """
 
-    collection = [(entry.IALVL, orig_index) for orig_index, entry in enumerate(image_headers)]
-    collection = sorted(collection, key=lambda x: x[0])   # (stable) order by IALVL
-
-    if all(entry[0] == 0 for entry in collection):
+    ImLvl = namedtuple('ImLvl', ['index', 'IALVL', 'IDLVL'])
+    im_levels = sorted([ImLvl(index=n, IALVL=hdr.IALVL, IDLVL=hdr.IDLVL) for n, hdr in enumerate(image_headers)],
+                       key=lambda x: x.IDLVL)
+    if all(entry.IALVL == 0 for entry in im_levels):
         # all IALVL is 0, and order doesn't matter
         return tuple(range(len(image_headers)))
-    if all(entry0[0]+1 == entry1[0] for entry0, entry1 in zip(collection[:-1], collection[1:])):
-        # ordered, uninterrupted sequence of IALVL values
-        return tuple(entry[1] for entry in collection)
-
-    raise ValueError(
-        'Collection of (IALVL, image segment index) has\n\t'
-        'neither all IALVL == 0, or an uninterrupted sequence of IALVL values.\n\t'
-        'See {}'.format(collection))
+    if im_levels[0].IALVL == 0  and all(im_levels[n].IALVL == im_levels[n-1].IDLVL for n in range(1, len(im_levels))):
+        # From ISO/IEC Joint BIIF Profile JBP-2024.1 - 4.5.4.2 Attachment Level (ALVL) Interpretation
+        # The image or graphic segment in the MI collection (multi files) with the minimum display level has an
+        # attachment level of zero.
+        # The attachment level of an item is equal to the display level of the item to which it is "attached.""
+        return tuple(x.index for x in im_levels)
+    raise ValueError(f"Unable to interpret image segment attachment/display levels:\n{im_levels}\n per ISO/IEC JBP")
 
 
 def _get_collection_element_coordinate_limits(

--- a/sarpy/io/product/sidd.py
+++ b/sarpy/io/product/sidd.py
@@ -764,6 +764,8 @@ class SIDDWritingDetails(NITFWritingDetails):
         image_segment_indices = []
         total_image_count = starting_index
         for i, entry in enumerate(image_segment_limits):
+            image_segment_indices.append(total_image_count)
+            total_image_count += 1
             if i == 0:
                 iloc = '0000000000'
             else:
@@ -780,15 +782,13 @@ class SIDDWritingDetails(NITFWritingDetails):
                 IGEOLO=interpolate_corner_points_string(numpy.array(entry, dtype=numpy.int64), rows, cols, icp),
                 NPPBH=0 if this_cols > 8192 else this_cols,
                 NPPBV=0 if this_rows > 8192 else this_rows,
-                IDLVL=sidd_index + i + 2,
-                IALVL=sidd_index + i + 1,
+                IDLVL=total_image_count,
+                IALVL=0 if i == 0 else (total_image_count - 1),
                 ILOC=iloc,
                 Bands=ImageBands(values=[ImageBand(ISUBCAT='', IREPBAND=entry) for entry in irepband]),
                 Security=self._sidd_security_tags[sidd_index],
                 **basic_args)
             image_managers.append(ImageSubheaderManager(subhead))
-            image_segment_indices.append(total_image_count)
-            total_image_count += 1
         return image_managers, tuple(image_segment_indices), image_segment_limits
 
     def _create_image_segments(self) -> Tuple[Tuple[ImageSubheaderManager, ...], Tuple[Tuple[int, ...], ...], Tuple[Tuple[Tuple[int, ...], ...]]]:


### PR DESCRIPTION
# Description
While using SarPy to write large SIDD NITFs, we discovered a bug affecting the IALVL/IDLVL in the NITF Image subheaders written by SarPy. The new unittest demonstrates the current behavior as compared against an example from SIDD 1.0 Volume 2:

![image](https://github.com/ngageoint/sarpy/assets/78438270/1c165bc5-214b-4bf6-8435-9330fec99a75)


<details><summary>current behavior in integration/1.3.59-rc</summary>

```
SARPY_TEST_PATH=/data/sarpy_test pytest tests/io/product/test_sidd_writing.py -vv
=========================================================================== test session starts ===========================================================================
platform linux -- Python 3.10.13, pytest-7.4.0, pluggy-1.0.0 -- /home/vscuser/miniconda3/envs/sarpy/bin/python
cachedir: .pytest_cache
rootdir: /home/vscuser/git/glweb/software/third-party/sarpy
plugins: anyio-4.2.0
collected 2 items                                                                                                                                                         

tests/io/product/test_sidd_writing.py::TestSIDDWriting::test_nitf_multi_image_multi_segment FAILED                                                                  [ 50%]
tests/io/product/test_sidd_writing.py::TestSIDDWriting::test_sidd_creation PASSED                                                                                   [100%]

================================================================================ FAILURES =================================================================================
___________________________________________________________ TestSIDDWriting.test_nitf_multi_image_multi_segment ___________________________________________________________

self = <tests.io.product.test_sidd_writing.TestSIDDWriting testMethod=test_nitf_multi_image_multi_segment>

    def test_nitf_multi_image_multi_segment(self):
        """From Figure 2.5-6 SIDD 1.0 Multiple Input Image - Multiple Product Images Requiring Segmentation"""
        sidd_xml = pathlib.Path(__file__).parents[2]/ 'data/example.sidd.xml'
        sidd_meta = sarpy.io.product.sidd.SIDDType2.from_xml_file(sidd_xml)
        assert sidd_meta.Display.PixelType == 'MONO8I'
    
        # Tweak SIDD size to force three image segments
        li_max = 9_999_999_998
        iloc_max = 99_999
        num_cols = li_max // (2 * iloc_max)  # set num_cols so that row limit is iloc_max
        last_rows = 24
        num_rows = iloc_max * 2 + last_rows
        sidd_meta.Measurement.PixelFootprint.Row = num_rows
        sidd_meta.Measurement.PixelFootprint.Col = num_cols
        sidd_writing_details = sarpy.io.product.sidd.SIDDWritingDetails([sidd_meta, sidd_meta], None)
    
        # SIDD segmentation algorithm (2.4.2.1 in 1.0/2.0/3.0) would lead to overlaps of the last partial
        # image segment due to ILOC. This implements a scheme similar to SICD wherein "RRRRR" of ILOC matches
        # the NROWs in the previous segment.
        ImHdr = collections.namedtuple('ImHdr', ['IID1', 'IDLVL', 'IALVL', 'ILOC', 'NROWS', 'NCOLS'])
        expected_imhdrs = [
            ImHdr(IID1='SIDD001001', IDLVL=1, IALVL=0, ILOC='0'*10, NROWS=iloc_max, NCOLS=num_cols),
            ImHdr(IID1='SIDD001002', IDLVL=2, IALVL=1, ILOC=f'{iloc_max:05d}{0:05d}', NROWS=iloc_max, NCOLS=num_cols),
            ImHdr(IID1='SIDD001003', IDLVL=3, IALVL=2, ILOC=f'{iloc_max:05d}{0:05d}', NROWS=last_rows, NCOLS=num_cols),
            ImHdr(IID1='SIDD002001', IDLVL=4, IALVL=0, ILOC='0'*10, NROWS=iloc_max, NCOLS=num_cols),
            ImHdr(IID1='SIDD002002', IDLVL=5, IALVL=4, ILOC=f'{iloc_max:05d}{0:05d}', NROWS=iloc_max, NCOLS=num_cols),
            ImHdr(IID1='SIDD002003', IDLVL=6, IALVL=5, ILOC=f'{iloc_max:05d}{0:05d}', NROWS=last_rows, NCOLS=num_cols),
        ]
    
        actual_imhdrs = [
            ImHdr(IID1=im.subheader.IID1,
                  IDLVL=im.subheader.IDLVL,
                  IALVL=im.subheader.IALVL,
                  ILOC=im.subheader.ILOC,
                  NROWS=im.subheader.NROWS,
                  NCOLS=im.subheader.NCOLS)
            for im in sidd_writing_details.image_managers
        ]
>       assert expected_imhdrs == actual_imhdrs
E       AssertionError: assert [ImHdr(IID1='SIDD001001', IDLVL=1, IALVL=0, ILOC='0000000000', NROWS=99999, NCOLS=50000), ImHdr(IID1='SIDD001002', IDLVL=2, IALVL=1, ILOC='9
999900000', NROWS=99999, NCOLS=50000), ImHdr(IID1='SIDD001003', IDLVL=3, IALVL=2, ILOC='9999900000', NROWS=24, NCOLS=50000), ImHdr(IID1='SIDD002001', IDLVL=4, IALVL=0, ILOC='0000000000', NROWS=99999, NCOLS=50000), ImHdr(IID1='SIDD002002', IDLVL=5, IALVL=4, ILOC='9999900000', NROWS=99999, NCOLS=50000), ImHdr(IID1='SIDD002003', IDLVL=6, IALVL=5, ILOC='9999900000', NROWS=24, NCOLS=50000)] == [ImHdr(IID1='SIDD001001', IDLVL=2, IALVL=1, ILOC='0000000000', NROWS=99999, NCOLS=50000), ImHdr(IID1='SIDD001002', IDLVL=3, IALVL=2, ILOC='9999900000', NROWS=99999, NCOLS=50000), ImHdr(IID1='SIDD001003', IDLVL=4, IALVL=3, ILOC='9999900000', NROWS=24, NCOLS=50000), ImHdr(IID1='SIDD002001', IDLVL=3, IALVL=2, ILOC='0000000000', NROWS=99999, NCOLS=50000), ImHdr(IID1='SIDD002002', IDLVL=4, IALVL=3, ILOC='9999900000', NROWS=99999, NCOLS=50000), ImHdr(IID1='SIDD002003', IDLVL=5, IALVL=4, ILOC='9999900000', NROWS=24, NCOLS=50000)]                                                                                                          E         At index 0 diff: ImHdr(IID1='SIDD001001', IDLVL=1, IALVL=0, ILOC='0000000000', NROWS=99999, NCOLS=50000) != ImHdr(IID1='SIDD001001', IDLVL=2, IALVL=1, ILOC='0000
000000', NROWS=99999, NCOLS=50000)                                                                                                                                         E         Full diff:
E           [
E         -  ImHdr(IID1='SIDD001001', IDLVL=2, IALVL=1, ILOC='0000000000', NROWS=99999, NCOLS=50000),
E         ?                                 ^        ^
E         +  ImHdr(IID1='SIDD001001', IDLVL=1, IALVL=0, ILOC='0000000000', NROWS=99999, NCOLS=50000),
E         ?                                 ^        ^
E         -  ImHdr(IID1='SIDD001002', IDLVL=3, IALVL=2, ILOC='9999900000', NROWS=99999, NCOLS=50000),
E         ?                                 ^        ^
E         +  ImHdr(IID1='SIDD001002', IDLVL=2, IALVL=1, ILOC='9999900000', NROWS=99999, NCOLS=50000),
E         ?                                 ^        ^
E         -  ImHdr(IID1='SIDD001003', IDLVL=4, IALVL=3, ILOC='9999900000', NROWS=24, NCOLS=50000),
E         ?                                 ^        ^
E         +  ImHdr(IID1='SIDD001003', IDLVL=3, IALVL=2, ILOC='9999900000', NROWS=24, NCOLS=50000),
E         ?                                 ^        ^
E         -  ImHdr(IID1='SIDD002001', IDLVL=3, IALVL=2, ILOC='0000000000', NROWS=99999, NCOLS=50000),
E         ?                                 ^        ^
E         +  ImHdr(IID1='SIDD002001', IDLVL=4, IALVL=0, ILOC='0000000000', NROWS=99999, NCOLS=50000),
E         ?                                 ^        ^
E         -  ImHdr(IID1='SIDD002002', IDLVL=4, IALVL=3, ILOC='9999900000', NROWS=99999, NCOLS=50000),
E         ?                                 ^        ^
E         +  ImHdr(IID1='SIDD002002', IDLVL=5, IALVL=4, ILOC='9999900000', NROWS=99999, NCOLS=50000),
E         ?                                 ^        ^
E         -  ImHdr(IID1='SIDD002003', IDLVL=5, IALVL=4, ILOC='9999900000', NROWS=24, NCOLS=50000),
E         ?                                 ^        ^
E         +  ImHdr(IID1='SIDD002003', IDLVL=6, IALVL=5, ILOC='9999900000', NROWS=24, NCOLS=50000),
E         ?                                 ^        ^
E           ]

tests/io/product/test_sidd_writing.py:154: AssertionError
========================================================================= short test summary info =========================================================================
FAILED tests/io/product/test_sidd_writing.py::TestSIDDWriting::test_nitf_multi_image_multi_segment - AssertionError: assert [ImHdr(IID1='SIDD001001', IDLVL=1, IALVL=0, ILO
C='0000000000', NROWS=99999, NCOLS=50000), ImHdr(IID1='SIDD001002', IDLVL=2, IALVL=1, ILOC='9999...                                                                        ======================================================================= 1 failed, 1 passed in 3.41s =======================================================================
                                                                                                                                                                           

```

</details>

While fixing this bug, another bug was discovered in `sarpy.io.general.nitf.__correctly_order_image_segment_collection` wherein the interpretation of attachment and display levels was too restrictive and did not follow NITF/JBP:

![image](https://github.com/ngageoint/sarpy/assets/78438270/7e5e444c-5d7c-4fe1-b44d-c86fa0a447f7)


# Test Plan
The new test passes in this branch (the full test results will be posted in a comment below):

```
SARPY_TEST_PATH=/data/sarpy_test pytest tests/io/product/test_sidd_writing.py -vv
=========================================================================== test session starts ===========================================================================
platform linux -- Python 3.10.13, pytest-7.4.0, pluggy-1.0.0 -- /home/vscuser/miniconda3/envs/sarpy/bin/python
cachedir: .pytest_cache
rootdir: /home/vscuser/git/glweb/software/third-party/sarpy
plugins: anyio-4.2.0
collected 2 items                                                                                                                                                         

tests/io/product/test_sidd_writing.py::TestSIDDWriting::test_nitf_multi_image_multi_segment PASSED                                                                  [ 50%]
tests/io/product/test_sidd_writing.py::TestSIDDWriting::test_sidd_creation PASSED                                                                                   [100%]

============================================================================ 2 passed in 3.56s ============================================================================

```