### PR TITLE
Bugfix: Incorrect SIDD ISM.compliesWith definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ release points are not being annotated in GitHub.
 - SIDD 3.0.0 point projection
 - Restored missing antenna beam footprints in some KMZs
 - DTED parsing for tiles with null values
+- Incorrect SIDD ISM.compliesWith definition
 
 ## [1.3.58] - 2023-08-07
 ### Added

--- a/sarpy/io/product/sidd1_elements/ProductCreation.py
+++ b/sarpy/io/product/sidd1_elements/ProductCreation.py
@@ -49,9 +49,9 @@ class ProductClassificationType(Serializable):
     createDate = StringDescriptor(
         'createDate', _required, strict=DEFAULT_STRICT,
         docstring='This should be a date of format :code:`YYYY-MM-DD`, but this is not checked.')  # type: str
-    compliesWith = StringEnumDescriptor(
-        'compliesWith', ('ICD-710', 'DoD5230.24'), _required, strict=DEFAULT_STRICT, default_value=None,
-        docstring='')  # type: Union[None, str]
+    compliesWith = StringDescriptor(
+        'compliesWith', _required, strict=DEFAULT_STRICT, default_value=None,
+        docstring='The ISM.XML rule sets a document complies with.')  # type: Union[None, str]
     classification = StringEnumDescriptor(
         'classification', ('U', 'C', 'R', 'S', 'TS'), _required, strict=DEFAULT_STRICT,
         docstring='')  # type: str

--- a/sarpy/io/product/sidd2_elements/ProductCreation.py
+++ b/sarpy/io/product/sidd2_elements/ProductCreation.py
@@ -133,10 +133,9 @@ class ProductClassificationType(Serializable):
     createDate = StringDescriptor(
         'createDate', _required, strict=DEFAULT_STRICT,
         docstring='This should be a date of format :code:`YYYY-MM-DD`, but this is not checked.')  # type: str
-    compliesWith = StringEnumDescriptor(
-        'compliesWith', ('USGov', 'USIC', 'USDOD', 'OtherAuthority'), _required,
-        strict=DEFAULT_STRICT, default_value='USGov',
-        docstring='The ISM rule sets with which the document may complies.')  # type: Union[None, str]
+    compliesWith = StringDescriptor(
+        'compliesWith', _required, strict=DEFAULT_STRICT, default_value="USGov",
+        docstring='The ISM.XML rule sets a document complies with.')  # type: Union[None, str]
     ISMCATCESVersion = StringDescriptor(
         'ISMCATCESVersion', _required, strict=DEFAULT_STRICT, default_value='201903',
         docstring='')  # type: Union[None, str]

--- a/tests/io/product/test_sidd.py
+++ b/tests/io/product/test_sidd.py
@@ -3,6 +3,7 @@
 #
 # Licensed under MIT License.  See LICENSE.
 #
+import logging
 import pathlib
 import tempfile
 
@@ -11,6 +12,7 @@ import pytest
 
 import sarpy.io.product
 import sarpy.utils.create_product
+from sarpy.consistency import sidd_consistency
 
 import tests
 
@@ -46,3 +48,46 @@ def test_sidd_projection(sidd_nitf):
         ref_pt_rowcol_proj, _, _ = sidd_obj.project_ground_to_image(ref_pt_ecef)
         assert np.linalg.norm(ref_pt_rowcol - ref_pt_rowcol_proj) == pytest.approx(0, abs=1e-2)
         assert np.linalg.norm(ref_pt_ecef - ref_pt_ecef_proj) == pytest.approx(0, abs=1e-3)
+
+
+def test_product_creation_classification(sidd_nitf, tmp_path, caplog):
+    assert sidd_consistency.check_file(str(sidd_nitf))
+    sidd_reader = sarpy.io.product.open(str(sidd_nitf))
+    this_sidd_meta = sidd_reader.sidd_meta[0]
+    this_ns = this_sidd_meta.get_xmlns_collection()["xmlns"]
+
+    if this_ns == "urn:SIDD:1.0.0":
+        valid_values = (
+            "",
+            "ICD-710",
+            "ICD-710 DoD5230.24",
+        )
+        invalid_values = (
+            "ICD-710 ICD-710 ICD-710",
+            "not_an_enum",
+        )
+    elif this_ns in ("urn:SIDD:2.0.0", "urn:SIDD:3.0.0"):
+        valid_values = (
+            "",
+            " ".join(["USIC"] * 4),
+            "USGov",
+            "OtherAuthority USDOD USIC USGov",
+        )
+        invalid_values = (
+            " ".join(["USIC"] * 5),
+            "not_an_enum",
+        )
+
+    tmp_xml = tmp_path / "sidd.xml"
+    for value in valid_values:
+        caplog.clear()
+        with caplog.at_level(logging.WARNING):
+            this_sidd_meta.ProductCreation.Classification.compliesWith = value
+            assert not caplog.messages  # does not log problem when setting to valid value
+        tmp_xml.write_text(this_sidd_meta.to_xml_string())
+        assert sidd_consistency.check_file(str(tmp_xml))
+
+    for value in invalid_values:
+        this_sidd_meta.ProductCreation.Classification.compliesWith = value
+        tmp_xml.write_text(this_sidd_meta.to_xml_string())
+        assert not sidd_consistency.check_file(str(tmp_xml))


