### PR TITLE
Integrate compressed CPHD I/O

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ release points are not being annotated in GitHub.
 - Support reading CPHDs with an AmpSF PVP whose Data/SignalArrayFormat is CF8
 - Unit tests for `sarpy/consistency/sidd_consistency.py`
 - Support for MATESA TRE
+- Support reading/writing CPHDs with compressed signal arrays
 ### Fixed
 - `sarpy.io.kml.add_polygon` coordinate conditioning for older numpy versions
 - Replace unsupported `pillow` constant `Image.ANTIALIAS` with `Image.LANCZOS`

--- a/sarpy/consistency/cphd_consistency.py
+++ b/sarpy/consistency/cphd_consistency.py
@@ -1184,6 +1184,7 @@ class CphdConsistency(con.ConsistencyChecker):
 
         with self.precondition():
             assert self.header is not None
+            assert self.xml.find('./Data/SignalCompressionID') is None
             format_string = self.xml.findtext('./Data/SignalArrayFormat')
             signal_dtype = cphd1_utils.binary_format_string_to_dtype(format_string)
 

--- a/sarpy/io/phase_history/cphd.py
+++ b/sarpy/io/phase_history/cphd.py
@@ -543,7 +543,10 @@ class CPHDReader1(CPHDReader):
         data = self.cphd_meta.Data
         sample_type = data.SignalArrayFormat
 
-        if sample_type == "CF8":
+        compressed = data.SignalCompressionID
+        if compressed is not None:
+            raw_dtype = numpy.dtype('B')
+        elif sample_type == "CF8":
             raw_dtype = numpy.dtype('>f4')
         elif sample_type == "CI4":
             raw_dtype = numpy.dtype('>i2')
@@ -555,13 +558,22 @@ class CPHDReader1(CPHDReader):
         block_offset = self.cphd_header.SIGNAL_BLOCK_BYTE_OFFSET
         for entry in data.Channels:
             amp_sf = self.read_pvp_variable('AmpSF', entry.Identifier)
-            format_function = AmpScalingFunction(raw_dtype, amplitude_scaling=amp_sf)
-            raw_shape = (entry.NumVectors, entry.NumSamples, 2)
+            if compressed:
+                raw_shape = (entry.CompressedSignalSize,)
+                formatted_shape = raw_shape
+                formatted_dtype = 'byte'
+                format_function = None
+            else:
+                raw_shape = (entry.NumVectors, entry.NumSamples, 2)
+                formatted_shape = raw_shape[:2]
+                formatted_dtype = 'complex64'
+                format_function = AmpScalingFunction(raw_dtype, amplitude_scaling=amp_sf)
+
             data_offset = entry.SignalArrayByteOffset
             data_segments.append(
                 NumpyMemmapSegment(
                     self.cphd_details.file_object, block_offset+data_offset,
-                    raw_dtype, raw_shape, formatted_dtype='complex64', formatted_shape=raw_shape[:2],
+                    raw_dtype, raw_shape, formatted_dtype=formatted_dtype, formatted_shape = formatted_shape,
                     format_function=format_function, close_file=False))
         return data_segments
 
@@ -1555,7 +1567,10 @@ class CPHDWriter1(BaseWriter):
         self._can_write_regular_data = {}
         signal_data_segments = []
         signal_array_format = self.meta.Data.SignalArrayFormat
-        if signal_array_format == 'CI2':
+        compressed = self.meta.Data.SignalCompressionID
+        if compressed is not None:
+            signal_dtype = numpy.dtype('B')
+        elif signal_array_format == 'CI2':
             signal_dtype = numpy.dtype('>i1')
         elif signal_array_format == 'CI4':
             signal_dtype = numpy.dtype('>i2')
@@ -1565,18 +1580,27 @@ class CPHDWriter1(BaseWriter):
             raise ValueError('Got unhandled SignalArrayFormat {}'.format(signal_array_format))
         for i, entry in enumerate(self.meta.Data.Channels):
             self._can_write_regular_data[entry.Identifier] = no_amp_sf
