### PR TITLE
Bugfix: SIO reading/writing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ release points are not being annotated in GitHub.
 - DTED parsing for tiles with null values
 - Improved mapping of SICD -> SIDD polarizations
 - Incorrect SIDD ISM.compliesWith definition
+- SIO reading/writing
 
 ## [1.3.58] - 2023-08-07
 ### Added

--- a/sarpy/io/complex/sicd_elements/SICD.py
+++ b/sarpy/io/complex/sicd_elements/SICD.py
@@ -312,7 +312,10 @@ class SICDType(Serializable):
         """
 
         if self.GeoData is None:
-            self.GeoData = GeoDataType(SCP=SCPType(self.RadarCollection.Area.Plane.RefPt.ECF))
+            try:
+                self.GeoData = GeoDataType(SCP=SCPType(self.RadarCollection.Area.Plane.RefPt.ECF))
+            except AttributeError:
+                return
 
         if self.GeoData.ImageCorners is not None and not override:
             return  # nothing to be done

--- a/tests/io/complex/test_sio.py
+++ b/tests/io/complex/test_sio.py
@@ -1,0 +1,32 @@
+import numpy as np
+
+import sarpy.io.complex.sio as sarpy_sio
+from sarpy.io.complex.sicd_elements.blocks import RowColType
+from sarpy.io.complex.sicd_elements.SICD import SICDType
+from sarpy.io.complex.sicd_elements.ImageData import ImageDataType, FullImageType
+
+
+def test_sio_io(tmp_path):
+    original_data = np.arange(13*17*2, dtype=np.float32).reshape((13, 17, 2)).view(np.complex64).squeeze()
+    sicd_meta = SICDType(
+            ImageData=ImageDataType(
+                NumRows=original_data.shape[0],
+                NumCols=original_data.shape[1],
+                PixelType="RE32F_IM32F",
+                FirstRow=0,
+                FirstCol=0,
+                FullImage=FullImageType(
+                    NumRows=original_data.shape[0],
+                    NumCols=original_data.shape[1]
+                ),
+                SCPPixel=RowColType(Row=original_data.shape[0] // 2, Col=original_data.shape[1] // 2)
+            ),
+    )
+
+    output_file = tmp_path / "test.sio"
+    with sarpy_sio.SIOWriter(str(output_file), sicd_meta, check_existence=False) as sio_writer:
+        sio_writer.write(original_data)
+
+    with sarpy_sio.SIOReader(str(output_file)) as sio_reader:
+        read_data = sio_reader[...]
+        assert np.array_equal(original_data, read_data)


### PR DESCRIPTION
# Description
While investigating #517 and adding a SIO read/write unittest, we found a handful of bugs. Absent a canonical document, we used the [sio implementation in the MATLAB_SAR toolbox](https://github.com/ngageoint/MATLAB_SAR/tree/master/IO/complex/sio) to guide the bugfixes.

Notes:
- `SIODetails` interpretation of magic number was incorrect
- `SIOReader` did not account for the uint32 following the header that indicates how many userdata name-value pairs there are
- `SIOWriter` was trying to write magnitude-phase instead of IQ
- `SIOWriter` was not inserting the uint32 following the header that indicates how many userdata name-value pairs there are
- `SIOWriter` incorrectly using SARPY's `NumpyMemmapSegment`
- `define_geo_image_corners` used in `SICD.derive` did not handle the case when the `RadarCollection` is missing

# Test Plan

With the fixes, the new unittest passes

<details><summary>test results</summary>

```
SARPY_TEST_PATH=/data/sarpy_test/ nox
nox > Running session test(version='3.6')
nox > Creating conda env in .nox/test-version-3-6 with python
nox > conda install --yes --prefix /home/vscuser/git/glweb/software/third-party/sarpy/.nox/test-version-3-6 python=3.6
nox > python -m pip install '.[all]'
nox > pytest tests
=========================================================================== test session starts ============================================================================
platform linux -- Python 3.6.13, pytest-7.0.1, pluggy-1.0.0
rootdir: /home/vscuser/git/glweb/software/third-party/sarpy
collected 791 items                                                                                                                                                        

tests/test_class_string.py .                                                                                                                                         [  0%]
tests/consistency/test_consistency.py ........                                                                                                                       [  1%]
tests/consistency/test_cphd_consistency.py ..............................................................                                                            [  8%]
tests/consistency/test_sicd_consistency.py ...                                                                                                                       [  9%]
tests/consistency/test_sidd_consistency.py ....                                                                                                                      [  9%]
tests/geometry/test_geocoords.py ..........                                                                                                                          [ 11%]
tests/geometry/test_geometry_elements.py ..........                                                                                                                  [ 12%]
tests/geometry/test_latlon.py ...                                                                                                                                    [ 12%]
tests/geometry/test_point_projection.py ..............                                                                                                               [ 14%]
tests/io/test_kml.py .                                                                                                                                               [ 14%]
tests/io/DEM/test_dted.py ..                                                                                                                                         [ 14%]
tests/io/DEM/test_geoid.py .                                                                                                                                         [ 15%]
tests/io/DEM/test_geotiff1deg_list.py ....                                                                                                                           [ 15%]
tests/io/DEM/test_geotiff1deg_reader.py ........                                                                                                                     [ 16%]
tests/io/complex/test_other_nitf.py ...                                                                                                                              [ 16%]
tests/io/complex/test_reader.py ..sss.ssss.                                                                                                                          [ 18%]
tests/io/complex/test_remote.py s                                                                                                                                    [ 18%]
tests/io/complex/test_sicd.py .                                                                                                                                      [ 18%]
tests/io/complex/test_sio.py .                                                                                                                                       [ 18%]
tests/io/complex/test_utils.py .                                                                                                                                     [ 18%]
tests/io/complex/sicd_elements/test_sicd_elements_antenna.py ...                                                                                                     [ 19%]
tests/io/complex/sicd_elements/test_sicd_elements_base.py ...                                                                                                        [ 19%]
tests/io/complex/sicd_elements/test_sicd_elements_blocks.py .....................                                                                                    [ 22%]
tests/io/complex/sicd_elements/test_sicd_elements_collectioninfo.py ..                                                                                               [ 22%]
tests/io/complex/sicd_elements/test_sicd_elements_errorstatistics.py .                                                                                               [ 22%]
tests/io/complex/sicd_elements/test_sicd_elements_geodata.py ...                                                                                                     [ 23%]
tests/io/complex/sicd_elements/test_sicd_elements_grid.py ..                                                                                                         [ 23%]
tests/io/complex/sicd_elements/test_sicd_elements_imagecreation.py .                                                                                                 [ 23%]
tests/io/complex/sicd_elements/test_sicd_elements_imagedata.py .                                                                                                     [ 23%]
tests/io/complex/sicd_elements/test_sicd_elements_imageformation.py ......                                                                                           [ 24%]
tests/io/complex/sicd_elements/test_sicd_elements_matchinfo.py .                                                                                                     [ 24%]
tests/io/complex/sicd_elements/test_sicd_elements_pfa.py .                                                                                                           [ 24%]
tests/io/complex/sicd_elements/test_sicd_elements_position.py ...                                                                                                    [ 24%]
tests/io/complex/sicd_elements/test_sicd_elements_radarcollection.py ..............                                                                                  [ 26%]
tests/io/complex/sicd_elements/test_sicd_elements_radiometric.py .                                                                                                   [ 26%]
tests/io/complex/sicd_elements/test_sicd_elements_rgazcomp.py .                                                                                                      [ 26%]
tests/io/complex/sicd_elements/test_sicd_elements_rma.py ...                                                                                                         [ 27%]
tests/io/complex/sicd_elements/test_sicd_elements_scpcoa.py ...................                                                                                      [ 29%]
tests/io/complex/sicd_elements/test_sicd_elements_sicd.py ..................................                                                                         [ 34%]
tests/io/complex/sicd_elements/test_sicd_elements_timeline.py ..................                                                                                     [ 36%]
tests/io/complex/sicd_elements/test_sicd_elements_utils.py ...                                                                                                       [ 36%]
tests/io/general/test_base.py ...                                                                                                                                    [ 37%]
tests/io/general/test_data_segment.py ..........                                                                                                                     [ 38%]
tests/io/general/test_format_function.py ........                                                                                                                    [ 39%]
tests/io/general/test_nitf.py ..                                                                                                                                     [ 39%]
tests/io/general/test_nitf_headers.py .                                                                                                                              [ 39%]
tests/io/general/test_nitf_image.py ....                                                                                                                             [ 40%]
tests/io/general/test_tre.py ...                                                                                                                                     [ 40%]
tests/io/phase_history/test_cphd.py .......                                                                                                                          [ 41%]
tests/io/phase_history/test_cphd_versions.py .....                                                                                                                   [ 42%]
tests/io/phase_history/cphd1_elements/test_cphd.py ......                                                                                                            [ 42%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_antenna.py .....                                                                                           [ 43%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_blocks.py ....                                                                                             [ 43%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_channel.py .                                                                                               [ 44%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_data.py .                                                                                                  [ 44%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_dwell.py .                                                                                                 [ 44%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_geoinfo.py ...                                                                                             [ 44%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_global.py ..                                                                                               [ 45%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_pvp.py .                                                                                                   [ 45%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_referencegeometry.py .                                                                                     [ 45%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_supportarray.py ..                                                                                         [ 45%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_txrcv.py .                                                                                                 [ 45%]
tests/io/phase_history/cphd1_elements/test_utils.py .                                                                                                                [ 45%]
tests/io/product/test_reader.py ...s                                                                                                                                 [ 46%]
tests/io/product/test_sidd.py ......                                                                                                                                 [ 47%]
tests/io/product/test_sidd_schema.py .........                                                                                                                       [ 48%]
tests/io/product/test_sidd_writing.py ..                                                                                                                             [ 48%]
tests/io/product/sidd1_elements/test_exploitationfeatures.py .........................................................                                               [ 55%]
tests/io/product/sidd2_elements/test_exploitationfeatures.py ....................................................................                                    [ 64%]
tests/io/product/sidd3_elements/test_exploitationfeatures.py ....................................................................................................... [ 77%]
..............................................................................................................................                                       [ 93%]
tests/io/product/sidd3_elements/test_sidd3_elements.py .....                                                                                                         [ 93%]
tests/io/received/test_crsd.py .                                                                                                                                     [ 93%]
tests/processing/sicd/test_spectral_taper.py ........ss...........                                                                                                   [ 96%]
tests/utils/test_sicd_sidelobe_control.py ..                                                                                                                         [ 96%]
tests/visualization/test_cphd_kmz_product_creation.py ..                                                                                                             [ 97%]
tests/visualization/test_crsd_kmz_product_creation.py .                                                                                                              [ 97%]
tests/visualization/test_kmz_product_creation.py .x                                                                                                                  [ 97%]
tests/visualization/test_remap.py ....................                                                                                                               [100%]

============================================================================= warnings summary =============================================================================
tests/geometry/test_point_projection.py::test_image_to_ground_errors
tests/geometry/test_point_projection.py::test_image_to_ground_dem
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/geometry/point_projection.py:1882: RuntimeWarning: divide by zero encountered in double_scalars
    lon_grid_size = min(10, lat_grid_size/abs(numpy.sin(numpy.deg2rad(ref_llh[0]))))

tests/visualization/test_kmz_product_creation.py::test_create_kmz[True]
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/visualization/kmz_utils.py:169: RuntimeWarning: invalid value encountered in double_scalars
    + dir_z**2 * semiaxis_a**2 * semiaxis_b**2

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================= 779 passed, 11 skipped, 1 xfailed, 3 warnings in 59.67s ==========================================================
nox > Session test(version='3.6') was successful.
nox > Running session test(version='3.11')
nox > Creating conda env in .nox/test-version-3-11 with python
nox > conda install --yes --prefix /home/vscuser/git/glweb/software/third-party/sarpy/.nox/test-version-3-11 python=3.11
nox > python -m pip install '.[all]'
nox > pytest tests
=========================================================================== test session starts ============================================================================
platform linux -- Python 3.11.9, pytest-8.3.2, pluggy-1.5.0
rootdir: /home/vscuser/git/glweb/software/third-party/sarpy
collected 791 items                                                                                                                                                        

tests/consistency/test_consistency.py ........                                                                                                                       [  1%]
tests/consistency/test_cphd_consistency.py ..............................................................                                                            [  8%]
tests/consistency/test_sicd_consistency.py ...                                                                                                                       [  9%]
tests/consistency/test_sidd_consistency.py ....                                                                                                                      [  9%]
tests/geometry/test_geocoords.py ..........                                                                                                                          [ 10%]
tests/geometry/test_geometry_elements.py ..........                                                                                                                  [ 12%]
tests/geometry/test_latlon.py ...                                                                                                                                    [ 12%]
tests/geometry/test_point_projection.py ..............                                                                                                               [ 14%]
tests/io/DEM/test_dted.py ..                                                                                                                                         [ 14%]
tests/io/DEM/test_geoid.py .                                                                                                                                         [ 14%]
tests/io/DEM/test_geotiff1deg_list.py ....                                                                                                                           [ 15%]
tests/io/DEM/test_geotiff1deg_reader.py ........                                                                                                                     [ 16%]
tests/io/complex/sicd_elements/test_sicd_elements_antenna.py ...                                                                                                     [ 16%]
tests/io/complex/sicd_elements/test_sicd_elements_base.py ...                                                                                                        [ 17%]
tests/io/complex/sicd_elements/test_sicd_elements_blocks.py .....................                                                                                    [ 19%]
tests/io/complex/sicd_elements/test_sicd_elements_collectioninfo.py ..                                                                                               [ 19%]
tests/io/complex/sicd_elements/test_sicd_elements_errorstatistics.py .                                                                                               [ 20%]
tests/io/complex/sicd_elements/test_sicd_elements_geodata.py ...                                                                                                     [ 20%]
tests/io/complex/sicd_elements/test_sicd_elements_grid.py ..                                                                                                         [ 20%]
tests/io/complex/sicd_elements/test_sicd_elements_imagecreation.py .                                                                                                 [ 20%]
tests/io/complex/sicd_elements/test_sicd_elements_imagedata.py .                                                                                                     [ 20%]
tests/io/complex/sicd_elements/test_sicd_elements_imageformation.py ......                                                                                           [ 21%]
tests/io/complex/sicd_elements/test_sicd_elements_matchinfo.py .                                                                                                     [ 21%]
tests/io/complex/sicd_elements/test_sicd_elements_pfa.py .                                                                                                           [ 21%]
tests/io/complex/sicd_elements/test_sicd_elements_position.py ...                                                                                                    [ 22%]
tests/io/complex/sicd_elements/test_sicd_elements_radarcollection.py ..............                                                                                  [ 24%]
tests/io/complex/sicd_elements/test_sicd_elements_radiometric.py .                                                                                                   [ 24%]
tests/io/complex/sicd_elements/test_sicd_elements_rgazcomp.py .                                                                                                      [ 24%]
tests/io/complex/sicd_elements/test_sicd_elements_rma.py ...                                                                                                         [ 24%]
tests/io/complex/sicd_elements/test_sicd_elements_scpcoa.py ...................                                                                                      [ 27%]
tests/io/complex/sicd_elements/test_sicd_elements_sicd.py ..................................                                                                         [ 31%]
tests/io/complex/sicd_elements/test_sicd_elements_timeline.py ..................                                                                                     [ 33%]
tests/io/complex/sicd_elements/test_sicd_elements_utils.py ...                                                                                                       [ 34%]
tests/io/complex/test_other_nitf.py ...                                                                                                                              [ 34%]
tests/io/complex/test_reader.py ..sss.ssss.                                                                                                                          [ 35%]
tests/io/complex/test_remote.py s                                                                                                                                    [ 36%]
tests/io/complex/test_sicd.py .                                                                                                                                      [ 36%]
tests/io/complex/test_sio.py .                                                                                                                                       [ 36%]
tests/io/complex/test_utils.py .                                                                                                                                     [ 36%]
tests/io/general/test_base.py ...                                                                                                                                    [ 36%]
tests/io/general/test_data_segment.py ..........                                                                                                                     [ 38%]
tests/io/general/test_format_function.py ........                                                                                                                    [ 39%]
tests/io/general/test_nitf.py ..                                                                                                                                     [ 39%]
tests/io/general/test_nitf_headers.py .                                                                                                                              [ 39%]
tests/io/general/test_nitf_image.py ....                                                                                                                             [ 39%]
tests/io/general/test_tre.py ...                                                                                                                                     [ 40%]
tests/io/phase_history/cphd1_elements/test_cphd.py ......                                                                                                            [ 41%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_antenna.py .....                                                                                           [ 41%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_blocks.py ....                                                                                             [ 42%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_channel.py .                                                                                               [ 42%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_data.py .                                                                                                  [ 42%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_dwell.py .                                                                                                 [ 42%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_geoinfo.py ...                                                                                             [ 42%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_global.py ..                                                                                               [ 43%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_pvp.py .                                                                                                   [ 43%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_referencegeometry.py .                                                                                     [ 43%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_supportarray.py ..                                                                                         [ 43%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_txrcv.py .                                                                                                 [ 43%]
tests/io/phase_history/cphd1_elements/test_utils.py .                                                                                                                [ 43%]
tests/io/phase_history/test_cphd.py .......                                                                                                                          [ 44%]
tests/io/phase_history/test_cphd_versions.py .....                                                                                                                   [ 45%]
tests/io/product/sidd1_elements/test_exploitationfeatures.py .........................................................                                               [ 52%]
tests/io/product/sidd2_elements/test_exploitationfeatures.py ....................................................................                                    [ 61%]
tests/io/product/sidd3_elements/test_exploitationfeatures.py ....................................................................................................... [ 74%]
..............................................................................................................................                                       [ 90%]
tests/io/product/sidd3_elements/test_sidd3_elements.py .....                                                                                                         [ 90%]
tests/io/product/test_reader.py ...s                                                                                                                                 [ 91%]
tests/io/product/test_sidd.py ......                                                                                                                                 [ 92%]
tests/io/product/test_sidd_schema.py .........                                                                                                                       [ 93%]
tests/io/product/test_sidd_writing.py ..                                                                                                                             [ 93%]
tests/io/received/test_crsd.py .                                                                                                                                     [ 93%]
tests/io/test_kml.py .                                                                                                                                               [ 93%]
tests/processing/sicd/test_spectral_taper.py .....................                                                                                                   [ 96%]
tests/test_class_string.py .                                                                                                                                         [ 96%]
tests/utils/test_sicd_sidelobe_control.py ..                                                                                                                         [ 96%]
tests/visualization/test_cphd_kmz_product_creation.py ..                                                                                                             [ 97%]
tests/visualization/test_crsd_kmz_product_creation.py .                                                                                                              [ 97%]
tests/visualization/test_kmz_product_creation.py .x                                                                                                                  [ 97%]
tests/visualization/test_remap.py ....................                                                                                                               [100%]

============================================================================= warnings summary =============================================================================
tests/geometry/test_geometry_elements.py: 77 warnings
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/geometry/geometry_elements.py:131: DeprecationWarning: Arrays of 2-dimensional vectors are deprecated. Use arrays
 of 3-dimensional vectors instead. (deprecated in NumPy 2.0)                                                                                                                    dir_cross = float(numpy.cross(R, S))  # the scalar cross product of the direction vectors

tests/geometry/test_geometry_elements.py: 43 warnings
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/geometry/geometry_elements.py:137: DeprecationWarning: Arrays of 2-dimensional vectors are deprecated. Use arrays
 of 3-dimensional vectors instead. (deprecated in NumPy 2.0)                                                                                                                    end_cross_0 = float(numpy.cross(Q-P, S))

tests/geometry/test_geometry_elements.py: 43 warnings
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/geometry/geometry_elements.py:138: DeprecationWarning: Arrays of 2-dimensional vectors are deprecated. Use arrays
 of 3-dimensional vectors instead. (deprecated in NumPy 2.0)                                                                                                                    end_cross_1 = float(numpy.cross(Q-P, R))

tests/geometry/test_point_projection.py::test_image_to_ground_errors
tests/geometry/test_point_projection.py::test_image_to_ground_dem
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/geometry/point_projection.py:1882: RuntimeWarning: divide by zero encountered in scalar divide
    lon_grid_size = min(10, lat_grid_size/abs(numpy.sin(numpy.deg2rad(ref_llh[0]))))

tests/test_class_string.py::TestClassString::test_class_str
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/annotation/afrl_rde_schema/__init__.py:7: DeprecationWarning: pkg_resources is deprecated as an API. See https://
setuptools.pypa.io/en/latest/pkg_resources.html                                                                                                                                 import pkg_resources

tests/visualization/test_kmz_product_creation.py::test_create_kmz[True]
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/visualization/kmz_utils.py:145: RuntimeWarning: invalid value encountered in scalar divide
    distance = (

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================= 781 passed, 9 skipped, 1 xfailed, 167 warnings in 36.65s =========================================================
nox > Session test(version='3.11') was successful.
nox > Ran multiple sessions:
nox > * test(version='3.6'): success
nox > * test(version='3.11'): success
```

</details>


## Read the unit-test-generated file with MATLAB_SAR toolbox (59bb85c)

```shell
$ /home/vscuser/matlab/R2020b/bin/matlab  -batch read_sarpy_sio
```

<details><summary>read_sarpy_sio.m</summary>

```matlab
addpath(genpath("/home/vscuser/git/github/MATLAB_SAR"));
[cdata, mdata] = read_sio("/data/tmp/pytest-of-vscuser/pytest-current/test_sio_iocurrent/test.sio")
```

</details>

<details><summary>example output</summary>

```
/home/vscuser/matlab/R2020b/bin/matlab  -batch read_sarpy_sio

cdata =

  17x13 single matrix

   1.0e+02 *

  Columns 1 through 9

   0.0000 + 0.0100i   0.3400 + 0.3500i   0.6800 + 0.6900i   1.0200 + 1.0300i   1.3600 + 1.3700i   1.7000 + 1.7100i   2.0400 + 2.0500i   2.3800 + 2.3900i   2.7200 + 2.7300i
   0.0200 + 0.0300i   0.3600 + 0.3700i   0.7000 + 0.7100i   1.0400 + 1.0500i   1.3800 + 1.3900i   1.7200 + 1.7300i   2.0600 + 2.0700i   2.4000 + 2.4100i   2.7400 + 2.7500i
   0.0400 + 0.0500i   0.3800 + 0.3900i   0.7200 + 0.7300i   1.0600 + 1.0700i   1.4000 + 1.4100i   1.7400 + 1.7500i   2.0800 + 2.0900i   2.4200 + 2.4300i   2.7600 + 2.7700i
   0.0600 + 0.0700i   0.4000 + 0.4100i   0.7400 + 0.7500i   1.0800 + 1.0900i   1.4200 + 1.4300i   1.7600 + 1.7700i   2.1000 + 2.1100i   2.4400 + 2.4500i   2.7800 + 2.7900i
   0.0800 + 0.0900i   0.4200 + 0.4300i   0.7600 + 0.7700i   1.1000 + 1.1100i   1.4400 + 1.4500i   1.7800 + 1.7900i   2.1200 + 2.1300i   2.4600 + 2.4700i   2.8000 + 2.8100i
   0.1000 + 0.1100i   0.4400 + 0.4500i   0.7800 + 0.7900i   1.1200 + 1.1300i   1.4600 + 1.4700i   1.8000 + 1.8100i   2.1400 + 2.1500i   2.4800 + 2.4900i   2.8200 + 2.8300i
   0.1200 + 0.1300i   0.4600 + 0.4700i   0.8000 + 0.8100i   1.1400 + 1.1500i   1.4800 + 1.4900i   1.8200 + 1.8300i   2.1600 + 2.1700i   2.5000 + 2.5100i   2.8400 + 2.8500i
   0.1400 + 0.1500i   0.4800 + 0.4900i   0.8200 + 0.8300i   1.1600 + 1.1700i   1.5000 + 1.5100i   1.8400 + 1.8500i   2.1800 + 2.1900i   2.5200 + 2.5300i   2.8600 + 2.8700i
   0.1600 + 0.1700i   0.5000 + 0.5100i   0.8400 + 0.8500i   1.1800 + 1.1900i   1.5200 + 1.5300i   1.8600 + 1.8700i   2.2000 + 2.2100i   2.5400 + 2.5500i   2.8800 + 2.8900i
   0.1800 + 0.1900i   0.5200 + 0.5300i   0.8600 + 0.8700i   1.2000 + 1.2100i   1.5400 + 1.5500i   1.8800 + 1.8900i   2.2200 + 2.2300i   2.5600 + 2.5700i   2.9000 + 2.9100i
   0.2000 + 0.2100i   0.5400 + 0.5500i   0.8800 + 0.8900i   1.2200 + 1.2300i   1.5600 + 1.5700i   1.9000 + 1.9100i   2.2400 + 2.2500i   2.5800 + 2.5900i   2.9200 + 2.9300i
   0.2200 + 0.2300i   0.5600 + 0.5700i   0.9000 + 0.9100i   1.2400 + 1.2500i   1.5800 + 1.5900i   1.9200 + 1.9300i   2.2600 + 2.2700i   2.6000 + 2.6100i   2.9400 + 2.9500i
   0.2400 + 0.2500i   0.5800 + 0.5900i   0.9200 + 0.9300i   1.2600 + 1.2700i   1.6000 + 1.6100i   1.9400 + 1.9500i   2.2800 + 2.2900i   2.6200 + 2.6300i   2.9600 + 2.9700i
   0.2600 + 0.2700i   0.6000 + 0.6100i   0.9400 + 0.9500i   1.2800 + 1.2900i   1.6200 + 1.6300i   1.9600 + 1.9700i   2.3000 + 2.3100i   2.6400 + 2.6500i   2.9800 + 2.9900i
   0.2800 + 0.2900i   0.6200 + 0.6300i   0.9600 + 0.9700i   1.3000 + 1.3100i   1.6400 + 1.6500i   1.9800 + 1.9900i   2.3200 + 2.3300i   2.6600 + 2.6700i   3.0000 + 3.0100i
   0.3000 + 0.3100i   0.6400 + 0.6500i   0.9800 + 0.9900i   1.3200 + 1.3300i   1.6600 + 1.6700i   2.0000 + 2.0100i   2.3400 + 2.3500i   2.6800 + 2.6900i   3.0200 + 3.0300i
   0.3200 + 0.3300i   0.6600 + 0.6700i   1.0000 + 1.0100i   1.3400 + 1.3500i   1.6800 + 1.6900i   2.0200 + 2.0300i   2.3600 + 2.3700i   2.7000 + 2.7100i   3.0400 + 3.0500i

  Columns 10 through 13

   3.0600 + 3.0700i   3.4000 + 3.4100i   3.7400 + 3.7500i   4.0800 + 4.0900i
   3.0800 + 3.0900i   3.4200 + 3.4300i   3.7600 + 3.7700i   4.1000 + 4.1100i
   3.1000 + 3.1100i   3.4400 + 3.4500i   3.7800 + 3.7900i   4.1200 + 4.1300i
   3.1200 + 3.1300i   3.4600 + 3.4700i   3.8000 + 3.8100i   4.1400 + 4.1500i
   3.1400 + 3.1500i   3.4800 + 3.4900i   3.8200 + 3.8300i   4.1600 + 4.1700i
   3.1600 + 3.1700i   3.5000 + 3.5100i   3.8400 + 3.8500i   4.1800 + 4.1900i
   3.1800 + 3.1900i   3.5200 + 3.5300i   3.8600 + 3.8700i   4.2000 + 4.2100i
   3.2000 + 3.2100i   3.5400 + 3.5500i   3.8800 + 3.8900i   4.2200 + 4.2300i
   3.2200 + 3.2300i   3.5600 + 3.5700i   3.9000 + 3.9100i   4.2400 + 4.2500i
   3.2400 + 3.2500i   3.5800 + 3.5900i   3.9200 + 3.9300i   4.2600 + 4.2700i
   3.2600 + 3.2700i   3.6000 + 3.6100i   3.9400 + 3.9500i   4.2800 + 4.2900i
   3.2800 + 3.2900i   3.6200 + 3.6300i   3.9600 + 3.9700i   4.3000 + 4.3100i
   3.3000 + 3.3100i   3.6400 + 3.6500i   3.9800 + 3.9900i   4.3200 + 4.3300i
   3.3200 + 3.3300i   3.6600 + 3.6700i   4.0000 + 4.0100i   4.3400 + 4.3500i
   3.3400 + 3.3500i   3.6800 + 3.6900i   4.0200 + 4.0300i   4.3600 + 4.3700i
   3.3600 + 3.3700i   3.7000 + 3.7100i   4.0400 + 4.0500i   4.3800 + 4.3900i
   3.3800 + 3.3900i   3.7200 + 3.7300i   4.0600 + 4.0700i   4.4000 + 4.4100i


mdata = 

  struct with fields:

    SICDMETA: '<SICD xmlns="urn:SICD:1.3.0"><ImageData><PixelType>RE32F_IM32F</PixelType><NumRows>13</NumRows><NumCols>17</NumCols><FirstRow>0</FirstRow><FirstCol>0</FirstCol><FullImage><NumRows>13</NumRows><NumCols>17</NumCols></FullImage><SC
PPixel><Row>6</Row><Col>8</Col></SCPPixel></ImageData></SICD>'                                                                                                                                                                                     

```

</details>

## Read the unit-test-generated file with six

```shell
$ /Working_Data/sio/print_sio /data/tmp/pytest-of-vscuser/pytest-current/test_sio_iocurrent/test.sio
. nl: 13
. ne: 17
. et: Complex float
. es: 8
. SICDMETA: [<SICD xmlns="urn:SICD:1.3.0"><ImageData><PixelType>RE32F_IM32F</PixelType><NumRows>13</NumRows><NumCols>17</NumCols><FirstRow>0</FirstRow><FirstCol>0</FirstCol>
<FullImage><NumRows>13</NumRows><NumCols>17</NumCols></FullImage><SCPPixel><Row>6</Row><Col>8</Col></SCPPixel></ImageData></SICD>]                                           
```