### PR DESCRIPTION
# Description
Someone reported that SARPy's handling of SIDD's ISM compliesWith attribute is currently incorrect. SARPy is treating the attribute as a scalar enum, when the various SIDD schemas in SARPy all have it as an `xsd:list`:

- [SIDD 1.0.0](https://github.com/ngageoint/sarpy/blob/master/sarpy/io/product/sidd_schema/version1/external/ISM/Schema/CVEGenerated/CVEnumISMCompliesWith.xsd#L39)
- [SIDD 2.0.0](https://github.com/ngageoint/sarpy/blob/master/sarpy/io/product/sidd_schema/version2/external/ISM-v13/Schema/ISM/CVEGenerated/CVEnumISMCompliesWith.xsd#L63)
- [SIDD 3.0.0](https://github.com/ngageoint/sarpy/blob/master/sarpy/io/product/sidd_schema/version3/external/ISM-v13/Schema/ISM/CVEGenerated/CVEnumISMCompliesWith.xsd#L63)    (same as 2.0.0)

The issue can be demonstrated by running the new test in `integration/1.3.59-rc`:

```
SARPY_TEST_PATH=/data/sarpy_test/ pytest tests/io/product/test_sidd.py::test_product_creation_classification
============================================================================================================================================================================== test session starts ==============================================================================================================================================================================
platform linux -- Python 3.10.14, pytest-7.4.4, pluggy-1.0.0
rootdir: /home/vscuser/git/glweb/software/third-party/sarpy
plugins: anyio-4.2.0, cov-4.1.0
collected 3 items                                                                                                                                                                                                                                                                                                                                                               

tests/io/product/test_sidd.py FFF                                                                                                                                                                                                                                                                                                                                         [100%]

============================================================================================================================================================================ short test summary info ============================================================================================================================================================================
FAILED tests/io/product/test_sidd.py::test_product_creation_classification[1] - assert not ["Attribute compliesWith of class ProductClassificationType received ,\n\tbut values ARE REQUIRED to be one of ('ICD-710', 'DoD5230.24')"]
FAILED tests/io/product/test_sidd.py::test_product_creation_classification[2] - assert not ["Attribute compliesWith of class ProductClassificationType received ,\n\tbut values ARE REQUIRED to be one of ('USGov', 'USIC', 'USDOD', 'OtherAuthority')"]
FAILED tests/io/product/test_sidd.py::test_product_creation_classification[3] - assert not ["Attribute compliesWith of class ProductClassificationType received ,\n\tbut values ARE REQUIRED to be one of ('USGov', 'USIC', 'USDOD', 'OtherAuthority')"]
=============================================================================================================================================================================== 3 failed in 2.44s ===============================================================================================================================================================================
```

# What is the fix?
Instead of `StringEnumDescriptor`, encode as `StringDescriptor`, as is done for all of the other ISM lists already:

```shell
$ grep -rIin --colour "xsd:list" sarpy/io/product/sidd_schema/version1/
sarpy/io/product/sidd_schema/version1/external/ISM/Schema/CVEGenerated/CVEnumISMCompliesWith.xsd:39:            <xsd:list itemType="CVEnumISMCompliesWithValues"/>
sarpy/io/product/sidd_schema/version1/external/ISM/Schema/CVEGenerated/CVEnumISMDissem.xsd:127:            <xsd:list itemType="CVEnumISMDissemValues"/>
sarpy/io/product/sidd_schema/version1/external/ISM/Schema/CVEGenerated/CVEnumISMFGIOpen.xsd:1380:            <xsd:list itemType="CVEnumISMFGIOpenValues"/>
sarpy/io/product/sidd_schema/version1/external/ISM/Schema/CVEGenerated/CVEnumISMFGIProtected.xsd:1380:            <xsd:list itemType="CVEnumISMFGIProtectedValues"/>
sarpy/io/product/sidd_schema/version1/external/ISM/Schema/CVEGenerated/CVEnumISMNonIC.xsd:74:            <xsd:list itemType="CVEnumISMNonICValues"/>
sarpy/io/product/sidd_schema/version1/external/ISM/Schema/CVEGenerated/CVEnumISMNonUSControls.xsd:44:            <xsd:list itemType="CVEnumISMNonUSControlsValues"/>
sarpy/io/product/sidd_schema/version1/external/ISM/Schema/CVEGenerated/CVEnumISMNotice.xsd:99:            <xsd:list itemType="CVEnumISMNoticeValues"/>
sarpy/io/product/sidd_schema/version1/external/ISM/Schema/CVEGenerated/CVEnumISMOwnerProducer.xsd:1385:            <xsd:list itemType="CVEnumISMOwnerProducerValues"/>
sarpy/io/product/sidd_schema/version1/external/ISM/Schema/CVEGenerated/CVEnumISMRelTo.xsd:1380:            <xsd:list itemType="CVEnumISMRelToValues"/>
sarpy/io/product/sidd_schema/version1/external/ISM/Schema/CVEGenerated/CVEnumISMSAR.xsd:41:            <xsd:list itemType="CVEnumISMSARValues"/>
sarpy/io/product/sidd_schema/version1/external/ISM/Schema/CVEGenerated/CVEnumISMSCIControls.xsd:72:            <xsd:list itemType="CVEnumISMSCIControlsValues"/>
```

I also added/changed the description to correct for grammar using a description from the ISM documentation:

![image](https://github.com/user-attachments/assets/e7244252-5c76-475d-b2bc-8ea5fc9ab753)
