### PR TITLE
Bugfix: replace deprecated matplotlib get_cmap call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ release points are not being annotated in GitHub.
 - SingleLUTFormatFunction application for LUT with more than one dimension
 - SIDD NITF IALVL/IDLVL for NITFs consisting of multiple image segments and/or product images
 - Reading/writing of uncompressed NITF image segments with two complex-component bands interleaved by block/row
+- Replace deprecated `matplotlib.cm.get_cmap` with `matplotlib.pyplot.get_cmap`
 
 ## [1.3.58] - 2023-08-07
 ### Added

--- a/sarpy/visualization/remap.py
+++ b/sarpy/visualization/remap.py
@@ -24,9 +24,9 @@ from sarpy.io.complex.utils import get_data_mean_magnitude, stats_calculation, \
     get_data_extrema
 
 try:
-    from matplotlib import cm
+    import matplotlib.pyplot as plt
 except ImportError:
-    cm = None
+    plt = None
 
 
 logger = logging.getLogger(__name__)
@@ -1744,11 +1744,11 @@ class LUT8bit(RemapFunction):
             use_alpha: bool) -> None:
         max_out_size = self.mono_remap.max_output_value
         if isinstance(value, str):
-            if cm is None:
+            if plt is None:
                 raise ImportError(
                     'The lookup_table has been specified by providing a matplotlib '
                     'colormap name, but matplotlib can not be imported.')
-            cmap = cm.get_cmap(value, max_out_size+1)
+            cmap = plt.get_cmap(value, max_out_size+1)
             color_array = cmap(numpy.arange(max_out_size+1))
             value = clip_cast(max_out_size*color_array, dtype='uint8')
             if value.shape[1] > 3 and not use_alpha:
@@ -1854,7 +1854,7 @@ def _register_defaults():
     register_remap(Linear(bit_depth=8), overwrite=False)
     register_remap(Logarithmic(bit_depth=8), overwrite=False)
     register_remap(PEDF(bit_depth=8), overwrite=False)
-    if cm is not None:
+    if plt is not None:
         try:
             register_remap(LUT8bit(NRL(bit_depth=8), 'viridis', use_alpha=False), overwrite=False)
         except KeyError:


