### PR TITLE
Support for numpy 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ release points are not being annotated in GitHub.
 - Unit tests for `sarpy/consistency/sidd_consistency.py`
 - Support for MATESA TRE
 - Support reading/writing CPHDs with compressed signal arrays
+- Support for numpy 2.0
 ### Fixed
 - `sarpy.io.kml.add_polygon` coordinate conditioning for older numpy versions
 - Replace unsupported `pillow` constant `Image.ANTIALIAS` with `Image.LANCZOS`

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ MIT license.
 
 Dependencies
 ------------
-The core library functionality depends only on `numpy >= 1.11.0` and `scipy`. 
+The core library functionality depends only on `numpy` and `scipy`. 
 
 Optional Dependencies and Behavior
 ----------------------------------

--- a/sarpy/io/DEM/DTED.py
+++ b/sarpy/io/DEM/DTED.py
@@ -423,8 +423,8 @@ class DTEDReader(object):
         fy = (lat - self._origin[1])/self._spacing[1]
 
         # get integer indices via floor
-        ix = numpy.cast[numpy.int32](numpy.floor(fx))
-        iy = numpy.cast[numpy.int32](numpy.floor(fy))
+        ix = numpy.asarray(numpy.floor(fx), dtype=numpy.int32)
+        iy = numpy.asarray(numpy.floor(fy), dtype=numpy.int32)
         return self._linear(ix, fx-ix, iy, fy-iy)
 
     def get_elevation(self, lat, lon, block_size=50000):

--- a/sarpy/io/DEM/geoid.py
+++ b/sarpy/io/DEM/geoid.py
@@ -288,8 +288,8 @@ class GeoidHeight(object):
         fx[fx < 0] += 360*self._lon_res
         fy = (90 - lat)*self._lat_res
 
-        ix = numpy.cast[numpy.int32](numpy.floor(fx))
-        iy = numpy.cast[numpy.int32](numpy.floor(fy))
+        ix = numpy.asarray(numpy.floor(fx), dtype=numpy.int32)
+        iy = numpy.asarray(numpy.floor(fy), dtype=numpy.int32)
 
         dx = fx - ix
         dy = fy - iy

