### PR TITLE
Fix tests for windows

### DIFF
--- a/sarpy/io/general/nitf.py
+++ b/sarpy/io/general/nitf.py
@@ -1227,7 +1227,7 @@ class NITFDetails(object):
                 self.parse_res_subheader(i).to_json() for i in range(self.res_subheader_offsets.size)]
         return out
 
-    def __del__(self):
+    def close(self):
         if self._close_after:
             self._close_after = False
             # noinspection PyBroadException
@@ -1235,6 +1235,9 @@ class NITFDetails(object):
                 self._file_object.close()
             except Exception:
                 pass
+
+    def __del__(self):
+        self.close()
 
 
 class NITFReader(BaseReader):
@@ -2445,6 +2448,7 @@ class NITFReader(BaseReader):
         return out
 
     def close(self) -> None:
+        self._nitf_details.close()
         self._image_segment_data_segments = None
         BaseReader.close(self)
 

--- a/tests/io/complex/test_sicd.py
+++ b/tests/io/complex/test_sicd.py
@@ -57,8 +57,8 @@ class TestSICDWriting(unittest.TestCase):
                 with tempfile.TemporaryDirectory() as tmpdirname:
                     conversion_utility(reader, tmpdirname)
                     new_filename = os.path.join(tmpdirname, os.listdir(tmpdirname)[0])
-                    reader2 = SICDReader(new_filename)
-                    self.assertEqual(os.stat(new_filename).st_size, reader2.nitf_details.nitf_header.FL)
+                    with SICDReader(new_filename) as reader2:
+                        self.assertEqual(os.stat(new_filename).st_size, reader2.nitf_details.nitf_header.FL)
 
             with self.subTest(msg='Test writing a single row of the sicd file {}'.format(fil)):
                 with tempfile.TemporaryDirectory() as tmpdirname:

--- a/tests/io/general/test_nitf.py
+++ b/tests/io/general/test_nitf.py
@@ -19,25 +19,25 @@ def test_iq_band_interleaved_by_block(tests_path, tmp_path):
         assert data_raw.size == data.size * 2
         assert np.iscomplexobj(data)
 
-    data_offset = reader.nitf_details.img_segment_offsets[0]
-    manual_bytes = in_nitf.read_bytes()[data_offset : data_offset + data.nbytes]
-    manual_data_raw = np.frombuffer(manual_bytes, dtype=data_raw.dtype).reshape(
-        data_raw.shape
-    )
-    manual_data = manual_data_raw[0] + 1j * manual_data_raw[1]  # interleaved by block
-    assert np.array_equal(data, manual_data)
+        data_offset = reader.nitf_details.img_segment_offsets[0]
+        manual_bytes = in_nitf.read_bytes()[data_offset : data_offset + data.nbytes]
+        manual_data_raw = np.frombuffer(manual_bytes, dtype=data_raw.dtype).reshape(
+            data_raw.shape
+        )
+        manual_data = manual_data_raw[0] + 1j * manual_data_raw[1]  # interleaved by block
+        assert np.array_equal(data, manual_data)
 
-    out_nitf = tmp_path / "out.nitf"
-    writer_details = sarpy.io.general.nitf.NITFWritingDetails(
-        reader.nitf_details.nitf_header,
-        (sarpy.io.general.nitf.ImageSubheaderManager(reader.get_image_header(0)),),
-        reader.image_segment_collections,
-    )
-    with sarpy.io.general.nitf.NITFWriter(
-        str(out_nitf), writing_details=writer_details
-    ) as writer:
-        writer.write(data)
-    assert filecmp.cmp(in_nitf, out_nitf, shallow=False)
+        out_nitf = tmp_path / "out.nitf"
+        writer_details = sarpy.io.general.nitf.NITFWritingDetails(
+            reader.nitf_details.nitf_header,
+            (sarpy.io.general.nitf.ImageSubheaderManager(reader.get_image_header(0)),),
+            reader.image_segment_collections,
+        )
+        with sarpy.io.general.nitf.NITFWriter(
+            str(out_nitf), writing_details=writer_details
+        ) as writer:
+            writer.write(data)
+        assert filecmp.cmp(in_nitf, out_nitf, shallow=False)
 
 
 def test_write_filehandle(tests_path, tmp_path):

--- a/tests/io/phase_history/cphd1_elements/test_cphd1_elements_pvp.py
+++ b/tests/io/phase_history/cphd1_elements/test_cphd1_elements_pvp.py
@@ -3,6 +3,8 @@
 #
 # Licensed under MIT License.  See LICENSE.
 #
+import numpy as np
+
 from sarpy.io.phase_history.cphd1_elements import PVP
 
 
@@ -59,7 +61,7 @@ def test_pvp_pvptype():
     pvp_type.TxAntenna = None
     assert pvp_type.get_offset_size_format('TxACX') is None
 
-    assert pvp_type.get_offset_size_format('userpvp') == (392, 8, 'l')
+    assert pvp_type.get_offset_size_format('userpvp') == (392, 8, np.dtype('>i8').char)
     assert pvp_type.get_offset_size_format('NOTuserpvp') is None
     pvp_type.AddedPVP = None
     assert pvp_type.get_offset_size_format('userpvp') is None


### PR DESCRIPTION
A couple tests failed on Windows.

* `numpy.dtype.char` can return different values for different platforms
* `NITFReader` has a reference to a `NITFDetails` which contains a reference to the file, which _may_ have been opened in the `__init__`.  This open file causes problems in the unit tests because they delete the file before the file object is deleted.
