### PR TITLE
fixes ReferencePoint bug in SIDD MeasurementType

### DIFF
--- a/sarpy/io/product/sidd2_elements/Measurement.py
+++ b/sarpy/io/product/sidd2_elements/Measurement.py
@@ -346,5 +346,5 @@ class MeasurementType(Serializable):
 
         for attribute in self._choice[0]['collection']:
             if getattr(self, attribute) is not None:
-                return attribute.ReferencePoint
+                return getattr(self, attribute).ReferencePoint
         return None


### PR DESCRIPTION
'attribute' is of type string and attempting to read attribute.ReferencePoint causes an error in the SIDD metadata: 'str' object has no attribute 'ReferencePoint'.

Changed line 349 to access ReferencePoint from the actual object attribute instead of its string name. 

