### PR TITLE
Fix sentinel radiometric polys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ release points are not being annotated in GitHub.
 - Reading/writing of uncompressed NITF image segments with two complex-component bands interleaved by block/row
 - Replace deprecated `matplotlib.cm.get_cmap` with `matplotlib.pyplot.get_cmap`
 - ReferencePoint attribute in SIDD MeasurementType objects
+- Sentinel clutter radiometric polynomials are no longer transposed
 
 ## [1.3.58] - 2023-08-07
 ### Added

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Changes to sarpy for the sole purpose of supporting a Python version beyond
 end-of-life are unlikely to be considered.
 
 Information regarding any discovered bugs would be greatly appreciated, so please
-feel free to create a GitHub issue. If more appropriate, contact wade.c.schwartzkopf@nga.mil.
+feel free to create a GitHub issue. If more appropriate, contact richard.m.naething@nga.mil.
 
 Integration Branches
 --------------------

--- a/sarpy/__about__.py
+++ b/sarpy/__about__.py
@@ -33,7 +33,7 @@ __version__ = _version_number + _post_identifier
 
 __author__ = "National Geospatial-Intelligence Agency"
 __url__ = "https://github.com/ngageoint/sarpy"
-__email__ = "Wade.C.Schwartzkopf@nga.mil"
+__email__ = "richard.m.naething@nga.mil"
 
 
 __title__ = "sarpy"


### PR DESCRIPTION
# Description
Credit to @mtrachy for finding and proposing this fix

SICD XML from 07May24S1A428215_24_IW1_01_028_232453_DS0757R_42N083W_001C___DVV_0101_SPY_SICD.nitf (S1A_IW_SLC__1SDV_20240507T232451_20240507T232518_053772_0688B7_FA8E.SAFE)

<details><summary>Current vs This PR</summary>
<p>

