### PR TITLE
Don't close file-like object on NITF tear-down

### DIFF
--- a/sarpy/io/general/nitf.py
+++ b/sarpy/io/general/nitf.py
@@ -4174,4 +4174,3 @@ class NITFWriter(BaseWriter):
 
         self._nitf_writing_details = None
         self._image_segment_data_segments = None
-        self._file_object.close()


### PR DESCRIPTION
If you try to write to a file-like object, NITFWriter will close the file-like object. This creates a problem, if the caller wants to still use the file-like object. For example, writing to an in-memory buffer:

```python
bytes= io.BytesIO()
with SICDWriter(bytes):
    <do some stuff>

# Trying to access bytes here generates an exception
```

At this point, sarpy has closed the buffer object, and trying to access the bytes (e.g. calling bytes.getbuffer()) raises an exception.