--- a/sarpy/io/DEM/geotiff1deg.py
+++ b/sarpy/io/DEM/geotiff1deg.py
@@ -388,7 +388,7 @@ class GeoTIFF1DegInterpolator(DEMInterpolator):
                  "max": {"lat": lat_deg, "lon": lon_deg, "height": height}}
 
         """
-        if np.all(self._bounding_box_cache.get("box", []) == lat_lon_box):
+        if np.array_equal(self._bounding_box_cache.get("box", []), lat_lon_box):
             # If we have already done this calculation then don't do it again.
             return self._bounding_box_cache
 

--- a/sarpy/io/complex/nisar.py
+++ b/sarpy/io/complex/nisar.py
@@ -284,7 +284,7 @@ class NISARDetails(object):
             row = DirParamType(
                 Sgn=-1,
                 DeltaKCOAPoly=[[0, ], ],
-                WgtFunct=numpy.cast[numpy.float64](row_wgt),
+                WgtFunct=numpy.asarray(row_wgt, dtype=numpy.float64),
                 WgtType=WgtTypeType(WindowName=win_name))
 
             col_wgt = gp['azimuthChirpWeighting'][:]
@@ -292,7 +292,7 @@ class NISARDetails(object):
             col = DirParamType(
                 Sgn=-1,
                 KCtr=0,
-                WgtFunct=numpy.cast[numpy.float64](col_wgt),
+                WgtFunct=numpy.asarray(col_wgt, dtype=numpy.float64),
                 WgtType=WgtTypeType(WindowName=win_name))
 
             return GridType(ImagePlane='SLANT', Type='RGZERO', Row=row, Col=col)

--- a/sarpy/io/complex/sicd.py
+++ b/sarpy/io/complex/sicd.py
@@ -92,7 +92,7 @@ class AmpLookupFunction(ComplexFormatFunction):
         if lookup_table.dtype.name not in ['float32', 'float64']:
             raise ValueError('requires a numpy.ndarray of float32 or 64 dtype, got {}'.format(lookup_table.dtype))
         if lookup_table.dtype.name != 'float32':
-            lookup_table = numpy.cast['float32'](lookup_table)
+            lookup_table = numpy.asarray(lookup_table, dtype=numpy.float32)
         if lookup_table.shape != (256,):
             raise ValueError('Requires a one-dimensional numpy.ndarray with 256 elements, '
                              'got shape {}'.format(lookup_table.shape))

--- a/sarpy/io/complex/sicd_elements/blocks.py
+++ b/sarpy/io/complex/sicd_elements/blocks.py
@@ -936,7 +936,7 @@ class Poly1DType(Serializable, Arrayable):
                 'Coefs for class Poly1D must be one-dimensional. Received numpy.ndarray '
                 'of shape {}.'.format(value.shape))
         elif not value.dtype.name == 'float64':
-            value = numpy.cast[numpy.float64](value)
+            value = numpy.asarray(value, dtype=numpy.float64)
         self._coefs = value
 
     def __call__(self, x: Union[float, int, numpy.ndarray]) -> numpy.ndarray:
@@ -1250,7 +1250,7 @@ class Poly2DType(Serializable, Arrayable):
                 'Coefs for class Poly2D must be two-dimensional. Received numpy.ndarray '
                 'of shape {}.'.format(value.shape))
         elif not value.dtype.name == 'float64':
-            value = numpy.cast[numpy.float64](value)
+            value = numpy.asarray(value, dtype=numpy.float64)
         self._coefs = value
 
     def __getitem__(self, item):

--- a/sarpy/io/phase_history/cphd.py
+++ b/sarpy/io/phase_history/cphd.py
@@ -116,7 +116,7 @@ class AmpScalingFunction(ComplexFormatFunction):
         if array.dtype.name not in ['float32', 'float64']:
             raise ValueError('requires a numpy.ndarray of float32 or 64 dtype, got {}'.format(array.dtype))
         if array.dtype.name != 'float32':
-            array = numpy.cast['float32'](array)
+            array = numpy.asarray(array, dtype=numpy.float32)
 
         self._amplitude_scaling = array
         self._validate_amplitude_scaling()

--- a/sarpy/io/product/sidd1_elements/Display.py
+++ b/sarpy/io/product/sidd1_elements/Display.py
@@ -144,7 +144,7 @@ class ColorDisplayRemapType(Serializable, Arrayable):
                 arr[i, :] = [int(el) for el in entry]
                 i += 1
             if numpy.max(arr) < 256:
-                arr = numpy.cast[numpy.uint8](arr)
+                arr = numpy.asarray(arr, dtype=numpy.uint8)
             return cls(RemapLUT=arr)
         return cls()
 

--- a/sarpy/io/product/sidd2_elements/blocks.py
+++ b/sarpy/io/product/sidd2_elements/blocks.py
@@ -518,7 +518,7 @@ class BankCustomType(Serializable, Arrayable):
                 'Coefs for class BankCustomType must be two-dimensional. Received numpy.ndarray '
                 'of shape {}.'.format(value.shape))
         elif not value.dtype.name == 'float64':
-            value = numpy.cast[numpy.float64](value)
+            value = numpy.asarray(value, dtype=numpy.float64)
         self._coefs = value
 
     def __getitem__(self, item):
@@ -844,7 +844,7 @@ class LUTInfoType(Serializable, Arrayable):
         for i, lut_node in enumerate(lut_nodes):
             arr[:, i] = [str(el) for el in get_node_value(lut_node)]
         if numpy.max(arr) < 256:
-            arr = numpy.cast[numpy.uint8](arr)
+            arr = numpy.asarray(arr, dtype=numpy.uint8)
         return cls(LUTValues=arr)
 
     def to_node(self, doc, tag, ns_key=None, parent=None, check_validity=False, strict=DEFAULT_STRICT, exclude=()):

--- a/sarpy/processing/sicd/csi.py
+++ b/sarpy/processing/sicd/csi.py
@@ -150,7 +150,7 @@ def csi_array(
     # move to phase history domain
     ph_indices = int(numpy.floor(0.5*(array.shape[1] - filter_map.shape[0]))) + \
                  numpy.arange(filter_map.shape[0], dtype=numpy.int32)
-    ph0 = fftshift(ifft(numpy.cast[numpy.complex128](array), axis=1), axes=1)[:, ph_indices]
+    ph0 = fftshift(ifft(numpy.asarray(array, numpy.complex128), axis=1), axes=1)[:, ph_indices]
     # construct the filtered workspace
     # NB: processing is more efficient with color band in the first dimension
     ph0_RGB = numpy.zeros((3, array.shape[0], filter_map.shape[0]), dtype=numpy.complex128)

--- a/sarpy/processing/sicd/rgiqe.py
+++ b/sarpy/processing/sicd/rgiqe.py
@@ -468,7 +468,7 @@ def get_bandwidth_noise_distribution(
 
     best_index = numpy.argmin((desired_information_density - inf_densities)**2)
 
-    indices = numpy.cast['int32'](best_index - alpha*best_index)
+    indices = numpy.asarray(best_index - alpha*best_index, dtype=numpy.int32)
     indices = numpy.clip(indices, 0, best_index)
 
     this_bw_areas = bw_areas[indices]
@@ -719,10 +719,10 @@ def get_bidirectional_bandwidth_multiplier_possibilities(
     aperture_size = numpy.empty((the_size, 2), dtype='int32')
     bandwidth_multiplier = numpy.empty((the_size, 2), dtype='float64')
 
-    row_indexing = numpy.cast['int32'](
-        numpy.ceil(float(row_aperture_size.size - 1)*numpy.arange(the_size)/float(the_size - 1)))
-    col_indexing = numpy.cast['int32'](
-        numpy.ceil(float(col_aperture_size.size - 1)*numpy.arange(the_size)/float(the_size - 1)))
+    row_indexing = numpy.asarray(
+        numpy.ceil(float(row_aperture_size.size - 1)*numpy.arange(the_size)/float(the_size - 1)), dtype=numpy.int32)
+    col_indexing = numpy.asarray(
+        numpy.ceil(float(col_aperture_size.size - 1)*numpy.arange(the_size)/float(the_size - 1)), dtype=numpy.int32)
 
     aperture_size[:, 0] = row_aperture_size[row_indexing]
     aperture_size[:, 1] = col_aperture_size[col_indexing]

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(name=parameters['__title__'],
       url=parameters['__url__'],
       author=parameters['__author__'],
       author_email=parameters['__email__'],  # The primary POC
-      install_requires=['numpy>=1.11.0,<2.0', 'scipy'],
+      install_requires=['numpy>=1.19.0', 'scipy'],
       zip_safe=False,  # Use of __file__ and __path__ in some code makes it unusable from zip
       test_suite="setup.my_test_suite",
       extras_require={

--- a/tests/io/complex/sicd_elements/test_sicd_elements_blocks.py
+++ b/tests/io/complex/sicd_elements/test_sicd_elements_blocks.py
@@ -445,7 +445,7 @@ def test_blocks_poly1dtype(sicd, poly1d_doc, kwargs):
     assert np.all(poly.Coefs == sicd.Position.ARPPoly.X.Coefs)
 
     # Setter
-    poly.Coefs = np.cast[np.float32](sicd.Position.ARPPoly.Y.Coefs)
+    poly.Coefs = np.asarray(sicd.Position.ARPPoly.Y.Coefs, dtype=np.float32)
     assert poly.Coefs.dtype.name == "float64"
 
     poly.Coefs = sicd.Position.ARPPoly.Y.Coefs
@@ -573,7 +573,7 @@ def test_blocks_poly2dtype(sicd, poly2d_doc, kwargs):
     # Setter
     poly.Coefs = sicd.Radiometric.RCSSFPoly.Coefs.tolist()
 
-    poly.Coefs = np.cast[np.float32](sicd.Radiometric.RCSSFPoly.Coefs)
+    poly.Coefs = np.asarray(sicd.Radiometric.RCSSFPoly.Coefs, np.float32)
     assert poly.Coefs.dtype.name == "float64"
 
     poly.Coefs = sicd.Radiometric.RCSSFPoly.Coefs


### PR DESCRIPTION
Ran into some problems with using newer versions of numpy.  This PR fixes a problem with numpy >=1.25 and adds support for 2.0.

# Test Results
<details><summary>Tests pass</summary>

```
$ SARPY_TEST_PATH=/data/sarpy_test_path/ nox
nox > Running session test(version='3.6')
nox > Creating conda env in .nox/test-version-3-6 with python
nox > conda install --yes --prefix /home/vscuser/git/software/thirdparty/sarpy/.nox/test-version-3-6 python=3.6
nox > python -m pip install '.[all]'
nox > pytest tests
====================================================== test session starts ======================================================
platform linux -- Python 3.6.13, pytest-7.0.1, pluggy-1.0.0
rootdir: /home/vscuser/git/software/thirdparty/sarpy
collected 555 items                                                                                                             

tests/test_class_string.py .                                                                                              [  0%]
tests/consistency/test_consistency.py ........                                                                            [  1%]
tests/consistency/test_cphd_consistency.py ..............................................................                 [ 12%]
tests/consistency/test_sicd_consistency.py ...                                                                            [ 13%]
tests/consistency/test_sidd_consistency.py ....                                                                           [ 14%]
tests/geometry/test_geocoords.py ..........                                                                               [ 15%]
tests/geometry/test_geometry_elements.py ..........                                                                       [ 17%]
tests/geometry/test_latlon.py ...                                                                                         [ 18%]
tests/geometry/test_point_projection.py ..............                                                                    [ 20%]
tests/io/test_kml.py .                                                                                                    [ 20%]
tests/io/DEM/test_geoid.py .                                                                                              [ 21%]
tests/io/DEM/test_geotiff1deg_list.py ....                                                                                [ 21%]
tests/io/DEM/test_geotiff1deg_reader.py ........                                                                          [ 23%]
tests/io/complex/test_other_nitf.py ...                                                                                   [ 23%]
tests/io/complex/test_reader.py ..sss.ssss.                                                                               [ 25%]
tests/io/complex/test_remote.py s                                                                                         [ 25%]
tests/io/complex/test_sicd.py .                                                                                           [ 26%]
tests/io/complex/test_utils.py .                                                                                          [ 26%]
tests/io/complex/sicd_elements/test_sicd_elements_antenna.py ...                                                          [ 26%]
tests/io/complex/sicd_elements/test_sicd_elements_base.py ...                                                             [ 27%]
tests/io/complex/sicd_elements/test_sicd_elements_blocks.py .....................                                         [ 31%]
tests/io/complex/sicd_elements/test_sicd_elements_collectioninfo.py ..                                                    [ 31%]
tests/io/complex/sicd_elements/test_sicd_elements_errorstatistics.py .                                                    [ 31%]
tests/io/complex/sicd_elements/test_sicd_elements_geodata.py ...                                                          [ 32%]
tests/io/complex/sicd_elements/test_sicd_elements_grid.py ..                                                              [ 32%]
tests/io/complex/sicd_elements/test_sicd_elements_imagecreation.py .                                                      [ 32%]
tests/io/complex/sicd_elements/test_sicd_elements_imagedata.py .                                                          [ 32%]
tests/io/complex/sicd_elements/test_sicd_elements_imageformation.py ......                                                [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_matchinfo.py .                                                          [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_pfa.py .                                                                [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_position.py ...                                                         [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_radarcollection.py ..............                                       [ 37%]
tests/io/complex/sicd_elements/test_sicd_elements_radiometric.py .                                                        [ 37%]
tests/io/complex/sicd_elements/test_sicd_elements_rgazcomp.py .                                                           [ 37%]
tests/io/complex/sicd_elements/test_sicd_elements_rma.py ...                                                              [ 38%]
tests/io/complex/sicd_elements/test_sicd_elements_scpcoa.py ...................                                           [ 41%]
tests/io/complex/sicd_elements/test_sicd_elements_sicd.py ..................................                              [ 47%]
tests/io/complex/sicd_elements/test_sicd_elements_timeline.py ..................                                          [ 51%]
tests/io/complex/sicd_elements/test_sicd_elements_utils.py ...                                                            [ 51%]
tests/io/general/test_base.py ...                                                                                         [ 52%]
tests/io/general/test_data_segment.py ..........                                                                          [ 54%]
tests/io/general/test_format_function.py ........                                                                         [ 55%]
tests/io/general/test_nitf.py .                                                                                           [ 55%]
tests/io/general/test_nitf_headers.py .                                                                                   [ 55%]
tests/io/general/test_nitf_image.py ....                                                                                  [ 56%]
tests/io/general/test_tre.py ...                                                                                          [ 57%]
tests/io/phase_history/test_cphd.py .......                                                                               [ 58%]
tests/io/phase_history/test_cphd_versions.py .....                                                                        [ 59%]
tests/io/phase_history/cphd1_elements/test_cphd.py ....                                                                   [ 60%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_antenna.py .....                                                [ 60%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_blocks.py ....                                                  [ 61%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_channel.py .                                                    [ 61%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_data.py .                                                       [ 61%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_dwell.py .                                                      [ 62%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_geoinfo.py ...                                                  [ 62%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_global.py ..                                                    [ 63%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_pvp.py .                                                        [ 63%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_referencegeometry.py .                                          [ 63%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_supportarray.py ..                                              [ 63%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_txrcv.py .                                                      [ 63%]
tests/io/phase_history/cphd1_elements/test_utils.py .                                                                     [ 64%]
tests/io/product/test_reader.py ...s                                                                                      [ 64%]
tests/io/product/test_sidd_schema.py .........                                                                            [ 66%]
tests/io/product/test_sidd_writing.py ..                                                                                  [ 66%]
tests/io/product/sidd3_elements/test_exploitationfeatures.py ............................................................ [ 77%]
......................................................................                                                    [ 90%]
tests/io/product/sidd3_elements/test_sidd3_elements.py .....                                                              [ 91%]
tests/io/received/test_crsd.py .                                                                                          [ 91%]
tests/processing/sicd/test_spectral_taper.py ........ss...........                                                        [ 95%]
tests/utils/test_sicd_sidelobe_control.py ..                                                                              [ 95%]
tests/visualization/test_cphd_kmz_product_creation.py ..                                                                  [ 95%]
tests/visualization/test_crsd_kmz_product_creation.py .                                                                   [ 96%]
tests/visualization/test_kmz_product_creation.py .x                                                                       [ 96%]
tests/visualization/test_remap.py ....................                                                                    [100%]

======================================================= warnings summary ========================================================
tests/geometry/test_point_projection.py::test_image_to_ground_errors
tests/geometry/test_point_projection.py::test_image_to_ground_dem
  /home/vscuser/git/software/thirdparty/sarpy/sarpy/geometry/point_projection.py:1903: RuntimeWarning: divide by zero encountered in double_scalars
    lon_grid_size = min(10, lat_grid_size/abs(numpy.sin(numpy.deg2rad(ref_llh[0]))))

tests/visualization/test_kmz_product_creation.py::test_create_kmz[True]
  /home/vscuser/git/software/thirdparty/sarpy/sarpy/visualization/kmz_utils.py:169: RuntimeWarning: invalid value encountered in double_scalars
    + dir_z**2 * semiaxis_a**2 * semiaxis_b**2

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=============================== 543 passed, 11 skipped, 1 xfailed, 3 warnings in 70.41s (0:01:10) ===============================
nox > Session test(version='3.6') was successful.
nox > Running session test(version='3.11')
nox > Creating conda env in .nox/test-version-3-11 with python
nox > conda install --yes --prefix /home/vscuser/git/software/thirdparty/sarpy/.nox/test-version-3-11 python=3.11
nox > python -m pip install '.[all]'
nox > pytest tests
====================================================== test session starts ======================================================
platform linux -- Python 3.11.9, pytest-8.2.2, pluggy-1.5.0
rootdir: /home/vscuser/git/software/thirdparty/sarpy
collected 555 items                                                                                                             

tests/consistency/test_consistency.py ........                                                                            [  1%]
tests/consistency/test_cphd_consistency.py ..............................................................                 [ 12%]
tests/consistency/test_sicd_consistency.py ...                                                                            [ 13%]
tests/consistency/test_sidd_consistency.py ....                                                                           [ 13%]
tests/geometry/test_geocoords.py ..........                                                                               [ 15%]
tests/geometry/test_geometry_elements.py ..........                                                                       [ 17%]
tests/geometry/test_latlon.py ...                                                                                         [ 18%]
tests/geometry/test_point_projection.py ..............                                                                    [ 20%]
tests/io/DEM/test_geoid.py .                                                                                              [ 20%]
tests/io/DEM/test_geotiff1deg_list.py ....                                                                                [ 21%]
tests/io/DEM/test_geotiff1deg_reader.py ........                                                                          [ 22%]
tests/io/complex/sicd_elements/test_sicd_elements_antenna.py ...                                                          [ 23%]
tests/io/complex/sicd_elements/test_sicd_elements_base.py ...                                                             [ 23%]
tests/io/complex/sicd_elements/test_sicd_elements_blocks.py .....................                                         [ 27%]
tests/io/complex/sicd_elements/test_sicd_elements_collectioninfo.py ..                                                    [ 28%]
tests/io/complex/sicd_elements/test_sicd_elements_errorstatistics.py .                                                    [ 28%]
tests/io/complex/sicd_elements/test_sicd_elements_geodata.py ...                                                          [ 28%]
tests/io/complex/sicd_elements/test_sicd_elements_grid.py ..                                                              [ 29%]
tests/io/complex/sicd_elements/test_sicd_elements_imagecreation.py .                                                      [ 29%]
tests/io/complex/sicd_elements/test_sicd_elements_imagedata.py .                                                          [ 29%]
tests/io/complex/sicd_elements/test_sicd_elements_imageformation.py ......                                                [ 30%]
tests/io/complex/sicd_elements/test_sicd_elements_matchinfo.py .                                                          [ 30%]
tests/io/complex/sicd_elements/test_sicd_elements_pfa.py .                                                                [ 30%]
tests/io/complex/sicd_elements/test_sicd_elements_position.py ...                                                         [ 31%]
tests/io/complex/sicd_elements/test_sicd_elements_radarcollection.py ..............                                       [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_radiometric.py .                                                        [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_rgazcomp.py .                                                           [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_rma.py ...                                                              [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_scpcoa.py ...................                                           [ 38%]
tests/io/complex/sicd_elements/test_sicd_elements_sicd.py ..................................                              [ 44%]
tests/io/complex/sicd_elements/test_sicd_elements_timeline.py ..................                                          [ 47%]
tests/io/complex/sicd_elements/test_sicd_elements_utils.py ...                                                            [ 48%]
tests/io/complex/test_other_nitf.py ...                                                                                   [ 48%]
tests/io/complex/test_reader.py ..sss.ssss.                                                                               [ 50%]
tests/io/complex/test_remote.py s                                                                                         [ 50%]
tests/io/complex/test_sicd.py .                                                                                           [ 51%]
tests/io/complex/test_utils.py .                                                                                          [ 51%]
tests/io/general/test_base.py ...                                                                                         [ 51%]
tests/io/general/test_data_segment.py ..........                                                                          [ 53%]
tests/io/general/test_format_function.py ........                                                                         [ 55%]
tests/io/general/test_nitf.py .                                                                                           [ 55%]
tests/io/general/test_nitf_headers.py .                                                                                   [ 55%]
tests/io/general/test_nitf_image.py ....                                                                                  [ 56%]
tests/io/general/test_tre.py ...                                                                                          [ 56%]
tests/io/phase_history/cphd1_elements/test_cphd.py ....                                                                   [ 57%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_antenna.py .....                                                [ 58%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_blocks.py ....                                                  [ 59%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_channel.py .                                                    [ 59%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_data.py .                                                       [ 59%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_dwell.py .                                                      [ 59%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_geoinfo.py ...                                                  [ 60%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_global.py ..                                                    [ 60%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_pvp.py .                                                        [ 60%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_referencegeometry.py .                                          [ 60%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_supportarray.py ..                                              [ 61%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_txrcv.py .                                                      [ 61%]
tests/io/phase_history/cphd1_elements/test_utils.py .                                                                     [ 61%]
tests/io/phase_history/test_cphd.py .......                                                                               [ 62%]
tests/io/phase_history/test_cphd_versions.py .....                                                                        [ 63%]
tests/io/product/sidd3_elements/test_exploitationfeatures.py ............................................................ [ 74%]
......................................................................                                                    [ 87%]
tests/io/product/sidd3_elements/test_sidd3_elements.py .....                                                              [ 88%]
tests/io/product/test_reader.py ...s                                                                                      [ 88%]
tests/io/product/test_sidd_schema.py .........                                                                            [ 90%]
tests/io/product/test_sidd_writing.py ..                                                                                  [ 90%]
tests/io/received/test_crsd.py .                                                                                          [ 90%]
tests/io/test_kml.py .                                                                                                    [ 91%]
tests/processing/sicd/test_spectral_taper.py .....................                                                        [ 94%]
tests/test_class_string.py .                                                                                              [ 95%]
tests/utils/test_sicd_sidelobe_control.py ..                                                                              [ 95%]
tests/visualization/test_cphd_kmz_product_creation.py ..                                                                  [ 95%]
tests/visualization/test_crsd_kmz_product_creation.py .                                                                   [ 96%]
tests/visualization/test_kmz_product_creation.py .x                                                                       [ 96%]
tests/visualization/test_remap.py ....................                                                                    [100%]

======================================================= warnings summary ========================================================
tests/geometry/test_geometry_elements.py: 77 warnings
  /home/vscuser/git/software/thirdparty/sarpy/sarpy/geometry/geometry_elements.py:131: DeprecationWarning: Arrays of 2-dimensional vectors are deprecated. Use arrays of 3-dimensional vectors instead. (deprecated in NumPy 2.0)
    dir_cross = float(numpy.cross(R, S))  # the scalar cross product of the direction vectors

tests/geometry/test_geometry_elements.py: 43 warnings
  /home/vscuser/git/software/thirdparty/sarpy/sarpy/geometry/geometry_elements.py:137: DeprecationWarning: Arrays of 2-dimensional vectors are deprecated. Use arrays of 3-dimensional vectors instead. (deprecated in NumPy 2.0)
    end_cross_0 = float(numpy.cross(Q-P, S))

tests/geometry/test_geometry_elements.py: 43 warnings
  /home/vscuser/git/software/thirdparty/sarpy/sarpy/geometry/geometry_elements.py:138: DeprecationWarning: Arrays of 2-dimensional vectors are deprecated. Use arrays of 3-dimensional vectors instead. (deprecated in NumPy 2.0)
    end_cross_1 = float(numpy.cross(Q-P, R))

tests/geometry/test_point_projection.py::test_image_to_ground_errors
tests/geometry/test_point_projection.py::test_image_to_ground_dem
  /home/vscuser/git/software/thirdparty/sarpy/sarpy/geometry/point_projection.py:1903: RuntimeWarning: divide by zero encountered in scalar divide
    lon_grid_size = min(10, lat_grid_size/abs(numpy.sin(numpy.deg2rad(ref_llh[0]))))

tests/test_class_string.py::TestClassString::test_class_str
  /home/vscuser/git/software/thirdparty/sarpy/sarpy/annotation/afrl_rde_schema/__init__.py:7: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
    import pkg_resources

tests/visualization/test_cphd_kmz_product_creation.py::test_create_kmz
tests/visualization/test_cphd_kmz_product_creation.py::test_create_kmz
tests/visualization/test_cphd_kmz_product_creation.py::test_create_kmz
tests/visualization/test_cphd_kmz_product_creation.py::test_create_kmz
tests/visualization/test_cphd_kmz_product_creation.py::test_create_kmz
tests/visualization/test_cphd_kmz_product_creation.py::test_create_kmz
  /home/vscuser/git/software/thirdparty/sarpy/sarpy/visualization/kmz_utils.py:302: MatplotlibDeprecationWarning: The collections attribute was deprecated in Matplotlib 3.8 and will be removed in 3.10.
    for path in contour_sets.collections[0].get_paths()

tests/visualization/test_kmz_product_creation.py::test_create_kmz[True]
  /home/vscuser/git/software/thirdparty/sarpy/sarpy/visualization/kmz_utils.py:145: RuntimeWarning: invalid value encountered in scalar divide
    distance = (

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=================================== 545 passed, 9 skipped, 1 xfailed, 173 warnings in 34.63s ====================================
nox > Session test(version='3.11') was successful.
nox > Ran multiple sessions:
nox > * test(version='3.6'): success
nox > * test(version='3.11'): success
```

</details>