### PR DESCRIPTION
# Description
`matplotlib=3.9` has removed [`matplotlib.cm.get_cmap`](https://matplotlib.org/stable/api/prev_api_changes/api_changes_3.9.0.html#top-level-cmap-registration-and-access-functions-in-mpl-cm)

To accommodate this in sarpy, we can use the `matplotlib.pyplot.get_cmap` function which "will stay available for backward compatibility".

I considered pinning `matplotlib` in `setup.py` to the earliest version where this function was documented ([appears to be 3.6](https://matplotlib.org/3.6.3/api/_as_gen/matplotlib.pyplot.get_cmap.html#matplotlib.pyplot.get_cmap)) however that is too recent for the python=3.6 SarPy test environment, so I ended up just leaving it alone.

# Test Plan

<details><summary>unitttests pass</summary>

```
SARPY_TEST_PATH=/data/sarpy_test/ nox
nox > Running session test(version='3.6')
nox > Creating conda env in .nox/test-version-3-6 with python
nox > conda install --yes --prefix /home/vscuser/git/glweb/software/third-party/sarpy/.nox/test-version-3-6 python=3.6
nox > python -m pip install '.[all]'
nox > pytest tests
===================================================================================================================================================================== test session starts ======================================================================================================================================================================
platform linux -- Python 3.6.13, pytest-7.0.1, pluggy-1.0.0
rootdir: /home/vscuser/git/glweb/software/third-party/sarpy
collected 552 items                                                                                                                                                                                                                                                                                                                                            

tests/test_class_string.py .                                                                                                                                                                                                                                                                                                                             [  0%]
tests/consistency/test_consistency.py ........                                                                                                                                                                                                                                                                                                           [  1%]
tests/consistency/test_cphd_consistency.py ..............................................................                                                                                                                                                                                                                                                [ 12%]
tests/consistency/test_sicd_consistency.py ...                                                                                                                                                                                                                                                                                                           [ 13%]
tests/consistency/test_sidd_consistency.py ....                                                                                                                                                                                                                                                                                                          [ 14%]
tests/geometry/test_geocoords.py ..........                                                                                                                                                                                                                                                                                                              [ 15%]
tests/geometry/test_geometry_elements.py ..........                                                                                                                                                                                                                                                                                                      [ 17%]
tests/geometry/test_latlon.py ...                                                                                                                                                                                                                                                                                                                        [ 18%]
tests/geometry/test_point_projection.py ..............                                                                                                                                                                                                                                                                                                   [ 20%]
tests/io/test_kml.py .                                                                                                                                                                                                                                                                                                                                   [ 21%]
tests/io/DEM/test_geoid.py .                                                                                                                                                                                                                                                                                                                             [ 21%]
tests/io/DEM/test_geotiff1deg_list.py ....                                                                                                                                                                                                                                                                                                               [ 21%]
tests/io/DEM/test_geotiff1deg_reader.py ........                                                                                                                                                                                                                                                                                                         [ 23%]
tests/io/complex/test_other_nitf.py ...                                                                                                                                                                                                                                                                                                                  [ 23%]
tests/io/complex/test_reader.py .ssssssssss                                                                                                                                                                                                                                                                                                              [ 25%]
tests/io/complex/test_remote.py s                                                                                                                                                                                                                                                                                                                        [ 26%]
tests/io/complex/test_sicd.py .                                                                                                                                                                                                                                                                                                                          [ 26%]
tests/io/complex/test_utils.py .                                                                                                                                                                                                                                                                                                                         [ 26%]
tests/io/complex/sicd_elements/test_sicd_elements_antenna.py ...                                                                                                                                                                                                                                                                                         [ 26%]
tests/io/complex/sicd_elements/test_sicd_elements_base.py ...                                                                                                                                                                                                                                                                                            [ 27%]
tests/io/complex/sicd_elements/test_sicd_elements_blocks.py .....................                                                                                                                                                                                                                                                                        [ 31%]
tests/io/complex/sicd_elements/test_sicd_elements_collectioninfo.py ..                                                                                                                                                                                                                                                                                   [ 31%]
tests/io/complex/sicd_elements/test_sicd_elements_errorstatistics.py .                                                                                                                                                                                                                                                                                   [ 31%]
tests/io/complex/sicd_elements/test_sicd_elements_geodata.py ...                                                                                                                                                                                                                                                                                         [ 32%]
tests/io/complex/sicd_elements/test_sicd_elements_grid.py ..                                                                                                                                                                                                                                                                                             [ 32%]
tests/io/complex/sicd_elements/test_sicd_elements_imagecreation.py .                                                                                                                                                                                                                                                                                     [ 32%]
tests/io/complex/sicd_elements/test_sicd_elements_imagedata.py .                                                                                                                                                                                                                                                                                         [ 33%]
tests/io/complex/sicd_elements/test_sicd_elements_imageformation.py ......                                                                                                                                                                                                                                                                               [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_matchinfo.py .                                                                                                                                                                                                                                                                                         [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_pfa.py .                                                                                                                                                                                                                                                                                               [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_position.py ...                                                                                                                                                                                                                                                                                        [ 35%]
tests/io/complex/sicd_elements/test_sicd_elements_radarcollection.py ..............                                                                                                                                                                                                                                                                      [ 37%]
tests/io/complex/sicd_elements/test_sicd_elements_radiometric.py .                                                                                                                                                                                                                                                                                       [ 37%]
tests/io/complex/sicd_elements/test_sicd_elements_rgazcomp.py .                                                                                                                                                                                                                                                                                          [ 38%]
tests/io/complex/sicd_elements/test_sicd_elements_rma.py ...                                                                                                                                                                                                                                                                                             [ 38%]
tests/io/complex/sicd_elements/test_sicd_elements_scpcoa.py ...................                                                                                                                                                                                                                                                                          [ 42%]
tests/io/complex/sicd_elements/test_sicd_elements_sicd.py ..................................                                                                                                                                                                                                                                                             [ 48%]
tests/io/complex/sicd_elements/test_sicd_elements_timeline.py ..................                                                                                                                                                                                                                                                                         [ 51%]
tests/io/complex/sicd_elements/test_sicd_elements_utils.py ...                                                                                                                                                                                                                                                                                           [ 51%]
tests/io/general/test_base.py ...                                                                                                                                                                                                                                                                                                                        [ 52%]
tests/io/general/test_data_segment.py ..........                                                                                                                                                                                                                                                                                                         [ 54%]
tests/io/general/test_format_function.py ........                                                                                                                                                                                                                                                                                                        [ 55%]
tests/io/general/test_nitf.py .                                                                                                                                                                                                                                                                                                                          [ 55%]
tests/io/general/test_nitf_headers.py .                                                                                                                                                                                                                                                                                                                  [ 56%]
tests/io/general/test_nitf_image.py ....                                                                                                                                                                                                                                                                                                                 [ 56%]
tests/io/general/test_tre.py ...                                                                                                                                                                                                                                                                                                                         [ 57%]
tests/io/phase_history/test_cphd.py .....                                                                                                                                                                                                                                                                                                                [ 58%]
tests/io/phase_history/test_cphd_versions.py .....                                                                                                                                                                                                                                                                                                       [ 59%]
tests/io/phase_history/cphd1_elements/test_cphd.py ....                                                                                                                                                                                                                                                                                                  [ 59%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_antenna.py .....                                                                                                                                                                                                                                                                               [ 60%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_blocks.py ....                                                                                                                                                                                                                                                                                 [ 61%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_channel.py .                                                                                                                                                                                                                                                                                   [ 61%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_data.py .                                                                                                                                                                                                                                                                                      [ 61%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_dwell.py .                                                                                                                                                                                                                                                                                     [ 62%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_geoinfo.py ...                                                                                                                                                                                                                                                                                 [ 62%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_global.py ..                                                                                                                                                                                                                                                                                   [ 63%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_pvp.py .                                                                                                                                                                                                                                                                                       [ 63%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_referencegeometry.py .                                                                                                                                                                                                                                                                         [ 63%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_supportarray.py ..                                                                                                                                                                                                                                                                             [ 63%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_txrcv.py .                                                                                                                                                                                                                                                                                     [ 63%]
tests/io/phase_history/cphd1_elements/test_utils.py .                                                                                                                                                                                                                                                                                                    [ 64%]
tests/io/product/test_reader.py ..s                                                                                                                                                                                                                                                                                                                      [ 64%]
tests/io/product/test_sidd_schema.py .........                                                                                                                                                                                                                                                                                                           [ 66%]
tests/io/product/test_sidd_writing.py ..                                                                                                                                                                                                                                                                                                                 [ 66%]
tests/io/product/sidd3_elements/test_exploitationfeatures.py ..................................................................................................................................                                                                                                                                                          [ 90%]
tests/io/product/sidd3_elements/test_sidd3_elements.py .....                                                                                                                                                                                                                                                                                             [ 91%]
tests/io/received/test_crsd.py .                                                                                                                                                                                                                                                                                                                         [ 91%]
tests/processing/sicd/test_spectral_taper.py ........ss...........                                                                                                                                                                                                                                                                                       [ 95%]
tests/utils/test_sicd_sidelobe_control.py ..                                                                                                                                                                                                                                                                                                             [ 95%]
tests/visualization/test_cphd_kmz_product_creation.py ..                                                                                                                                                                                                                                                                                                 [ 95%]
tests/visualization/test_crsd_kmz_product_creation.py .                                                                                                                                                                                                                                                                                                  [ 96%]
tests/visualization/test_kmz_product_creation.py .x                                                                                                                                                                                                                                                                                                      [ 96%]
tests/visualization/test_remap.py ....................                                                                                                                                                                                                                                                                                                   [100%]

======================================================================================================================================================================= warnings summary =======================================================================================================================================================================
tests/geometry/test_point_projection.py::test_image_to_ground_errors
tests/geometry/test_point_projection.py::test_image_to_ground_dem
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/geometry/point_projection.py:1903: RuntimeWarning: divide by zero encountered in double_scalars
    lon_grid_size = min(10, lat_grid_size/abs(numpy.sin(numpy.deg2rad(ref_llh[0]))))

tests/visualization/test_kmz_product_creation.py::test_create_kmz[True]
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/visualization/kmz_utils.py:169: RuntimeWarning: invalid value encountered in double_scalars
    + dir_z**2 * semiaxis_a**2 * semiaxis_b**2

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=================================================================================================================================================== 537 passed, 14 skipped, 1 xfailed, 3 warnings in 39.43s ====================================================================================================================================================
nox > Session test(version='3.6') was successful.
nox > Running session test(version='3.11')
nox > Creating conda env in .nox/test-version-3-11 with python
nox > conda install --yes --prefix /home/vscuser/git/glweb/software/third-party/sarpy/.nox/test-version-3-11 python=3.11
nox > python -m pip install '.[all]'
nox > pytest tests
===================================================================================================================================================================== test session starts ======================================================================================================================================================================
platform linux -- Python 3.11.9, pytest-8.2.1, pluggy-1.5.0
rootdir: /home/vscuser/git/glweb/software/third-party/sarpy
collected 552 items                                                                                                                                                                                                                                                                                                                                            

tests/consistency/test_consistency.py ........                                                                                                                                                                                                                                                                                                           [  1%]
tests/consistency/test_cphd_consistency.py ..............................................................                                                                                                                                                                                                                                                [ 12%]
tests/consistency/test_sicd_consistency.py ...                                                                                                                                                                                                                                                                                                           [ 13%]
tests/consistency/test_sidd_consistency.py ....                                                                                                                                                                                                                                                                                                          [ 13%]
tests/geometry/test_geocoords.py ..........                                                                                                                                                                                                                                                                                                              [ 15%]
tests/geometry/test_geometry_elements.py ..........                                                                                                                                                                                                                                                                                                      [ 17%]
tests/geometry/test_latlon.py ...                                                                                                                                                                                                                                                                                                                        [ 18%]
tests/geometry/test_point_projection.py ..............                                                                                                                                                                                                                                                                                                   [ 20%]
tests/io/DEM/test_geoid.py .                                                                                                                                                                                                                                                                                                                             [ 20%]
tests/io/DEM/test_geotiff1deg_list.py ....                                                                                                                                                                                                                                                                                                               [ 21%]
tests/io/DEM/test_geotiff1deg_reader.py ........                                                                                                                                                                                                                                                                                                         [ 23%]
tests/io/complex/sicd_elements/test_sicd_elements_antenna.py ...                                                                                                                                                                                                                                                                                         [ 23%]
tests/io/complex/sicd_elements/test_sicd_elements_base.py ...                                                                                                                                                                                                                                                                                            [ 24%]
tests/io/complex/sicd_elements/test_sicd_elements_blocks.py .....................                                                                                                                                                                                                                                                                        [ 27%]
tests/io/complex/sicd_elements/test_sicd_elements_collectioninfo.py ..                                                                                                                                                                                                                                                                                   [ 28%]
tests/io/complex/sicd_elements/test_sicd_elements_errorstatistics.py .                                                                                                                                                                                                                                                                                   [ 28%]
tests/io/complex/sicd_elements/test_sicd_elements_geodata.py ...                                                                                                                                                                                                                                                                                         [ 28%]
tests/io/complex/sicd_elements/test_sicd_elements_grid.py ..                                                                                                                                                                                                                                                                                             [ 29%]
tests/io/complex/sicd_elements/test_sicd_elements_imagecreation.py .                                                                                                                                                                                                                                                                                     [ 29%]
tests/io/complex/sicd_elements/test_sicd_elements_imagedata.py .                                                                                                                                                                                                                                                                                         [ 29%]
tests/io/complex/sicd_elements/test_sicd_elements_imageformation.py ......                                                                                                                                                                                                                                                                               [ 30%]
tests/io/complex/sicd_elements/test_sicd_elements_matchinfo.py .                                                                                                                                                                                                                                                                                         [ 30%]
tests/io/complex/sicd_elements/test_sicd_elements_pfa.py .                                                                                                                                                                                                                                                                                               [ 31%]
tests/io/complex/sicd_elements/test_sicd_elements_position.py ...                                                                                                                                                                                                                                                                                        [ 31%]
tests/io/complex/sicd_elements/test_sicd_elements_radarcollection.py ..............                                                                                                                                                                                                                                                                      [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_radiometric.py .                                                                                                                                                                                                                                                                                       [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_rgazcomp.py .                                                                                                                                                                                                                                                                                          [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_rma.py ...                                                                                                                                                                                                                                                                                             [ 35%]
tests/io/complex/sicd_elements/test_sicd_elements_scpcoa.py ...................                                                                                                                                                                                                                                                                          [ 38%]
tests/io/complex/sicd_elements/test_sicd_elements_sicd.py ..................................                                                                                                                                                                                                                                                             [ 44%]
tests/io/complex/sicd_elements/test_sicd_elements_timeline.py ..................                                                                                                                                                                                                                                                                         [ 48%]
tests/io/complex/sicd_elements/test_sicd_elements_utils.py ...                                                                                                                                                                                                                                                                                           [ 48%]
tests/io/complex/test_other_nitf.py ...                                                                                                                                                                                                                                                                                                                  [ 49%]
tests/io/complex/test_reader.py .ssssssssss                                                                                                                                                                                                                                                                                                              [ 51%]
tests/io/complex/test_remote.py s                                                                                                                                                                                                                                                                                                                        [ 51%]
tests/io/complex/test_sicd.py .                                                                                                                                                                                                                                                                                                                          [ 51%]
tests/io/complex/test_utils.py .                                                                                                                                                                                                                                                                                                                         [ 51%]
tests/io/general/test_base.py ...                                                                                                                                                                                                                                                                                                                        [ 52%]
tests/io/general/test_data_segment.py ..........                                                                                                                                                                                                                                                                                                         [ 53%]
tests/io/general/test_format_function.py ........                                                                                                                                                                                                                                                                                                        [ 55%]
tests/io/general/test_nitf.py .                                                                                                                                                                                                                                                                                                                          [ 55%]
tests/io/general/test_nitf_headers.py .                                                                                                                                                                                                                                                                                                                  [ 55%]
tests/io/general/test_nitf_image.py ....                                                                                                                                                                                                                                                                                                                 [ 56%]
tests/io/general/test_tre.py ...                                                                                                                                                                                                                                                                                                                         [ 57%]
tests/io/phase_history/cphd1_elements/test_cphd.py ....                                                                                                                                                                                                                                                                                                  [ 57%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_antenna.py .....                                                                                                                                                                                                                                                                               [ 58%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_blocks.py ....                                                                                                                                                                                                                                                                                 [ 59%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_channel.py .                                                                                                                                                                                                                                                                                   [ 59%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_data.py .                                                                                                                                                                                                                                                                                      [ 59%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_dwell.py .                                                                                                                                                                                                                                                                                     [ 59%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_geoinfo.py ...                                                                                                                                                                                                                                                                                 [ 60%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_global.py ..                                                                                                                                                                                                                                                                                   [ 60%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_pvp.py .                                                                                                                                                                                                                                                                                       [ 61%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_referencegeometry.py .                                                                                                                                                                                                                                                                         [ 61%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_supportarray.py ..                                                                                                                                                                                                                                                                             [ 61%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_txrcv.py .                                                                                                                                                                                                                                                                                     [ 61%]
tests/io/phase_history/cphd1_elements/test_utils.py .                                                                                                                                                                                                                                                                                                    [ 61%]
tests/io/phase_history/test_cphd.py .....                                                                                                                                                                                                                                                                                                                [ 62%]
tests/io/phase_history/test_cphd_versions.py .....                                                                                                                                                                                                                                                                                                       [ 63%]
tests/io/product/sidd3_elements/test_exploitationfeatures.py ..................................................................................................................................                                                                                                                                                          [ 87%]
tests/io/product/sidd3_elements/test_sidd3_elements.py .....                                                                                                                                                                                                                                                                                             [ 88%]
tests/io/product/test_reader.py ..s                                                                                                                                                                                                                                                                                                                      [ 88%]
tests/io/product/test_sidd_schema.py .........                                                                                                                                                                                                                                                                                                           [ 90%]
tests/io/product/test_sidd_writing.py ..                                                                                                                                                                                                                                                                                                                 [ 90%]
tests/io/received/test_crsd.py .                                                                                                                                                                                                                                                                                                                         [ 90%]
tests/io/test_kml.py .                                                                                                                                                                                                                                                                                                                                   [ 91%]
tests/processing/sicd/test_spectral_taper.py .....................                                                                                                                                                                                                                                                                                       [ 94%]
tests/test_class_string.py .                                                                                                                                                                                                                                                                                                                             [ 95%]
tests/utils/test_sicd_sidelobe_control.py ..                                                                                                                                                                                                                                                                                                             [ 95%]
tests/visualization/test_cphd_kmz_product_creation.py ..                                                                                                                                                                                                                                                                                                 [ 95%]
tests/visualization/test_crsd_kmz_product_creation.py .                                                                                                                                                                                                                                                                                                  [ 96%]
tests/visualization/test_kmz_product_creation.py .x                                                                                                                                                                                                                                                                                                      [ 96%]
tests/visualization/test_remap.py ....................                                                                                                                                                                                                                                                                                                   [100%]

======================================================================================================================================================================= warnings summary =======================================================================================================================================================================
tests/geometry/test_point_projection.py::test_image_to_ground_errors
tests/geometry/test_point_projection.py::test_image_to_ground_dem
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/geometry/point_projection.py:1903: RuntimeWarning: divide by zero encountered in scalar divide
    lon_grid_size = min(10, lat_grid_size/abs(numpy.sin(numpy.deg2rad(ref_llh[0]))))

tests/test_class_string.py::TestClassString::test_class_str
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/annotation/afrl_rde_schema/__init__.py:7: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
    import pkg_resources

tests/visualization/test_cphd_kmz_product_creation.py::test_create_kmz
tests/visualization/test_cphd_kmz_product_creation.py::test_create_kmz
tests/visualization/test_cphd_kmz_product_creation.py::test_create_kmz
tests/visualization/test_cphd_kmz_product_creation.py::test_create_kmz
tests/visualization/test_cphd_kmz_product_creation.py::test_create_kmz
tests/visualization/test_cphd_kmz_product_creation.py::test_create_kmz
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/visualization/kmz_utils.py:302: MatplotlibDeprecationWarning: The collections attribute was deprecated in Matplotlib 3.8 and will be removed in 3.10.
    for path in contour_sets.collections[0].get_paths()

tests/visualization/test_kmz_product_creation.py::test_create_kmz[True]
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/visualization/kmz_utils.py:145: RuntimeWarning: invalid value encountered in scalar divide
    distance = (

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=================================================================================================================================================== 539 passed, 12 skipped, 1 xfailed, 10 warnings in 27.73s ===================================================================================================================================================
nox > Session test(version='3.11') was successful.
nox > Ran multiple sessions:
nox > * test(version='3.6'): success
nox > * test(version='3.11'): success

```

</details>