### PR TITLE
Handle partial DEM data.

### DIFF
--- a/sarpy/io/DEM/DTED.py
+++ b/sarpy/io/DEM/DTED.py
@@ -790,12 +790,22 @@ class DTEDInterpolator(DEMInterpolator):
             return self._get_ref_geoid(lat_lon_box)
 
         obs_maxes = [reader.get_max(lat_lon_box=lat_lon_box) for reader in self._readers]
-        return float(max(value for value in obs_maxes if value is not None))
+        obs_maxes = [value for value in obs_maxes if value is not None]
+
+        if not obs_maxes:
+            return self._get_ref_geoid(lat_lon_box)
+
+        return float(max(obs_maxes))
 
     def get_min_geoid(self, lat_lon_box=None):
         if len(self._readers) < 1:
             return self._get_ref_geoid(lat_lon_box)
 
         obs_mins = [reader.get_min(lat_lon_box=lat_lon_box) for reader in self._readers]
-        return float(min(value for value in obs_mins if value is not None))
+        obs_mins = [value for value in obs_mins if value is not None]
+
+        if not obs_mins:
+            return self._get_ref_geoid(lat_lon_box)
+
+        return float(min(obs_mins))
 


### PR DESCRIPTION
When creating a DTEDInterpolator where we only have DEM tiles for part of the area covered by the lat_lon_box, sarpy has problems geolocating points without DEM tiles.  Handle this by falling back to the reference geoid as we would if we didn't have any DEM at all.

  File "/share/home/kjurka@emagsys.com/git/kjurka/sarpy/sarpy/geometry/point_projection.py", line 1248, in image_to_ground
    return image_to_ground_dem(
  File "/share/home/kjurka@emagsys.com/git/kjurka/sarpy/sarpy/geometry/point_projection.py", line 1949, in image_to_ground_dem
    coords[mask, :] = _image_to_ground_dem_block(
  File "/share/home/kjurka@emagsys.com/git/kjurka/sarpy/sarpy/geometry/point_projection.py", line 1784, in _image_to_ground_dem_block
    min_dem = dem_interpolator.get_min_hae(padded_box) - 10
  File "/share/home/kjurka@emagsys.com/git/kjurka/sarpy/sarpy/io/DEM/DTED.py", line 786, in get_min_hae
    return self.get_min_geoid(lat_lon_box=lat_lon_box) + self._get_ref_geoid(lat_lon_box)
  File "/share/home/kjurka@emagsys.com/git/kjurka/sarpy/sarpy/io/DEM/DTED.py", line 800, in get_min_geoid
    return float(min(value for value in obs_mins if value is not None))
ValueError: min() arg is an empty sequence