```
OLD                                                                     |  AFTER PR 
------------------------------------------------------------------------+----------------------------------------------------------------------
 <RCSSFPoly order1="2" order2="2">                                      |  <RCSSFPoly order1="2" order2="2">
     <Coef exponent1="0" exponent2="0">0.0011302328296189245</Coef>     |    <Coef exponent1="0" exponent2="0">0.0011302328296189271</Coef>
     <Coef exponent1="0" exponent2="1">-6.2888043697752153E-24</Coef>   |    <Coef exponent1="0" exponent2="1">-2.1033359522552577E-22</Coef>
     <Coef exponent1="0" exponent2="2">-2.0193684853187064E-27</Coef>   |    <Coef exponent1="0" exponent2="2">-1.1146234933051507E-26</Coef>
     <Coef exponent1="1" exponent2="0">3.257286868174348E-23</Coef>     |    <Coef exponent1="1" exponent2="0">1.4837515287241753E-23</Coef>
     <Coef exponent1="1" exponent2="1">-1.8124088553588476E-43</Coef>   |    <Coef exponent1="1" exponent2="1">-9.415512873113371E-28</Coef>
     <Coef exponent1="1" exponent2="2">-5.8197410983465298E-47</Coef>   |    <Coef exponent1="1" exponent2="2">4.3804922641658137E-31</Coef>
     <Coef exponent1="2" exponent2="0">-5.1635638734464793E-27</Coef>   |    <Coef exponent1="2" exponent2="0">5.2233305172545714E-28</Coef>
     <Coef exponent1="2" exponent2="1">2.8730932423801833E-47</Coef>    |    <Coef exponent1="2" exponent2="1">2.0333262104155023E-31</Coef>
     <Coef exponent1="2" exponent2="2">9.2256550019730714E-51</Coef>    |    <Coef exponent1="2" exponent2="2">7.4537795968935227E-35</Coef>
 </RCSSFPoly>                                                           |  </RCSSFPoly>
 <SigmaZeroSFPoly order1="2" order2="2">                                |  <SigmaZeroSFPoly order1="2" order2="2">
     <Coef exponent1="0" exponent2="0">9.8724621654083891E-06</Coef>    |    <Coef exponent1="0" exponent2="0">9.872292908025862E-06</Coef>
     <Coef exponent1="0" exponent2="1">3.1317302041506464E-11</Coef>    |    <Coef exponent1="0" exponent2="1">-4.9039447776268959E-14</Coef>
     <Coef exponent1="0" exponent2="2">-1.0735898666700214E-16</Coef>   |    <Coef exponent1="0" exponent2="2">1.034542918388957E-18</Coef>
     <Coef exponent1="1" exponent2="0">-4.9537398879167156E-14</Coef>   |    <Coef exponent1="1" exponent2="0">3.1318289312706256E-11</Coef>
     <Coef exponent1="1" exponent2="1">-1.5714192235501836E-19</Coef>   |    <Coef exponent1="1" exponent2="1">2.8555700201415385E-19</Coef>
     <Coef exponent1="1" exponent2="2">5.3869894426346221E-25</Coef>    |    <Coef exponent1="1" exponent2="2">-6.0687677538036377E-24</Coef>
     <Coef exponent1="2" exponent2="0">1.0421000514754084E-18</Coef>    |    <Coef exponent1="2" exponent2="0">-1.0736450733325646E-16</Coef>
     <Coef exponent1="2" exponent2="1">3.3057368590254576E-24</Coef>    |    <Coef exponent1="2" exponent2="1">-1.7464586861684794E-24</Coef>
     <Coef exponent1="2" exponent2="2">-1.1332411677811942E-29</Coef>   |    <Coef exponent1="2" exponent2="2">2.3409777106418499E-29</Coef>
 </SigmaZeroSFPoly>                                                     |  </SigmaZeroSFPoly>
 <BetaZeroSFPoly order1="2" order2="2">                                 |  <BetaZeroSFPoly order1="2" order2="2">
     <Coef exponent1="0" exponent2="0">1.7803414694938489E-05</Coef>    |    <Coef exponent1="0" exponent2="0">1.780341469493853E-05</Coef>
     <Coef exponent1="0" exponent2="1">-9.9061175004268137E-26</Coef>   |    <Coef exponent1="0" exponent2="1">-3.3131724030171184E-24</Coef>
     <Coef exponent1="0" exponent2="2">-3.1809069444691668E-29</Coef>   |    <Coef exponent1="0" exponent2="2">-1.7557536606615239E-28</Coef>
     <Coef exponent1="1" exponent2="0">5.130874575111914E-25</Coef>     |    <Coef exponent1="1" exponent2="0">2.3372037227968276E-25</Coef>
     <Coef exponent1="1" exponent2="1">-2.8549043704217737E-45</Coef>   |    <Coef exponent1="1" exponent2="1">-1.4831305183560061E-29</Coef>
     <Coef exponent1="1" exponent2="2">-9.1672495680358371E-49</Coef>   |    <Coef exponent1="1" exponent2="2">6.90014643913757E-33</Coef>
     <Coef exponent1="2" exponent2="0">-8.1336399486613628E-29</Coef>   |    <Coef exponent1="2" exponent2="0">8.2277842981047332E-30</Coef>
     <Coef exponent1="2" exponent2="1">4.5256932121292334E-49</Coef>    |    <Coef exponent1="2" exponent2="1">3.2028931371884131E-33</Coef>
     <Coef exponent1="2" exponent2="2">1.4532241280581008E-52</Coef>    |    <Coef exponent1="2" exponent2="2">1.1741185155001171E-36</Coef>
 </BetaZeroSFPoly>                                                      |  </BetaZeroSFPoly>
 <GammaZeroSFPoly order1="2" order2="2">                                |  <GammaZeroSFPoly order1="2" order2="2">
     <Coef exponent1="0" exponent2="0">1.1863504106132207E-05</Coef>    |    <Coef exponent1="0" exponent2="0">1.1863210652382083E-05</Coef>
     <Coef exponent1="0" exponent2="1">5.4188428099697248E-11</Coef>    |    <Coef exponent1="0" exponent2="1">-8.5139837408223012E-14</Coef>
     <Coef exponent1="0" exponent2="2">-7.1711846134574438E-17</Coef>   |    <Coef exponent1="0" exponent2="2">1.785461274577751E-18</Coef>
     <Coef exponent1="1" exponent2="0">-8.5552268485214971E-14</Coef>   |    <Coef exponent1="1" exponent2="0">5.4188881389766835E-11</Coef>
     <Coef exponent1="1" exponent2="1">-3.9077349391068715E-19</Coef>   |    <Coef exponent1="1" exponent2="1">1.3678940109313185E-19</Coef>
     <Coef exponent1="1" exponent2="2">5.1714156788670206E-25</Coef>    |    <Coef exponent1="1" exponent2="2">-2.386891612211036E-24</Coef>
     <Coef exponent1="2" exponent2="0">1.7953679592336228E-18</Coef>    |    <Coef exponent1="2" exponent2="0">-7.171679869422298E-17</Coef>
     <Coef exponent1="2" exponent2="1">8.2006266193428813E-24</Coef>    |    <Coef exponent1="2" exponent2="1">-1.3742055627797562E-24</Coef>
     <Coef exponent1="2" exponent2="2">-1.0852539831040009E-29</Coef>   |    <Coef exponent1="2" exponent2="2">3.4541162449165958E-29</Coef>
 </GammaZeroSFPoly>                                                     |  </GammaZeroSFPoly>



```



