### PR TITLE
Bugfix: DTED parsing of null values; accommodate numpy 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ release points are not being annotated in GitHub.
 - Improved DTEDInterpolator handling of missing DEMs
 - SIDD 3.0.0 point projection
 - Restored missing antenna beam footprints in some KMZs
+- DTED parsing for tiles with null values
 
 ## [1.3.58] - 2023-08-07
 ### Added

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,49 +1,47 @@
 Relevance of these unit tests to users:
 =======================================
-There is no configuration of sarpy beyond establishing a python environment with 
-dependencies `numpy>=1.11`, `scipy` (no specific know version required). If you 
-hope to read formats for Cosmo Skymed, KompSat, ICEYE, or NISAR, then you also 
-need package `h5py`. 
+There is no configuration of sarpy beyond establishing a python environment with
+appropriate dependencies.
 
-**This suite of unit tests are really only relevant to developers adding or modifying 
+**This suite of unit tests are really only relevant to developers adding or modifying
 core capabilities of sarpy.** Users can otherwise safely ignore these tests.
 
 
 Unit Test Approach and Configuration:
 =====================================
-The traditional unit test approach aims for small capability checks which are ideally 
-self-contained tests with no dependencies on anything external to the test itself. 
-If a test does have any dependencies, it is ideal that any dependency is distributed 
+The traditional unit test approach aims for small capability checks which are ideally
+self-contained tests with no dependencies on anything external to the test itself.
+If a test does have any dependencies, it is ideal that any dependency is distributed
 with the test itself (i.e. in the same git repository).
 
-The most important sarpy capabilities are centered around reading complex imagery 
-in a wide variety of different formats. Any tests for the most important capabilities 
-of sarpy inherently depend on files and packages in a variety of formats. For a variety 
-of reasons, this means that effective tests depend on files much too large to be 
-feasible distributed with git, and some files cannot be freely distributed. 
+The most important sarpy capabilities are centered around reading complex imagery
+in a wide variety of different formats. Any tests for the most important capabilities
+of sarpy inherently depend on files and packages in a variety of formats. For a variety
+of reasons, this means that effective tests depend on files much too large to be
+feasible distributed with git, and some files cannot be freely distributed.
 
-A comprehensive suite of test files will be available to developers with an 
-appropriate relationship with NGA. Many developers may only be interested in 
-testing reading capability for a single format, and could easily identify their 
+A comprehensive suite of test files will be available to developers with an
+appropriate relationship with NGA. Many developers may only be interested in
+testing reading capability for a single format, and could easily identify their
 own collection of test files.
 
 File Identification:
 --------------------
-Files used for individual tests will be identified is a json structure referenced 
-in a given unit test. Tests referencing paths that don't exist will not be performed, 
-so you only need to assemble or reference files that you care to test. 
+Files used for individual tests will be identified is a json structure referenced
+in a given unit test. Tests referencing paths that don't exist will not be performed,
+so you only need to assemble or reference files that you care to test.
 
 There are two cases for paths provided for these tests:
-1. The path is identified as absolute (the default). User path lengthening will be 
-   performed, so the path `'~/'` will evaluate to your home directory. 
-2. The path is identified as relative, all such paths will be assumed relative to 
-   the same parent, and environment variable `SARPY_TEST_PATH` must be defined as 
-   this **absolute** parent path. If this environment variable is not set, then an 
+1. The path is identified as absolute (the default). User path lengthening will be
+   performed, so the path `'~/'` will evaluate to your home directory.
+2. The path is identified as relative, all such paths will be assumed relative to
+   the same parent, and environment variable `SARPY_TEST_PATH` must be defined as
+   this **absolute** parent path. If this environment variable is not set, then an
    error will result.
 
 Run the Tests:
 --------------
-Unit tests can be run using the command `python setup.py test` or `pytest`, if 
+Unit tests can be run using the command `python setup.py test` or `pytest`, if
 using pytest.
 
 Testing across multiple environments
@@ -92,6 +90,9 @@ Non-SAR data:
             + https://sourceforge.net/projects/geographiclib/files/geoids-distrib/egm2008-5.tar.bz2
             + https://sourceforge.net/projects/geographiclib/files/geoids-distrib/egm2008-5.zip
 
