### PR TITLE
Bugfix: SIDD 3.0.0 projection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ release points are not being annotated in GitHub.
 - Various SICD and SIDD elements fixed to better match NGA standard
 - Fixed case where DTEDInterpolator applied geoid offset incorrectly
 - Improved DTEDInterpolator handling of missing DEMs
+- SIDD 3.0.0 point projection
 
 ## [1.3.58] - 2023-08-07
 ### Added

--- a/sarpy/io/product/sidd.py
+++ b/sarpy/io/product/sidd.py
@@ -41,6 +41,7 @@ logger = logging.getLogger(__name__)
 ########
 # module variables
 _class_priority = {'U': 0, 'R': 1, 'C': 2, 'S': 3, 'T': 4}
+SIDD_TYPES = (SIDDType1, SIDDType2, SIDDType3)
 
 
 #########

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -28,16 +28,15 @@ def find_test_data_files(test_json_file):
         the path specified by the environmental variable SARPY_TEST_PATH.
     """
     test_data_files = {}
-    if os.path.isfile(test_json_file):
-        with open(test_json_file, 'r') as fi:
-            the_files = json.load(fi)
-            for the_type in the_files:
-                valid_entries = []
-                for entry in the_files[the_type]:
-                    the_file = parse_file_entry(entry)
-                    if the_file is not None:
-                        valid_entries.append(the_file)
-                test_data_files[the_type] = valid_entries
+    with open(test_json_file, 'r') as fi:
+        the_files = json.load(fi)
+        for the_type in the_files:
+            valid_entries = []
+            for entry in the_files[the_type]:
+                the_file = parse_file_entry(entry)
+                if the_file is not None:
+                    valid_entries.append(the_file)
+            test_data_files[the_type] = valid_entries
     return test_data_files
 
 

--- a/tests/io/product/test_sidd.py
+++ b/tests/io/product/test_sidd.py
@@ -1,0 +1,48 @@
+#
+# Copyright 2023 Valkyrie Systems Corporation
+#
+# Licensed under MIT License.  See LICENSE.
+#
+import pathlib
+import tempfile
+
+import numpy as np
+import pytest
+
+import sarpy.io.product
+import sarpy.utils.create_product
+
+import tests
+
+
+TOLERANCE = 1e-8
+
+product_file_types = tests.find_test_data_files(pathlib.Path(__file__).parent / 'product_file_types.json')
+sicd_files = product_file_types.get('SICD', [])
+
+
+@pytest.fixture(scope="module", params=[1, 2, 3])
+def sidd_nitf(request):
+    if not sicd_files:
+        pytest.skip("SICD file required; check SARPY_TEST_PATH")
+    with tempfile.TemporaryDirectory() as tmpdir:
+        sarpy.utils.create_product.main([
+            str(sicd_files[0]),
+            tmpdir,
+            f'--version={request.param}',
+        ])
+        contents = list(pathlib.Path(tmpdir).iterdir())
+        assert len(contents) == 1
+        yield contents[0]
+
+
+def test_sidd_projection(sidd_nitf):
+    sidd_reader = sarpy.io.product.open(str(sidd_nitf))
+    for sidd_obj in sidd_reader.sidd_meta:
+        assert sidd_obj.Measurement.ProjectionType != "PolynomialProjection"  # would not support projections
+        ref_pt_rowcol = sidd_obj.Measurement.ReferencePoint.Point.get_array()
+        ref_pt_ecef = sidd_obj.Measurement.ReferencePoint.ECEF.get_array()
+        ref_pt_ecef_proj = sidd_obj.project_image_to_ground(ref_pt_rowcol)
+        ref_pt_rowcol_proj, _, _ = sidd_obj.project_ground_to_image(ref_pt_ecef)
+        assert np.linalg.norm(ref_pt_rowcol - ref_pt_rowcol_proj) == pytest.approx(0, abs=1e-2)
+        assert np.linalg.norm(ref_pt_ecef - ref_pt_ecef_proj) == pytest.approx(0, abs=1e-3)


### PR DESCRIPTION
# Description
This PR fixes an oversight where SIDD 3.0.0 support was inadvertently omitted from `point_projection.py`.

<details><summary>unittest fails in integration/1.3.59-rc</summary>

```
$ SARPY_TEST_PATH=/data/sarpy_test/ pytest tests/io/product/test_sidd.py::test_sidd_projection  -v
=================================================================================================================================================================================== test session starts ===================================================================================================================================================================================
platform linux -- Python 3.10.14, pytest-7.4.4, pluggy-1.0.0 -- /home/vscuser/miniconda3/envs/sarpy/bin/python
cachedir: .pytest_cache
rootdir: /home/vscuser/git/glweb/software/third-party/sarpy
plugins: anyio-4.2.0, cov-4.1.0
collected 3 items                                                                                                                                                                                                                                                                                                                                                                         

tests/io/product/test_sidd.py::test_sidd_projection[1] PASSED                                                                                                                                                                                                                                                                                                                       [ 33%]
tests/io/product/test_sidd.py::test_sidd_projection[2] PASSED                                                                                                                                                                                                                                                                                                                       [ 66%]
tests/io/product/test_sidd.py::test_sidd_projection[3] FAILED  
```

</details>

but passes with the changes from this branch.

## Miscellaneous
In addition, due to a typo in my testing I realized that currently `tests.find_test_data_files` just silently skips if the requested `test_json_file` can't be found. This PR proposes changing this so that typos/data problems don't just silently skip tests.