</p>
</details> 


Notice that the BetaZero is nearly constant. The SICD DIDD states 
![image](https://github.com/ngageoint/sarpy/assets/78438270/78fb9dda-ef5e-4074-99b9-9b913e4dff9e)


So the SigmaZero and GammaZero should depend much more significantly on range than on azimuth due to the slope and graze changing much faster with range than with azimuth.

* SigmaZero goes like cos(slope) which goes up with increasing range.
* GammaZero goes like cos(slope)/sin(graze) ≅ cot(graze) (if slope ≅ graze, which is true for sentinel), which goes up even more with range.

# Test Results

<details><summary>Tests pass</summary>
<p>

```
SARPY_TEST_PATH=/data/sarpy_test/ nox
nox > Running session test(version='3.6')
nox > Creating conda env in .nox/test-version-3-6 with python
nox > conda install --yes --prefix /home/vscuser/git/glweb/software/third-party/sarpy/.nox/test-version-3-6 python=3.6
nox > python -m pip install '.[all]'
nox > pytest tests
========================================================================================================================== test session starts ==========================================================================================================================
platform linux -- Python 3.6.13, pytest-7.0.1, pluggy-1.0.0
rootdir: /home/vscuser/git/glweb/software/third-party/sarpy
collected 555 items                                                                                                                                                                                                                                                     

tests/test_class_string.py .                                                                                                                                                                                                                                      [  0%]
tests/consistency/test_consistency.py ........                                                                                                                                                                                                                    [  1%]
tests/consistency/test_cphd_consistency.py ..............................................................                                                                                                                                                         [ 12%]
tests/consistency/test_sicd_consistency.py ...                                                                                                                                                                                                                    [ 13%]
tests/consistency/test_sidd_consistency.py ....                                                                                                                                                                                                                   [ 14%]
tests/geometry/test_geocoords.py ..........                                                                                                                                                                                                                       [ 15%]
tests/geometry/test_geometry_elements.py ..........                                                                                                                                                                                                               [ 17%]
tests/geometry/test_latlon.py ...                                                                                                                                                                                                                                 [ 18%]
tests/geometry/test_point_projection.py ..............                                                                                                                                                                                                            [ 20%]
tests/io/test_kml.py .                                                                                                                                                                                                                                            [ 20%]
tests/io/DEM/test_geoid.py .                                                                                                                                                                                                                                      [ 21%]
tests/io/DEM/test_geotiff1deg_list.py ....                                                                                                                                                                                                                        [ 21%]
tests/io/DEM/test_geotiff1deg_reader.py ........                                                                                                                                                                                                                  [ 23%]
tests/io/complex/test_other_nitf.py ...                                                                                                                                                                                                                           [ 23%]
tests/io/complex/test_reader.py .ssssssssss                                                                                                                                                                                                                       [ 25%]
tests/io/complex/test_remote.py s                                                                                                                                                                                                                                 [ 25%]
tests/io/complex/test_sicd.py .                                                                                                                                                                                                                                   [ 26%]
tests/io/complex/test_utils.py .                                                                                                                                                                                                                                  [ 26%]
tests/io/complex/sicd_elements/test_sicd_elements_antenna.py ...                                                                                                                                                                                                  [ 26%]
tests/io/complex/sicd_elements/test_sicd_elements_base.py ...                                                                                                                                                                                                     [ 27%]
tests/io/complex/sicd_elements/test_sicd_elements_blocks.py .....................                                                                                                                                                                                 [ 31%]
tests/io/complex/sicd_elements/test_sicd_elements_collectioninfo.py ..                                                                                                                                                                                            [ 31%]
tests/io/complex/sicd_elements/test_sicd_elements_errorstatistics.py .                                                                                                                                                                                            [ 31%]
tests/io/complex/sicd_elements/test_sicd_elements_geodata.py ...                                                                                                                                                                                                  [ 32%]
tests/io/complex/sicd_elements/test_sicd_elements_grid.py ..                                                                                                                                                                                                      [ 32%]
tests/io/complex/sicd_elements/test_sicd_elements_imagecreation.py .                                                                                                                                                                                              [ 32%]
tests/io/complex/sicd_elements/test_sicd_elements_imagedata.py .                                                                                                                                                                                                  [ 32%]
tests/io/complex/sicd_elements/test_sicd_elements_imageformation.py ......                                                                                                                                                                                        [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_matchinfo.py .                                                                                                                                                                                                  [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_pfa.py .                                                                                                                                                                                                        [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_position.py ...                                                                                                                                                                                                 [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_radarcollection.py ..............                                                                                                                                                                               [ 37%]
tests/io/complex/sicd_elements/test_sicd_elements_radiometric.py .                                                                                                                                                                                                [ 37%]
tests/io/complex/sicd_elements/test_sicd_elements_rgazcomp.py .                                                                                                                                                                                                   [ 37%]
tests/io/complex/sicd_elements/test_sicd_elements_rma.py ...                                                                                                                                                                                                      [ 38%]
tests/io/complex/sicd_elements/test_sicd_elements_scpcoa.py ...................                                                                                                                                                                                   [ 41%]
tests/io/complex/sicd_elements/test_sicd_elements_sicd.py ..................................                                                                                                                                                                      [ 47%]
tests/io/complex/sicd_elements/test_sicd_elements_timeline.py ..................                                                                                                                                                                                  [ 51%]
tests/io/complex/sicd_elements/test_sicd_elements_utils.py ...                                                                                                                                                                                                    [ 51%]
tests/io/general/test_base.py ...                                                                                                                                                                                                                                 [ 52%]
tests/io/general/test_data_segment.py ..........                                                                                                                                                                                                                  [ 54%]
tests/io/general/test_format_function.py ........                                                                                                                                                                                                                 [ 55%]
tests/io/general/test_nitf.py .                                                                                                                                                                                                                                   [ 55%]
tests/io/general/test_nitf_headers.py .                                                                                                                                                                                                                           [ 55%]
tests/io/general/test_nitf_image.py ....                                                                                                                                                                                                                          [ 56%]
tests/io/general/test_tre.py ...                                                                                                                                                                                                                                  [ 57%]
tests/io/phase_history/test_cphd.py .......                                                                                                                                                                                                                       [ 58%]
tests/io/phase_history/test_cphd_versions.py .....                                                                                                                                                                                                                [ 59%]
tests/io/phase_history/cphd1_elements/test_cphd.py ....                                                                                                                                                                                                           [ 60%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_antenna.py .....                                                                                                                                                                                        [ 60%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_blocks.py ....                                                                                                                                                                                          [ 61%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_channel.py .                                                                                                                                                                                            [ 61%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_data.py .                                                                                                                                                                                               [ 61%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_dwell.py .                                                                                                                                                                                              [ 62%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_geoinfo.py ...                                                                                                                                                                                          [ 62%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_global.py ..                                                                                                                                                                                            [ 63%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_pvp.py .                                                                                                                                                                                                [ 63%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_referencegeometry.py .                                                                                                                                                                                  [ 63%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_supportarray.py ..                                                                                                                                                                                      [ 63%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_txrcv.py .                                                                                                                                                                                              [ 63%]
tests/io/phase_history/cphd1_elements/test_utils.py .                                                                                                                                                                                                             [ 64%]
tests/io/product/test_reader.py ...s                                                                                                                                                                                                                              [ 64%]
tests/io/product/test_sidd_schema.py .........                                                                                                                                                                                                                    [ 66%]
tests/io/product/test_sidd_writing.py ..                                                                                                                                                                                                                          [ 66%]
tests/io/product/sidd3_elements/test_exploitationfeatures.py ..................................................................................................................................                                                                   [ 90%]
tests/io/product/sidd3_elements/test_sidd3_elements.py .....                                                                                                                                                                                                      [ 91%]
tests/io/received/test_crsd.py .                                                                                                                                                                                                                                  [ 91%]
tests/processing/sicd/test_spectral_taper.py ........ss...........                                                                                                                                                                                                [ 95%]
tests/utils/test_sicd_sidelobe_control.py ..                                                                                                                                                                                                                      [ 95%]
tests/visualization/test_cphd_kmz_product_creation.py ..                                                                                                                                                                                                          [ 95%]
tests/visualization/test_crsd_kmz_product_creation.py .                                                                                                                                                                                                           [ 96%]
tests/visualization/test_kmz_product_creation.py .x                                                                                                                                                                                                               [ 96%]
tests/visualization/test_remap.py ....................                                                                                                                                                                                                            [100%]

=========================================================================================================================== warnings summary ============================================================================================================================
tests/geometry/test_point_projection.py::test_image_to_ground_errors
tests/geometry/test_point_projection.py::test_image_to_ground_dem
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/geometry/point_projection.py:1903: RuntimeWarning: divide by zero encountered in double_scalars
    lon_grid_size = min(10, lat_grid_size/abs(numpy.sin(numpy.deg2rad(ref_llh[0]))))

tests/visualization/test_kmz_product_creation.py::test_create_kmz[True]
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/visualization/kmz_utils.py:169: RuntimeWarning: invalid value encountered in double_scalars
    + dir_z**2 * semiaxis_a**2 * semiaxis_b**2

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================================================================================================== 540 passed, 14 skipped, 1 xfailed, 3 warnings in 51.16s ========================================================================================================
nox > Session test(version='3.6') was successful.
nox > Running session test(version='3.11')
nox > Creating conda env in .nox/test-version-3-11 with python
nox > conda install --yes --prefix /home/vscuser/git/glweb/software/third-party/sarpy/.nox/test-version-3-11 python=3.11
nox > python -m pip install '.[all]'
nox > pytest tests
========================================================================================================================== test session starts ==========================================================================================================================
platform linux -- Python 3.11.9, pytest-8.2.2, pluggy-1.5.0
rootdir: /home/vscuser/git/glweb/software/third-party/sarpy
collected 555 items                                                                                                                                                                                                                                                     

tests/consistency/test_consistency.py ........                                                                                                                                                                                                                    [  1%]
tests/consistency/test_cphd_consistency.py ..............................................................                                                                                                                                                         [ 12%]
tests/consistency/test_sicd_consistency.py ...                                                                                                                                                                                                                    [ 13%]
tests/consistency/test_sidd_consistency.py ....                                                                                                                                                                                                                   [ 13%]
tests/geometry/test_geocoords.py ..........                                                                                                                                                                                                                       [ 15%]
tests/geometry/test_geometry_elements.py ..........                                                                                                                                                                                                               [ 17%]
tests/geometry/test_latlon.py ...                                                                                                                                                                                                                                 [ 18%]
tests/geometry/test_point_projection.py ..............                                                                                                                                                                                                            [ 20%]
tests/io/DEM/test_geoid.py .                                                                                                                                                                                                                                      [ 20%]
tests/io/DEM/test_geotiff1deg_list.py ....                                                                                                                                                                                                                        [ 21%]
tests/io/DEM/test_geotiff1deg_reader.py ........                                                                                                                                                                                                                  [ 22%]
tests/io/complex/sicd_elements/test_sicd_elements_antenna.py ...                                                                                                                                                                                                  [ 23%]
tests/io/complex/sicd_elements/test_sicd_elements_base.py ...                                                                                                                                                                                                     [ 23%]
tests/io/complex/sicd_elements/test_sicd_elements_blocks.py .....................                                                                                                                                                                                 [ 27%]
tests/io/complex/sicd_elements/test_sicd_elements_collectioninfo.py ..                                                                                                                                                                                            [ 28%]
tests/io/complex/sicd_elements/test_sicd_elements_errorstatistics.py .                                                                                                                                                                                            [ 28%]
tests/io/complex/sicd_elements/test_sicd_elements_geodata.py ...                                                                                                                                                                                                  [ 28%]
tests/io/complex/sicd_elements/test_sicd_elements_grid.py ..                                                                                                                                                                                                      [ 29%]
tests/io/complex/sicd_elements/test_sicd_elements_imagecreation.py .                                                                                                                                                                                              [ 29%]
tests/io/complex/sicd_elements/test_sicd_elements_imagedata.py .                                                                                                                                                                                                  [ 29%]
tests/io/complex/sicd_elements/test_sicd_elements_imageformation.py ......                                                                                                                                                                                        [ 30%]
tests/io/complex/sicd_elements/test_sicd_elements_matchinfo.py .                                                                                                                                                                                                  [ 30%]
tests/io/complex/sicd_elements/test_sicd_elements_pfa.py .                                                                                                                                                                                                        [ 30%]
tests/io/complex/sicd_elements/test_sicd_elements_position.py ...                                                                                                                                                                                                 [ 31%]
tests/io/complex/sicd_elements/test_sicd_elements_radarcollection.py ..............                                                                                                                                                                               [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_radiometric.py .                                                                                                                                                                                                [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_rgazcomp.py .                                                                                                                                                                                                   [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_rma.py ...                                                                                                                                                                                                      [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_scpcoa.py ...................                                                                                                                                                                                   [ 38%]
tests/io/complex/sicd_elements/test_sicd_elements_sicd.py ..................................                                                                                                                                                                      [ 44%]
tests/io/complex/sicd_elements/test_sicd_elements_timeline.py ..................                                                                                                                                                                                  [ 47%]
tests/io/complex/sicd_elements/test_sicd_elements_utils.py ...                                                                                                                                                                                                    [ 48%]
tests/io/complex/test_other_nitf.py ...                                                                                                                                                                                                                           [ 48%]
tests/io/complex/test_reader.py .ssssssssss                                                                                                                                                                                                                       [ 50%]
tests/io/complex/test_remote.py s                                                                                                                                                                                                                                 [ 50%]
tests/io/complex/test_sicd.py .                                                                                                                                                                                                                                   [ 51%]
tests/io/complex/test_utils.py .                                                                                                                                                                                                                                  [ 51%]
tests/io/general/test_base.py ...                                                                                                                                                                                                                                 [ 51%]
tests/io/general/test_data_segment.py ..........                                                                                                                                                                                                                  [ 53%]
tests/io/general/test_format_function.py ........                                                                                                                                                                                                                 [ 55%]
tests/io/general/test_nitf.py .                                                                                                                                                                                                                                   [ 55%]
tests/io/general/test_nitf_headers.py .                                                                                                                                                                                                                           [ 55%]
tests/io/general/test_nitf_image.py ....                                                                                                                                                                                                                          [ 56%]
tests/io/general/test_tre.py ...                                                                                                                                                                                                                                  [ 56%]
tests/io/phase_history/cphd1_elements/test_cphd.py ....                                                                                                                                                                                                           [ 57%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_antenna.py .....                                                                                                                                                                                        [ 58%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_blocks.py ....                                                                                                                                                                                          [ 59%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_channel.py .                                                                                                                                                                                            [ 59%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_data.py .                                                                                                                                                                                               [ 59%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_dwell.py .                                                                                                                                                                                              [ 59%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_geoinfo.py ...                                                                                                                                                                                          [ 60%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_global.py ..                                                                                                                                                                                            [ 60%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_pvp.py .                                                                                                                                                                                                [ 60%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_referencegeometry.py .                                                                                                                                                                                  [ 60%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_supportarray.py ..                                                                                                                                                                                      [ 61%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_txrcv.py .                                                                                                                                                                                              [ 61%]
tests/io/phase_history/cphd1_elements/test_utils.py .                                                                                                                                                                                                             [ 61%]
tests/io/phase_history/test_cphd.py .......                                                                                                                                                                                                                       [ 62%]
tests/io/phase_history/test_cphd_versions.py .....                                                                                                                                                                                                                [ 63%]
tests/io/product/sidd3_elements/test_exploitationfeatures.py ..................................................................................................................................                                                                   [ 87%]
tests/io/product/sidd3_elements/test_sidd3_elements.py .....                                                                                                                                                                                                      [ 88%]
tests/io/product/test_reader.py ...s                                                                                                                                                                                                                              [ 88%]
tests/io/product/test_sidd_schema.py .........                                                                                                                                                                                                                    [ 90%]
tests/io/product/test_sidd_writing.py ..                                                                                                                                                                                                                          [ 90%]
tests/io/received/test_crsd.py .                                                                                                                                                                                                                                  [ 90%]
tests/io/test_kml.py .                                                                                                                                                                                                                                            [ 91%]
tests/processing/sicd/test_spectral_taper.py .....................                                                                                                                                                                                                [ 94%]
tests/test_class_string.py .                                                                                                                                                                                                                                      [ 95%]
tests/utils/test_sicd_sidelobe_control.py ..                                                                                                                                                                                                                      [ 95%]
tests/visualization/test_cphd_kmz_product_creation.py ..                                                                                                                                                                                                          [ 95%]
tests/visualization/test_crsd_kmz_product_creation.py .                                                                                                                                                                                                           [ 96%]
tests/visualization/test_kmz_product_creation.py .x                                                                                                                                                                                                               [ 96%]
tests/visualization/test_remap.py ....................                                                                                                                                                                                                            [100%]

=========================================================================================================================== warnings summary ============================================================================================================================
tests/geometry/test_point_projection.py::test_image_to_ground_errors
tests/geometry/test_point_projection.py::test_image_to_ground_dem
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/geometry/point_projection.py:1903: RuntimeWarning: divide by zero encountered in scalar divide
    lon_grid_size = min(10, lat_grid_size/abs(numpy.sin(numpy.deg2rad(ref_llh[0]))))

tests/test_class_string.py::TestClassString::test_class_str
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/annotation/afrl_rde_schema/__init__.py:7: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
    import pkg_resources

tests/visualization/test_cphd_kmz_product_creation.py::test_create_kmz
tests/visualization/test_cphd_kmz_product_creation.py::test_create_kmz
tests/visualization/test_cphd_kmz_product_creation.py::test_create_kmz
tests/visualization/test_cphd_kmz_product_creation.py::test_create_kmz
tests/visualization/test_cphd_kmz_product_creation.py::test_create_kmz
tests/visualization/test_cphd_kmz_product_creation.py::test_create_kmz
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/visualization/kmz_utils.py:302: MatplotlibDeprecationWarning: The collections attribute was deprecated in Matplotlib 3.8 and will be removed in 3.10.
    for path in contour_sets.collections[0].get_paths()

tests/visualization/test_kmz_product_creation.py::test_create_kmz[True]
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/visualization/kmz_utils.py:145: RuntimeWarning: invalid value encountered in scalar divide
    distance = (

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================================================================================================= 542 passed, 12 skipped, 1 xfailed, 10 warnings in 33.23s ========================================================================================================
nox > Session test(version='3.11') was successful.
nox > Ran multiple sessions:
nox > * test(version='3.6'): success
nox > * test(version='3.11'): success

```

</p>
</details> 