+- DTED:
+    - Shuttle Radar Topography Mission (SRTM) data from https://earthexplorer.usgs.gov
+
 Publicly available complex valued SAR example data in various formats:
 ----------------------------------------------------------------------
 - SICD (a NITF file following particular rules):
@@ -121,10 +122,10 @@ Publicly available complex valued SAR example data in various formats:
     + Only the SLC (single-look complex) product is presently relevant to sarpy.
 - NISAR
     + https://uavsar.jpl.nasa.gov/cgi-bin/product.pl?jobName=sabine_01200_17088_017_170901_L090_CX_05#data
-    + Simulated NISAR product. 
+    + Simulated NISAR product.
 - CPHD
     + https://rdr.ucl.ac.uk/articles/dataset/T-72_SAR_data_dome_Remote_Sensing_0_25_no_PSF_/20681836
-    + Simulated CPHD files. 
+    + Simulated CPHD files.
 
 Not publicly available complex SAR data:
 ----------------------------------------

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -46,7 +46,7 @@ def parse_file_entry(entry, default='absolute'):
 
     Parameters
     ----------
-    entry : NOne|dict
+    entry : None|dict
         dict of the form {'path': <value>', 'path_type': 'relative' or 'absolute'}
     default : str
         The default value for 'path_type', if it is not provided.

--- a/tests/io/DEM/geoid.json
+++ b/tests/io/DEM/geoid.json
@@ -1,10 +1,15 @@
 {
-  "test_file": {"path":  "dem/geoid/GeoidHeights.dat", "path_type":  "relative"},
+  "test_file": [
+    {"path":  "dem/geoid/GeoidHeights.dat", "path_type":  "relative"}
+  ],
   "geoid_files": [
     {"path":  "dem/geoid/egm96-15.pgm", "path_type":  "relative"},
     {"path":  "dem/geoid/egm96-5.pgm", "path_type":  "relative"},
     {"path":  "dem/geoid/egm2008-5.pgm", "path_type":  "relative"},
     {"path":  "dem/geoid/egm2008-2_5.pgm", "path_type":  "relative"},
     {"path":  "dem/geoid/egm2008-1.pgm", "path_type":  "relative"}
+  ],
+  "dted_with_null": [
+    {"path":  "dem/dted/s04_w061_3arc_v1.dt1", "path_type":  "relative"}
   ]
 }

--- a/tests/io/DEM/test_dted.py
+++ b/tests/io/DEM/test_dted.py
@@ -1,25 +1,37 @@
-import json
-import os
 import pathlib
 
 import pytest
 
-from sarpy.io.DEM.DTED import DTEDInterpolator
+import sarpy.io.DEM.DTED as sarpy_dted
 from sarpy.io.DEM.geoid import GeoidHeight
 
-SRC_FILE_PATH = pathlib.Path(__file__).parent
-sarpy_test_path = os.environ.get("SARPY_TEST_PATH", ".")
-geoid_json_path = SRC_FILE_PATH / "geoid.json"
-
-geoid_file_info = json.loads(geoid_json_path.read_text())
-egm96_file = sarpy_test_path / pathlib.Path(geoid_file_info["geoid_files"][0]["path"])
+import tests
 
 
-@pytest.mark.skipif(not egm96_file.exists(), reason="EGM 96 data does not exist")
+test_data = tests.find_test_data_files(pathlib.Path(__file__).parent / "geoid.json")
+egm96_file = test_data["geoid_files"][0] if test_data["geoid_files"] else None
+
+
+@pytest.mark.skipif(egm96_file is None, reason="EGM 96 data does not exist")
 def test_interpolator_no_readers():
     llb = [10.0, 20.0, 10.5, 20.5]
     geoid = GeoidHeight(egm96_file)
-    dtedinterp = DTEDInterpolator([], geoid_file=geoid, lat_lon_box=llb)
+    dtedinterp = sarpy_dted.DTEDInterpolator([], geoid_file=geoid, lat_lon_box=llb)
 
     assert dtedinterp.get_max_geoid(llb) == 0
     assert dtedinterp.get_max_hae(llb) == geoid(10, 10.5)
+
+
+@pytest.mark.skipif(not test_data["dted_with_null"], reason="DTED with null data does not exist")
+def test_dted_reader():
+    dted_reader = sarpy_dted.DTEDReader(test_data["dted_with_null"][0])
+
+    # From entity ID: SRTM3S04W061V1, date updated: 2013-04-17T12:16:47-05
+    # Acquired from https://earthexplorer.usgs.gov/ on 2024-08-21
+    known_values = {
+        (1000, 800): -32767,  # null
+        (1000, 799): 7,
+        (3, 841): -5,
+    }
+    for index, expected_value in known_values.items():
+        assert dted_reader[index] == expected_value

--- a/tests/io/DEM/test_geoid.py
+++ b/tests/io/DEM/test_geoid.py
@@ -1,26 +1,18 @@
-import time
-import os
 import logging
-import numpy
-import json
+import os
+import pathlib
+import time
 import unittest
 
+import numpy
+
 import sarpy.io.DEM.geoid as geoid
-from tests import parse_file_entry
+import tests
 
 
-test_file = None
-geoid_files = []
-this_loc = os.path.abspath(__file__)
-file_reference = os.path.join(os.path.split(this_loc)[0], 'geoid.json')  # specifies file locations
-if os.path.isfile(file_reference):
-    with open(file_reference, 'r') as fi:
-        the_files = json.load(fi)
-        test_file = parse_file_entry(the_files.get('test_file', None))
-        for entry in the_files.get('geoid_files', []):
-            the_file = parse_file_entry(entry)
-            if the_file is not None:
-                geoid_files.append(the_file)
+test_data = tests.find_test_data_files(pathlib.Path(__file__).parent / "geoid.json")
+test_file = test_data["test_file"][0] if test_data["test_file"] else None
+geoid_files = test_data["geoid_files"]
 
 
 def generic_geoid_test(instance, test_file, geoid_file):


### PR DESCRIPTION
# Description
While investigating a reported issue with SARPy's DTED reading and numpy 2.0, we found that the DTED parsing was incorrect, most notably for null values. From MIL-PRF-89020B:

![image](https://github.com/user-attachments/assets/11563b4a-30cf-4498-b5a0-2118d58f1fda)

![image](https://github.com/user-attachments/assets/f5c335c6-210f-4a1d-b0bf-66ddaed5cb08)


The current logic:
- returns a values of -1 for nulls in numpy<2.0
- raises an `OverflowError` using NumPy 2.0 due to changes in [data type promotion](https://numpy.org/doc/stable/numpy_2_0_migration_guide.html#changes-to-numpy-data-type-promotion)

<details><summary>example failures running current code with new test</summary>

```
SARPY_TEST_PATH=/data/sarpy_test/ nox -- tests/io/DEM/test_dted.py::test_dted_reader
nox > Running session test(version='3.6')
nox > Creating conda env in .nox/test-version-3-6 with python
nox > conda install --yes --prefix /home/vscuser/git/glweb/software/third-party/sarpy/.nox/test-version-3-6 python=3.6
nox > python -m pip install '.[all]'
nox > pytest tests/io/DEM/test_dted.py::test_dted_reader
=========================================================================== test session starts ============================================================================
platform linux -- Python 3.6.13, pytest-7.0.1, pluggy-1.0.0
rootdir: /home/vscuser/git/glweb/software/third-party/sarpy
collected 1 item                                                                                                                                                           

tests/io/DEM/test_dted.py F                                                                                                                                          [100%]

================================================================================= FAILURES =================================================================================
_____________________________________________________________________________ test_dted_reader _____________________________________________________________________________

    @pytest.mark.skipif(not test_data["dted_with_null"], reason="DTED with null data does not exist")
    def test_dted_reader():
        dted_reader = sarpy_dted.DTEDReader(test_data["dted_with_null"][0])
    
        # From entity ID: SRTM3S04W061V1, date updated: 2013-04-17T12:16:47-05
        # Acquired from https://earthexplorer.usgs.gov/ on 2024-08-21
        known_values = {
            (1000, 800): -32767,  # null
            (1000, 799): 7,
            (3, 841): -5,
        }
        for index, expected_value in known_values.items():
>           assert dted_reader[index] == expected_value
E           assert array(-1, dtype=int16) == -32767

tests/io/DEM/test_dted.py:37: AssertionError
========================================================================= short test summary info ==========================================================================
FAILED tests/io/DEM/test_dted.py::test_dted_reader - assert array(-1, dtype=int16) == -32767
============================================================================ 1 failed in 0.21s =============================================================================
nox > Command pytest tests/io/DEM/test_dted.py::test_dted_reader failed with exit code 1
nox > Session test(version='3.6') failed.
nox > Running session test(version='3.11')
nox > Creating conda env in .nox/test-version-3-11 with python
nox > conda install --yes --prefix /home/vscuser/git/glweb/software/third-party/sarpy/.nox/test-version-3-11 python=3.11
nox > python -m pip install '.[all]'
nox > pytest tests/io/DEM/test_dted.py::test_dted_reader
=========================================================================== test session starts ============================================================================
platform linux -- Python 3.11.9, pytest-8.3.2, pluggy-1.5.0
rootdir: /home/vscuser/git/glweb/software/third-party/sarpy
collected 1 item                                                                                                                                                           

tests/io/DEM/test_dted.py F                                                                                                                                          [100%]

================================================================================= FAILURES =================================================================================
_____________________________________________________________________________ test_dted_reader _____________________________________________________________________________

    @pytest.mark.skipif(not test_data["dted_with_null"], reason="DTED with null data does not exist")
    def test_dted_reader():
        dted_reader = sarpy_dted.DTEDReader(test_data["dted_with_null"][0])
    
        # From entity ID: SRTM3S04W061V1, date updated: 2013-04-17T12:16:47-05
        # Acquired from https://earthexplorer.usgs.gov/ on 2024-08-21
        known_values = {
            (1000, 800): -32767,  # null
            (1000, 799): 7,
            (3, 841): -5,
        }
        for index, expected_value in known_values.items():
>           assert dted_reader[index] == expected_value

tests/io/DEM/test_dted.py:37: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
sarpy/io/DEM/DTED.py:351: in __getitem__
    return self._repair_values(data)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

elevations = array(-1, dtype=int16)

    @staticmethod
    def _repair_values(elevations):
        """
        This is a helper method for repairing the weird entries in a DTED.
        The array is modified in place.
    
        Parameters
        ----------
        elevations : numpy.ndarray
    
        Returns
        -------
        numpy.ndarray
        """
    
        elevations = numpy.copy(elevations)
        # BASED ON MIL-PRF-89020B SECTION 3.11.1, 3.11.2
        # There are some byte-swapping details that are poorly explained.
        # The following steps appear to correct for the "complemented" values.
        # Find negative voids and repair them
        neg_voids = (elevations < -15000)
>       elevations[neg_voids] = numpy.abs(elevations[neg_voids]) - 32768
E       OverflowError: Python integer 32768 out of bounds for int16

sarpy/io/DEM/DTED.py:374: OverflowError
========================================================================= short test summary info ==========================================================================
FAILED tests/io/DEM/test_dted.py::test_dted_reader - OverflowError: Python integer 32768 out of bounds for int16
============================================================================ 1 failed in 0.20s =============================================================================
nox > Command pytest tests/io/DEM/test_dted.py::test_dted_reader failed with exit code 1
nox > Session test(version='3.11') failed.
nox > Ran multiple sessions:
nox > * test(version='3.6'): failed
nox > * test(version='3.11'): failed

```

</details>

# Notes
- testing required the addition of a DTED file to `tests/io/DEM/geoid.json`
  - the existing JSON structure was not parseable by `tests.find_test_data_files`, so I updated it and changed places where it was being used
- minor copy-editing of `tests/README.md` while I was adding a note about the DTED source

# Test Results

<details><summary>tests pass</summary>

```
SARPY_TEST_PATH=/data/sarpy_test/ nox
nox > Running session test(version='3.6')
nox > Creating conda env in .nox/test-version-3-6 with python
nox > conda install --yes --prefix /home/vscuser/git/glweb/software/third-party/sarpy/.nox/test-version-3-6 python=3.6
nox > python -m pip install '.[all]'
nox > pytest tests
=========================================================================== test session starts ============================================================================
platform linux -- Python 3.6.13, pytest-7.0.1, pluggy-1.0.0
rootdir: /home/vscuser/git/glweb/software/third-party/sarpy
collected 563 items                                                                                                                                                        

tests/test_class_string.py .                                                                                                                                         [  0%]
tests/consistency/test_consistency.py ........                                                                                                                       [  1%]
tests/consistency/test_cphd_consistency.py ..............................................................                                                            [ 12%]
tests/consistency/test_sicd_consistency.py ...                                                                                                                       [ 13%]
tests/consistency/test_sidd_consistency.py ....                                                                                                                      [ 13%]
tests/geometry/test_geocoords.py ..........                                                                                                                          [ 15%]
tests/geometry/test_geometry_elements.py ..........                                                                                                                  [ 17%]
tests/geometry/test_latlon.py ...                                                                                                                                    [ 17%]
tests/geometry/test_point_projection.py ..............                                                                                                               [ 20%]
tests/io/test_kml.py .                                                                                                                                               [ 20%]
tests/io/DEM/test_dted.py ..                                                                                                                                         [ 20%]
tests/io/DEM/test_geoid.py .                                                                                                                                         [ 21%]
tests/io/DEM/test_geotiff1deg_list.py ....                                                                                                                           [ 21%]
tests/io/DEM/test_geotiff1deg_reader.py ........                                                                                                                     [ 23%]
tests/io/complex/test_other_nitf.py ...                                                                                                                              [ 23%]
tests/io/complex/test_reader.py ..sss.ssss.                                                                                                                          [ 25%]
tests/io/complex/test_remote.py s                                                                                                                                    [ 25%]
tests/io/complex/test_sicd.py .                                                                                                                                      [ 26%]
tests/io/complex/test_utils.py .                                                                                                                                     [ 26%]
tests/io/complex/sicd_elements/test_sicd_elements_antenna.py ...                                                                                                     [ 26%]
tests/io/complex/sicd_elements/test_sicd_elements_base.py ...                                                                                                        [ 27%]
tests/io/complex/sicd_elements/test_sicd_elements_blocks.py .....................                                                                                    [ 31%]
tests/io/complex/sicd_elements/test_sicd_elements_collectioninfo.py ..                                                                                               [ 31%]
tests/io/complex/sicd_elements/test_sicd_elements_errorstatistics.py .                                                                                               [ 31%]
tests/io/complex/sicd_elements/test_sicd_elements_geodata.py ...                                                                                                     [ 32%]
tests/io/complex/sicd_elements/test_sicd_elements_grid.py ..                                                                                                         [ 32%]
tests/io/complex/sicd_elements/test_sicd_elements_imagecreation.py .                                                                                                 [ 32%]
tests/io/complex/sicd_elements/test_sicd_elements_imagedata.py .                                                                                                     [ 32%]
tests/io/complex/sicd_elements/test_sicd_elements_imageformation.py ......                                                                                           [ 33%]
tests/io/complex/sicd_elements/test_sicd_elements_matchinfo.py .                                                                                                     [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_pfa.py .                                                                                                           [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_position.py ...                                                                                                    [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_radarcollection.py ..............                                                                                  [ 37%]
tests/io/complex/sicd_elements/test_sicd_elements_radiometric.py .                                                                                                   [ 37%]
tests/io/complex/sicd_elements/test_sicd_elements_rgazcomp.py .                                                                                                      [ 37%]
tests/io/complex/sicd_elements/test_sicd_elements_rma.py ...                                                                                                         [ 38%]
tests/io/complex/sicd_elements/test_sicd_elements_scpcoa.py ...................                                                                                      [ 41%]
tests/io/complex/sicd_elements/test_sicd_elements_sicd.py ..................................                                                                         [ 47%]
tests/io/complex/sicd_elements/test_sicd_elements_timeline.py ..................                                                                                     [ 50%]
tests/io/complex/sicd_elements/test_sicd_elements_utils.py ...                                                                                                       [ 51%]
tests/io/general/test_base.py ...                                                                                                                                    [ 51%]
tests/io/general/test_data_segment.py ..........                                                                                                                     [ 53%]
tests/io/general/test_format_function.py ........                                                                                                                    [ 55%]
tests/io/general/test_nitf.py ..                                                                                                                                     [ 55%]
tests/io/general/test_nitf_headers.py .                                                                                                                              [ 55%]
tests/io/general/test_nitf_image.py ....                                                                                                                             [ 56%]
tests/io/general/test_tre.py ...                                                                                                                                     [ 56%]
tests/io/phase_history/test_cphd.py .......                                                                                                                          [ 58%]
tests/io/phase_history/test_cphd_versions.py .....                                                                                                                   [ 58%]
tests/io/phase_history/cphd1_elements/test_cphd.py ......                                                                                                            [ 60%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_antenna.py .....                                                                                           [ 60%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_blocks.py ....                                                                                             [ 61%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_channel.py .                                                                                               [ 61%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_data.py .                                                                                                  [ 61%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_dwell.py .                                                                                                 [ 62%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_geoinfo.py ...                                                                                             [ 62%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_global.py ..                                                                                               [ 63%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_pvp.py .                                                                                                   [ 63%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_referencegeometry.py .                                                                                     [ 63%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_supportarray.py ..                                                                                         [ 63%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_txrcv.py .                                                                                                 [ 63%]
tests/io/phase_history/cphd1_elements/test_utils.py .                                                                                                                [ 64%]
tests/io/product/test_reader.py ...s                                                                                                                                 [ 64%]
tests/io/product/test_sidd.py ...                                                                                                                                    [ 65%]
tests/io/product/test_sidd_schema.py .........                                                                                                                       [ 66%]
tests/io/product/test_sidd_writing.py ..                                                                                                                             [ 67%]
tests/io/product/sidd3_elements/test_exploitationfeatures.py ....................................................................................................... [ 85%]
...........................                                                                                                                                          [ 90%]
tests/io/product/sidd3_elements/test_sidd3_elements.py .....                                                                                                         [ 91%]
tests/io/received/test_crsd.py .                                                                                                                                     [ 91%]
tests/processing/sicd/test_spectral_taper.py ........ss...........                                                                                                   [ 95%]
tests/utils/test_sicd_sidelobe_control.py ..                                                                                                                         [ 95%]
tests/visualization/test_cphd_kmz_product_creation.py ..                                                                                                             [ 95%]
tests/visualization/test_crsd_kmz_product_creation.py .                                                                                                              [ 96%]
tests/visualization/test_kmz_product_creation.py .x                                                                                                                  [ 96%]
tests/visualization/test_remap.py ....................                                                                                                               [100%]

============================================================================= warnings summary =============================================================================
tests/geometry/test_point_projection.py::test_image_to_ground_errors
tests/geometry/test_point_projection.py::test_image_to_ground_dem
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/geometry/point_projection.py:1882: RuntimeWarning: divide by zero encountered in double_scalars
    lon_grid_size = min(10, lat_grid_size/abs(numpy.sin(numpy.deg2rad(ref_llh[0]))))

tests/visualization/test_kmz_product_creation.py::test_create_kmz[True]
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/visualization/kmz_utils.py:169: RuntimeWarning: invalid value encountered in double_scalars
    + dir_z**2 * semiaxis_a**2 * semiaxis_b**2

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================= 551 passed, 11 skipped, 1 xfailed, 3 warnings in 48.31s ==========================================================
nox > Session test(version='3.6') was successful.
nox > Running session test(version='3.11')
nox > Creating conda env in .nox/test-version-3-11 with python
nox > conda install --yes --prefix /home/vscuser/git/glweb/software/third-party/sarpy/.nox/test-version-3-11 python=3.11
nox > python -m pip install '.[all]'
nox > pytest tests
=========================================================================== test session starts ============================================================================
platform linux -- Python 3.11.9, pytest-8.3.2, pluggy-1.5.0
rootdir: /home/vscuser/git/glweb/software/third-party/sarpy
collected 563 items                                                                                                                                                        

tests/consistency/test_consistency.py ........                                                                                                                       [  1%]
tests/consistency/test_cphd_consistency.py ..............................................................                                                            [ 12%]
tests/consistency/test_sicd_consistency.py ...                                                                                                                       [ 12%]
tests/consistency/test_sidd_consistency.py ....                                                                                                                      [ 13%]
tests/geometry/test_geocoords.py ..........                                                                                                                          [ 15%]
tests/geometry/test_geometry_elements.py ..........                                                                                                                  [ 17%]
tests/geometry/test_latlon.py ...                                                                                                                                    [ 17%]
tests/geometry/test_point_projection.py ..............                                                                                                               [ 20%]
tests/io/DEM/test_dted.py ..                                                                                                                                         [ 20%]
tests/io/DEM/test_geoid.py .                                                                                                                                         [ 20%]
tests/io/DEM/test_geotiff1deg_list.py ....                                                                                                                           [ 21%]
tests/io/DEM/test_geotiff1deg_reader.py ........                                                                                                                     [ 22%]
tests/io/complex/sicd_elements/test_sicd_elements_antenna.py ...                                                                                                     [ 23%]
tests/io/complex/sicd_elements/test_sicd_elements_base.py ...                                                                                                        [ 23%]
tests/io/complex/sicd_elements/test_sicd_elements_blocks.py .....................                                                                                    [ 27%]
tests/io/complex/sicd_elements/test_sicd_elements_collectioninfo.py ..                                                                                               [ 28%]
tests/io/complex/sicd_elements/test_sicd_elements_errorstatistics.py .                                                                                               [ 28%]
tests/io/complex/sicd_elements/test_sicd_elements_geodata.py ...                                                                                                     [ 28%]
tests/io/complex/sicd_elements/test_sicd_elements_grid.py ..                                                                                                         [ 29%]
tests/io/complex/sicd_elements/test_sicd_elements_imagecreation.py .                                                                                                 [ 29%]
tests/io/complex/sicd_elements/test_sicd_elements_imagedata.py .                                                                                                     [ 29%]
tests/io/complex/sicd_elements/test_sicd_elements_imageformation.py ......                                                                                           [ 30%]
tests/io/complex/sicd_elements/test_sicd_elements_matchinfo.py .                                                                                                     [ 30%]
tests/io/complex/sicd_elements/test_sicd_elements_pfa.py .                                                                                                           [ 30%]
tests/io/complex/sicd_elements/test_sicd_elements_position.py ...                                                                                                    [ 31%]
tests/io/complex/sicd_elements/test_sicd_elements_radarcollection.py ..............                                                                                  [ 33%]
tests/io/complex/sicd_elements/test_sicd_elements_radiometric.py .                                                                                                   [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_rgazcomp.py .                                                                                                      [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_rma.py ...                                                                                                         [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_scpcoa.py ...................                                                                                      [ 38%]
tests/io/complex/sicd_elements/test_sicd_elements_sicd.py ..................................                                                                         [ 44%]
tests/io/complex/sicd_elements/test_sicd_elements_timeline.py ..................                                                                                     [ 47%]
tests/io/complex/sicd_elements/test_sicd_elements_utils.py ...                                                                                                       [ 47%]
tests/io/complex/test_other_nitf.py ...                                                                                                                              [ 48%]
tests/io/complex/test_reader.py ..sss.ssss.                                                                                                                          [ 50%]
tests/io/complex/test_remote.py s                                                                                                                                    [ 50%]
tests/io/complex/test_sicd.py .                                                                                                                                      [ 50%]
tests/io/complex/test_utils.py .                                                                                                                                     [ 50%]
tests/io/general/test_base.py ...                                                                                                                                    [ 51%]
tests/io/general/test_data_segment.py ..........                                                                                                                     [ 53%]
tests/io/general/test_format_function.py ........                                                                                                                    [ 54%]
tests/io/general/test_nitf.py ..                                                                                                                                     [ 55%]
tests/io/general/test_nitf_headers.py .                                                                                                                              [ 55%]
tests/io/general/test_nitf_image.py ....                                                                                                                             [ 55%]
tests/io/general/test_tre.py ...                                                                                                                                     [ 56%]
tests/io/phase_history/cphd1_elements/test_cphd.py ......                                                                                                            [ 57%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_antenna.py .....                                                                                           [ 58%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_blocks.py ....                                                                                             [ 59%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_channel.py .                                                                                               [ 59%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_data.py .                                                                                                  [ 59%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_dwell.py .                                                                                                 [ 59%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_geoinfo.py ...                                                                                             [ 60%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_global.py ..                                                                                               [ 60%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_pvp.py .                                                                                                   [ 60%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_referencegeometry.py .                                                                                     [ 60%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_supportarray.py ..                                                                                         [ 61%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_txrcv.py .                                                                                                 [ 61%]
tests/io/phase_history/cphd1_elements/test_utils.py .                                                                                                                [ 61%]
tests/io/phase_history/test_cphd.py .......                                                                                                                          [ 62%]
tests/io/phase_history/test_cphd_versions.py .....                                                                                                                   [ 63%]
tests/io/product/sidd3_elements/test_exploitationfeatures.py ....................................................................................................... [ 82%]
...........................                                                                                                                                          [ 86%]
tests/io/product/sidd3_elements/test_sidd3_elements.py .....                                                                                                         [ 87%]
tests/io/product/test_reader.py ...s                                                                                                                                 [ 88%]
tests/io/product/test_sidd.py ...                                                                                                                                    [ 88%]
tests/io/product/test_sidd_schema.py .........                                                                                                                       [ 90%]
tests/io/product/test_sidd_writing.py ..                                                                                                                             [ 90%]
tests/io/received/test_crsd.py .                                                                                                                                     [ 91%]
tests/io/test_kml.py .                                                                                                                                               [ 91%]
tests/processing/sicd/test_spectral_taper.py .....................                                                                                                   [ 95%]
tests/test_class_string.py .                                                                                                                                         [ 95%]
tests/utils/test_sicd_sidelobe_control.py ..                                                                                                                         [ 95%]
tests/visualization/test_cphd_kmz_product_creation.py ..                                                                                                             [ 95%]
tests/visualization/test_crsd_kmz_product_creation.py .                                                                                                              [ 96%]
tests/visualization/test_kmz_product_creation.py .x                                                                                                                  [ 96%]
tests/visualization/test_remap.py ....................                                                                                                               [100%]

============================================================================= warnings summary =============================================================================
tests/geometry/test_geometry_elements.py: 77 warnings
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/geometry/geometry_elements.py:131: DeprecationWarning: Arrays of 2-dimensional vectors are deprecated. Use arrays
 of 3-dimensional vectors instead. (deprecated in NumPy 2.0)                                                                                                                    dir_cross = float(numpy.cross(R, S))  # the scalar cross product of the direction vectors

tests/geometry/test_geometry_elements.py: 43 warnings
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/geometry/geometry_elements.py:137: DeprecationWarning: Arrays of 2-dimensional vectors are deprecated. Use arrays
 of 3-dimensional vectors instead. (deprecated in NumPy 2.0)                                                                                                                    end_cross_0 = float(numpy.cross(Q-P, S))

tests/geometry/test_geometry_elements.py: 43 warnings
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/geometry/geometry_elements.py:138: DeprecationWarning: Arrays of 2-dimensional vectors are deprecated. Use arrays
 of 3-dimensional vectors instead. (deprecated in NumPy 2.0)                                                                                                                    end_cross_1 = float(numpy.cross(Q-P, R))

tests/geometry/test_point_projection.py::test_image_to_ground_errors
tests/geometry/test_point_projection.py::test_image_to_ground_dem
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/geometry/point_projection.py:1882: RuntimeWarning: divide by zero encountered in scalar divide
    lon_grid_size = min(10, lat_grid_size/abs(numpy.sin(numpy.deg2rad(ref_llh[0]))))

tests/test_class_string.py::TestClassString::test_class_str
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/annotation/afrl_rde_schema/__init__.py:7: DeprecationWarning: pkg_resources is deprecated as an API. See https://
setuptools.pypa.io/en/latest/pkg_resources.html                                                                                                                                 import pkg_resources

tests/visualization/test_kmz_product_creation.py::test_create_kmz[True]
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/visualization/kmz_utils.py:145: RuntimeWarning: invalid value encountered in scalar divide
    distance = (

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================= 553 passed, 9 skipped, 1 xfailed, 167 warnings in 31.10s =========================================================
nox > Session test(version='3.11') was successful.
nox > Ran multiple sessions:
nox > * test(version='3.6'): success
nox > * test(version='3.11'): success

```

</details>