-            raw_shape = (entry.NumVectors, entry.NumSamples, 2)
-            format_function = AmpScalingFunction(signal_dtype)
+            if compressed:
+                raw_shape = (entry.CompressedSignalSize,)
+                formatted_shape = raw_shape
+                formatted_dtype = 'byte'
+                format_function = None
+            else:
+                raw_shape = (entry.NumVectors, entry.NumSamples, 2)
+                formatted_shape = raw_shape[:2]
+                formatted_dtype = 'complex64'
+                format_function = AmpScalingFunction(signal_dtype)
+    
             offset = self.writing_details.signal_details[i].item_offset
             if self._in_memory:
                 underlying_array = numpy.full(raw_shape, 0, dtype=signal_dtype)
                 data_segment = NumpyArraySegment(
-                    underlying_array, 'complex64', formatted_shape=raw_shape[:2],
+                    underlying_array, formatted_dtype, formatted_shape=formatted_shape,
                     format_function=format_function, mode='w')
             else:
                 data_segment = NumpyMemmapSegment(
                     self._file_object.name, offset, signal_dtype, raw_shape,
-                    formatted_dtype='complex64', formatted_shape=raw_shape[:2],
+                    formatted_dtype=formatted_dtype, formatted_shape=formatted_shape,
                     format_function=format_function, mode='w', close_file=False)
             signal_data_segments.append(data_segment)
 


### PR DESCRIPTION
# Description
This builds atop @brianhendee's  #510; adding a unit test and tweaking the implementation slightly to account for bugs encountered in testing (CRSDWriter reusing CPHDWriter; writing compressed CPHD with AmpSF PVP).

<details><summary>Tests pass</summary>
<p>

