### PR TITLE
Handle BaseReader going away before an open file.

### DIFF
--- a/sarpy/io/general/nitf.py
+++ b/sarpy/io/general/nitf.py
@@ -2447,7 +2447,8 @@ class NITFReader(BaseReader):
 
     def close(self) -> None:
         self._image_segment_data_segments = None
-        BaseReader.close(self)
+        if BaseReader is not None:
+            BaseReader.close(self)
 
 
 ########


### PR DESCRIPTION
Our application doesn't close any open SICD files explicitly and maintains a reference to them throughout the application, so they're not garbage collected until shutdown.  At that point BaseReader has been destructed before our open file and we got a ton of errors like:

Exception ignored in: <function BaseReader.__del__ at 0x7fd05b307a30>
Traceback (most recent call last):
  File "/share/home/kjurka@emagsys.com/git/kjurka/sarpy/sarpy/io/general/base.py", line 463, in __del__
  File "/share/home/kjurka@emagsys.com/git/kjurka/sarpy/sarpy/io/general/nitf.py", line 2450, in close
AttributeError: 'NoneType' object has no attribute 'close'

I haven't been able to come up with a standalone replication of this problem, but this works for me.