```
SARPY_TEST_PATH=/data/sarpy_test/ nox
nox > Running session test(version='3.6')
nox > Creating conda env in .nox/test-version-3-6 with python
nox > conda install --yes --prefix /home/vscuser/git/glweb/software/third-party/sarpy/.nox/test-version-3-6 python=3.6
nox > python -m pip install '.[all]'
nox > pytest tests
================================================================================================================================================ test session starts =================================================================================================================================================
platform linux -- Python 3.6.13, pytest-7.0.1, pluggy-1.0.0
rootdir: /home/vscuser/git/glweb/software/third-party/sarpy
collected 554 items                                                                                                                                                                                                                                                                                                  

tests/test_class_string.py .                                                                                                                                                                                                                                                                                   [  0%]
tests/consistency/test_consistency.py ........                                                                                                                                                                                                                                                                 [  1%]
tests/consistency/test_cphd_consistency.py ..............................................................                                                                                                                                                                                                      [ 12%]
tests/consistency/test_sicd_consistency.py ...                                                                                                                                                                                                                                                                 [ 13%]
tests/consistency/test_sidd_consistency.py ....                                                                                                                                                                                                                                                                [ 14%]
tests/geometry/test_geocoords.py ..........                                                                                                                                                                                                                                                                    [ 15%]
tests/geometry/test_geometry_elements.py ..........                                                                                                                                                                                                                                                            [ 17%]
tests/geometry/test_latlon.py ...                                                                                                                                                                                                                                                                              [ 18%]
tests/geometry/test_point_projection.py ..............                                                                                                                                                                                                                                                         [ 20%]
tests/io/test_kml.py .                                                                                                                                                                                                                                                                                         [ 20%]
tests/io/DEM/test_geoid.py .                                                                                                                                                                                                                                                                                   [ 21%]
tests/io/DEM/test_geotiff1deg_list.py ....                                                                                                                                                                                                                                                                     [ 21%]
tests/io/DEM/test_geotiff1deg_reader.py ........                                                                                                                                                                                                                                                               [ 23%]
tests/io/complex/test_other_nitf.py ...                                                                                                                                                                                                                                                                        [ 23%]
tests/io/complex/test_reader.py .ssssssssss                                                                                                                                                                                                                                                                    [ 25%]
tests/io/complex/test_remote.py s                                                                                                                                                                                                                                                                              [ 25%]
tests/io/complex/test_sicd.py .                                                                                                                                                                                                                                                                                [ 26%]
tests/io/complex/test_utils.py .                                                                                                                                                                                                                                                                               [ 26%]
tests/io/complex/sicd_elements/test_sicd_elements_antenna.py ...                                                                                                                                                                                                                                               [ 26%]
tests/io/complex/sicd_elements/test_sicd_elements_base.py ...                                                                                                                                                                                                                                                  [ 27%]
tests/io/complex/sicd_elements/test_sicd_elements_blocks.py .....................                                                                                                                                                                                                                              [ 31%]
tests/io/complex/sicd_elements/test_sicd_elements_collectioninfo.py ..                                                                                                                                                                                                                                         [ 31%]
tests/io/complex/sicd_elements/test_sicd_elements_errorstatistics.py .                                                                                                                                                                                                                                         [ 31%]
tests/io/complex/sicd_elements/test_sicd_elements_geodata.py ...                                                                                                                                                                                                                                               [ 32%]
tests/io/complex/sicd_elements/test_sicd_elements_grid.py ..                                                                                                                                                                                                                                                   [ 32%]
tests/io/complex/sicd_elements/test_sicd_elements_imagecreation.py .                                                                                                                                                                                                                                           [ 32%]
tests/io/complex/sicd_elements/test_sicd_elements_imagedata.py .                                                                                                                                                                                                                                               [ 33%]
tests/io/complex/sicd_elements/test_sicd_elements_imageformation.py ......                                                                                                                                                                                                                                     [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_matchinfo.py .                                                                                                                                                                                                                                               [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_pfa.py .                                                                                                                                                                                                                                                     [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_position.py ...                                                                                                                                                                                                                                              [ 35%]
tests/io/complex/sicd_elements/test_sicd_elements_radarcollection.py ..............                                                                                                                                                                                                                            [ 37%]
tests/io/complex/sicd_elements/test_sicd_elements_radiometric.py .                                                                                                                                                                                                                                             [ 37%]
tests/io/complex/sicd_elements/test_sicd_elements_rgazcomp.py .                                                                                                                                                                                                                                                [ 37%]
tests/io/complex/sicd_elements/test_sicd_elements_rma.py ...                                                                                                                                                                                                                                                   [ 38%]
tests/io/complex/sicd_elements/test_sicd_elements_scpcoa.py ...................                                                                                                                                                                                                                                [ 41%]
tests/io/complex/sicd_elements/test_sicd_elements_sicd.py ..................................                                                                                                                                                                                                                   [ 48%]
tests/io/complex/sicd_elements/test_sicd_elements_timeline.py ..................                                                                                                                                                                                                                               [ 51%]
tests/io/complex/sicd_elements/test_sicd_elements_utils.py ...                                                                                                                                                                                                                                                 [ 51%]
tests/io/general/test_base.py ...                                                                                                                                                                                                                                                                              [ 52%]
tests/io/general/test_data_segment.py ..........                                                                                                                                                                                                                                                               [ 54%]
tests/io/general/test_format_function.py ........                                                                                                                                                                                                                                                              [ 55%]
tests/io/general/test_nitf.py .                                                                                                                                                                                                                                                                                [ 55%]
tests/io/general/test_nitf_headers.py .                                                                                                                                                                                                                                                                        [ 55%]
tests/io/general/test_nitf_image.py ....                                                                                                                                                                                                                                                                       [ 56%]
tests/io/general/test_tre.py ...                                                                                                                                                                                                                                                                               [ 57%]
tests/io/phase_history/test_cphd.py .......                                                                                                                                                                                                                                                                    [ 58%]
tests/io/phase_history/test_cphd_versions.py .....                                                                                                                                                                                                                                                             [ 59%]
tests/io/phase_history/cphd1_elements/test_cphd.py ....                                                                                                                                                                                                                                                        [ 60%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_antenna.py .....                                                                                                                                                                                                                                     [ 61%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_blocks.py ....                                                                                                                                                                                                                                       [ 61%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_channel.py .                                                                                                                                                                                                                                         [ 61%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_data.py .                                                                                                                                                                                                                                            [ 62%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_dwell.py .                                                                                                                                                                                                                                           [ 62%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_geoinfo.py ...                                                                                                                                                                                                                                       [ 62%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_global.py ..                                                                                                                                                                                                                                         [ 63%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_pvp.py .                                                                                                                                                                                                                                             [ 63%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_referencegeometry.py .                                                                                                                                                                                                                               [ 63%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_supportarray.py ..                                                                                                                                                                                                                                   [ 63%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_txrcv.py .                                                                                                                                                                                                                                           [ 64%]
tests/io/phase_history/cphd1_elements/test_utils.py .                                                                                                                                                                                                                                                          [ 64%]
tests/io/product/test_reader.py ..s                                                                                                                                                                                                                                                                            [ 64%]
tests/io/product/test_sidd_schema.py .........                                                                                                                                                                                                                                                                 [ 66%]
tests/io/product/test_sidd_writing.py ..                                                                                                                                                                                                                                                                       [ 66%]
tests/io/product/sidd3_elements/test_exploitationfeatures.py ..................................................................................................................................                                                                                                                [ 90%]
tests/io/product/sidd3_elements/test_sidd3_elements.py .....                                                                                                                                                                                                                                                   [ 91%]
tests/io/received/test_crsd.py .                                                                                                                                                                                                                                                                               [ 91%]
tests/processing/sicd/test_spectral_taper.py ........ss...........                                                                                                                                                                                                                                             [ 95%]
tests/utils/test_sicd_sidelobe_control.py ..                                                                                                                                                                                                                                                                   [ 95%]
tests/visualization/test_cphd_kmz_product_creation.py ..                                                                                                                                                                                                                                                       [ 95%]
tests/visualization/test_crsd_kmz_product_creation.py .                                                                                                                                                                                                                                                        [ 96%]
tests/visualization/test_kmz_product_creation.py .x                                                                                                                                                                                                                                                            [ 96%]
tests/visualization/test_remap.py ....................                                                                                                                                                                                                                                                         [100%]

================================================================================================================================================== warnings summary ==================================================================================================================================================
tests/geometry/test_point_projection.py::test_image_to_ground_errors
tests/geometry/test_point_projection.py::test_image_to_ground_dem
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/geometry/point_projection.py:1903: RuntimeWarning: divide by zero encountered in double_scalars
    lon_grid_size = min(10, lat_grid_size/abs(numpy.sin(numpy.deg2rad(ref_llh[0]))))

tests/visualization/test_kmz_product_creation.py::test_create_kmz[True]
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/visualization/kmz_utils.py:169: RuntimeWarning: invalid value encountered in double_scalars
    + dir_z**2 * semiaxis_a**2 * semiaxis_b**2

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================================================================================== 539 passed, 14 skipped, 1 xfailed, 3 warnings in 35.86s ===============================================================================================================================
nox > Session test(version='3.6') was successful.
nox > Running session test(version='3.11')
nox > Creating conda env in .nox/test-version-3-11 with python
nox > conda install --yes --prefix /home/vscuser/git/glweb/software/third-party/sarpy/.nox/test-version-3-11 python=3.11
nox > python -m pip install '.[all]'
nox > pytest tests
================================================================================================================================================ test session starts =================================================================================================================================================
platform linux -- Python 3.11.9, pytest-8.2.1, pluggy-1.5.0
rootdir: /home/vscuser/git/glweb/software/third-party/sarpy
collected 554 items                                                                                                                                                                                                                                                                                                  

tests/consistency/test_consistency.py ........                                                                                                                                                                                                                                                                 [  1%]
tests/consistency/test_cphd_consistency.py ..............................................................                                                                                                                                                                                                      [ 12%]
tests/consistency/test_sicd_consistency.py ...                                                                                                                                                                                                                                                                 [ 13%]
tests/consistency/test_sidd_consistency.py ....                                                                                                                                                                                                                                                                [ 13%]
tests/geometry/test_geocoords.py ..........                                                                                                                                                                                                                                                                    [ 15%]
tests/geometry/test_geometry_elements.py ..........                                                                                                                                                                                                                                                            [ 17%]
tests/geometry/test_latlon.py ...                                                                                                                                                                                                                                                                              [ 18%]
tests/geometry/test_point_projection.py ..............                                                                                                                                                                                                                                                         [ 20%]
tests/io/DEM/test_geoid.py .                                                                                                                                                                                                                                                                                   [ 20%]
tests/io/DEM/test_geotiff1deg_list.py ....                                                                                                                                                                                                                                                                     [ 21%]
tests/io/DEM/test_geotiff1deg_reader.py ........                                                                                                                                                                                                                                                               [ 22%]
tests/io/complex/sicd_elements/test_sicd_elements_antenna.py ...                                                                                                                                                                                                                                               [ 23%]
tests/io/complex/sicd_elements/test_sicd_elements_base.py ...                                                                                                                                                                                                                                                  [ 24%]
tests/io/complex/sicd_elements/test_sicd_elements_blocks.py .....................                                                                                                                                                                                                                              [ 27%]
tests/io/complex/sicd_elements/test_sicd_elements_collectioninfo.py ..                                                                                                                                                                                                                                         [ 28%]
tests/io/complex/sicd_elements/test_sicd_elements_errorstatistics.py .                                                                                                                                                                                                                                         [ 28%]
tests/io/complex/sicd_elements/test_sicd_elements_geodata.py ...                                                                                                                                                                                                                                               [ 28%]
tests/io/complex/sicd_elements/test_sicd_elements_grid.py ..                                                                                                                                                                                                                                                   [ 29%]
tests/io/complex/sicd_elements/test_sicd_elements_imagecreation.py .                                                                                                                                                                                                                                           [ 29%]
tests/io/complex/sicd_elements/test_sicd_elements_imagedata.py .                                                                                                                                                                                                                                               [ 29%]
tests/io/complex/sicd_elements/test_sicd_elements_imageformation.py ......                                                                                                                                                                                                                                     [ 30%]
tests/io/complex/sicd_elements/test_sicd_elements_matchinfo.py .                                                                                                                                                                                                                                               [ 30%]
tests/io/complex/sicd_elements/test_sicd_elements_pfa.py .                                                                                                                                                                                                                                                     [ 31%]
tests/io/complex/sicd_elements/test_sicd_elements_position.py ...                                                                                                                                                                                                                                              [ 31%]
tests/io/complex/sicd_elements/test_sicd_elements_radarcollection.py ..............                                                                                                                                                                                                                            [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_radiometric.py .                                                                                                                                                                                                                                             [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_rgazcomp.py .                                                                                                                                                                                                                                                [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_rma.py ...                                                                                                                                                                                                                                                   [ 35%]
tests/io/complex/sicd_elements/test_sicd_elements_scpcoa.py ...................                                                                                                                                                                                                                                [ 38%]
tests/io/complex/sicd_elements/test_sicd_elements_sicd.py ..................................                                                                                                                                                                                                                   [ 44%]
tests/io/complex/sicd_elements/test_sicd_elements_timeline.py ..................                                                                                                                                                                                                                               [ 47%]
tests/io/complex/sicd_elements/test_sicd_elements_utils.py ...                                                                                                                                                                                                                                                 [ 48%]
tests/io/complex/test_other_nitf.py ...                                                                                                                                                                                                                                                                        [ 48%]
tests/io/complex/test_reader.py .ssssssssss                                                                                                                                                                                                                                                                    [ 50%]
tests/io/complex/test_remote.py s                                                                                                                                                                                                                                                                              [ 51%]
tests/io/complex/test_sicd.py .                                                                                                                                                                                                                                                                                [ 51%]
tests/io/complex/test_utils.py .                                                                                                                                                                                                                                                                               [ 51%]
tests/io/general/test_base.py ...                                                                                                                                                                                                                                                                              [ 51%]
tests/io/general/test_data_segment.py ..........                                                                                                                                                                                                                                                               [ 53%]
tests/io/general/test_format_function.py ........                                                                                                                                                                                                                                                              [ 55%]
tests/io/general/test_nitf.py .                                                                                                                                                                                                                                                                                [ 55%]
tests/io/general/test_nitf_headers.py .                                                                                                                                                                                                                                                                        [ 55%]
tests/io/general/test_nitf_image.py ....                                                                                                                                                                                                                                                                       [ 56%]
tests/io/general/test_tre.py ...                                                                                                                                                                                                                                                                               [ 56%]
tests/io/phase_history/cphd1_elements/test_cphd.py ....                                                                                                                                                                                                                                                        [ 57%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_antenna.py .....                                                                                                                                                                                                                                     [ 58%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_blocks.py ....                                                                                                                                                                                                                                       [ 59%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_channel.py .                                                                                                                                                                                                                                         [ 59%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_data.py .                                                                                                                                                                                                                                            [ 59%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_dwell.py .                                                                                                                                                                                                                                           [ 59%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_geoinfo.py ...                                                                                                                                                                                                                                       [ 60%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_global.py ..                                                                                                                                                                                                                                         [ 60%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_pvp.py .                                                                                                                                                                                                                                             [ 60%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_referencegeometry.py .                                                                                                                                                                                                                               [ 61%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_supportarray.py ..                                                                                                                                                                                                                                   [ 61%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_txrcv.py .                                                                                                                                                                                                                                           [ 61%]
tests/io/phase_history/cphd1_elements/test_utils.py .                                                                                                                                                                                                                                                          [ 61%]
tests/io/phase_history/test_cphd.py .......                                                                                                                                                                                                                                                                    [ 62%]
tests/io/phase_history/test_cphd_versions.py .....                                                                                                                                                                                                                                                             [ 63%]
tests/io/product/sidd3_elements/test_exploitationfeatures.py ..................................................................................................................................                                                                                                                [ 87%]
tests/io/product/sidd3_elements/test_sidd3_elements.py .....                                                                                                                                                                                                                                                   [ 88%]
tests/io/product/test_reader.py ..s                                                                                                                                                                                                                                                                            [ 88%]
tests/io/product/test_sidd_schema.py .........                                                                                                                                                                                                                                                                 [ 90%]
tests/io/product/test_sidd_writing.py ..                                                                                                                                                                                                                                                                       [ 90%]
tests/io/received/test_crsd.py .                                                                                                                                                                                                                                                                               [ 90%]
tests/io/test_kml.py .                                                                                                                                                                                                                                                                                         [ 91%]
tests/processing/sicd/test_spectral_taper.py .....................                                                                                                                                                                                                                                             [ 94%]
tests/test_class_string.py .                                                                                                                                                                                                                                                                                   [ 95%]
tests/utils/test_sicd_sidelobe_control.py ..                                                                                                                                                                                                                                                                   [ 95%]
tests/visualization/test_cphd_kmz_product_creation.py ..                                                                                                                                                                                                                                                       [ 95%]
tests/visualization/test_crsd_kmz_product_creation.py .                                                                                                                                                                                                                                                        [ 96%]
tests/visualization/test_kmz_product_creation.py .x                                                                                                                                                                                                                                                            [ 96%]
tests/visualization/test_remap.py ....................                                                                                                                                                                                                                                                         [100%]

================================================================================================================================================== warnings summary ==================================================================================================================================================
tests/geometry/test_point_projection.py::test_image_to_ground_errors
tests/geometry/test_point_projection.py::test_image_to_ground_dem
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/geometry/point_projection.py:1903: RuntimeWarning: divide by zero encountered in scalar divide
    lon_grid_size = min(10, lat_grid_size/abs(numpy.sin(numpy.deg2rad(ref_llh[0]))))

tests/test_class_string.py::TestClassString::test_class_str
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/annotation/afrl_rde_schema/__init__.py:7: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
    import pkg_resources

tests/visualization/test_cphd_kmz_product_creation.py::test_create_kmz
tests/visualization/test_cphd_kmz_product_creation.py::test_create_kmz
tests/visualization/test_cphd_kmz_product_creation.py::test_create_kmz
tests/visualization/test_cphd_kmz_product_creation.py::test_create_kmz
tests/visualization/test_cphd_kmz_product_creation.py::test_create_kmz
tests/visualization/test_cphd_kmz_product_creation.py::test_create_kmz
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/visualization/kmz_utils.py:302: MatplotlibDeprecationWarning: The collections attribute was deprecated in Matplotlib 3.8 and will be removed in 3.10.
    for path in contour_sets.collections[0].get_paths()

tests/visualization/test_kmz_product_creation.py::test_create_kmz[True]
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/visualization/kmz_utils.py:145: RuntimeWarning: invalid value encountered in scalar divide
    distance = (

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================================================================================== 541 passed, 12 skipped, 1 xfailed, 10 warnings in 36.13s ==============================================================================================================================
nox > Session test(version='3.11') was successful.
nox > Ran multiple sessions:
nox > * test(version='3.6'): success
nox > * test(version='3.11'): success

```

</p>
</details> 