### PR TITLE
Bugfix: SIDD 2.0+ FilterType handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ release points are not being annotated in GitHub.
 - DTED parsing for tiles with null values
 - Improved mapping of SICD -> SIDD polarizations
 - Incorrect SIDD ISM.compliesWith definition
+- SIDD 2.0+ FilterType handling
 
 ## [1.3.58] - 2023-08-07
 ### Added

--- a/sarpy/io/product/sidd2_elements/blocks.py
+++ b/sarpy/io/product/sidd2_elements/blocks.py
@@ -10,7 +10,8 @@ from typing import Union
 
 import numpy
 
-from sarpy.io.xml.base import Serializable, Arrayable, get_node_value, create_text_node, create_new_node, find_children
+from sarpy.io.xml.base import Serializable, Arrayable, get_node_value, create_text_node, create_new_node, \
+    find_children, find_first_child
 from sarpy.io.xml.descriptors import SerializableDescriptor, IntegerDescriptor, \
     FloatDescriptor, FloatModularDescriptor, StringDescriptor, StringEnumDescriptor
 
@@ -412,50 +413,18 @@ class PredefinedFilterType(Serializable):
         super(PredefinedFilterType, self).__init__(**kwargs)
 
 
-class FilterKernelType(Serializable):
+class _CustomType(Serializable, Arrayable):
     """
-    The filter kernel parameters. Provides the specifics for **either** a predefined or custom
-    filter kernel.
-    """
-
-    _fields = ('Predefined', 'Custom')
-    _required = ()
-    _choice = ({'required': True, 'collection': ('Predefined', 'Custom')}, )
-    # Descriptor
-    Predefined = SerializableDescriptor(
-        'Predefined', PredefinedFilterType, _required, strict=DEFAULT_STRICT,
-        docstring='')  # type: PredefinedFilterType
-    Custom = StringEnumDescriptor(
-        'Custom', ('GENERAL', 'FILTER BANK'), _required, strict=DEFAULT_STRICT,
-        docstring='')  # type: str
-
-    def __init__(self, Predefined=None, Custom=None, **kwargs):
-        """
-
-        Parameters
-        ----------
-        Predefined : None|PredefinedFilterType
-        Custom : None|str
-        kwargs
-        """
-
-        if '_xml_ns' in kwargs:
-            self._xml_ns = kwargs['_xml_ns']
-        if '_xml_ns_key' in kwargs:
-            self._xml_ns_key = kwargs['_xml_ns_key']
-        self.Predefined = Predefined
-        self.Custom = Custom
-        super(FilterKernelType, self).__init__(**kwargs)
-
-
-class BankCustomType(Serializable, Arrayable):
-    """
-    A custom filter bank array.
+    A custom filter array.
     """
     __slots__ = ('_coefs', )
-    _fields = ('Coefs', 'numPhasings', 'numPoints')
+    _fields = ('Coefs', )
     _required = ('Coefs', )
     _numeric_format = {'Coefs': FLOAT_FORMAT}
+    _var0 = "x"
+    _nvar0 = "numXs"
+    _var1 = "y"
+    _nvar1 = "numYs"
 
     def __init__(self, Coefs=None, **kwargs):
         """
@@ -465,30 +434,19 @@ class BankCustomType(Serializable, Arrayable):
         Coefs : numpy.ndarray|list|tuple
         kwargs
         """
-
         self._coefs = None
         if '_xml_ns' in kwargs:
             self._xml_ns = kwargs['_xml_ns']
         if '_xml_ns_key' in kwargs:
             self._xml_ns_key = kwargs['_xml_ns_key']
         self.Coefs = Coefs
-        super(BankCustomType, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
-    @property
-    def numPhasings(self):
-        """
-        int: The number of phasings [READ ONLY]
-        """
+    def _shape0(self):
+        return self._coefs.shape[0]
 
-        return self._coefs.shape[0] - 1
-
-    @property
-    def numPoints(self):
-        """
-        int: The number of points [READ ONLY]
-        """
-
-        return self._coefs.shape[1] - 1
+    def _shape1(self):
+        return self._coefs.shape[1]
 
     @property
     def Coefs(self):
@@ -505,17 +463,17 @@ class BankCustomType(Serializable, Arrayable):
     @Coefs.setter
     def Coefs(self, value):
         if value is None:
-            raise ValueError('The coefficient array for a BankCustomType instance must be defined.')
+            raise ValueError('The coefficient array must be defined.')
 
         if isinstance(value, (list, tuple)):
             value = numpy.array(value, dtype=numpy.float64)
 
         if not isinstance(value, numpy.ndarray):
             raise ValueError(
-                'Coefs for class BankCustomType must be a list or numpy.ndarray. Received type {}.'.format(type(value)))
+                'Coefs must be a list or numpy.ndarray. Received type {}.'.format(type(value)))
         elif len(value.shape) != 2:
             raise ValueError(
-                'Coefs for class BankCustomType must be two-dimensional. Received numpy.ndarray '
+                'Coefs must be two-dimensional. Received numpy.ndarray '
                 'of shape {}.'.format(value.shape))
         elif not value.dtype.name == 'float64':
             value = numpy.asarray(value, dtype=numpy.float64)
@@ -528,7 +486,7 @@ class BankCustomType(Serializable, Arrayable):
         self._coefs[item] = value
 
     @classmethod
-    def from_array(cls, array):  # type: (numpy.ndarray) -> BankCustomType
+    def from_array(cls, array):
         if array is None:
             return None
         return cls(Coefs=array)
@@ -552,14 +510,15 @@ class BankCustomType(Serializable, Arrayable):
 
     @classmethod
     def from_node(cls, node, xml_ns, ns_key=None, kwargs=None):
-        num_phasings = int(node.attrib['numPhasings'])
-        num_points = int(node.attrib['numPoints'])
-        coefs = numpy.zeros((num_phasings+1, num_points+1), dtype=numpy.float64)
+        filter_coefs_node = find_first_child(node, "FilterCoefficients", xml_ns, ns_key)
+        num_x = int(filter_coefs_node.attrib[cls._nvar0])
+        num_y = int(filter_coefs_node.attrib[cls._nvar1])
+        coefs = numpy.zeros((num_x, num_y), dtype=numpy.float64)
         ckey = cls._child_xml_ns_key.get('Coefs', ns_key)
-        coef_nodes = find_children(node, 'Coef', xml_ns, ckey)
+        coef_nodes = find_children(filter_coefs_node, 'Coef', xml_ns, ckey)
         for cnode in coef_nodes:
-            ind1 = int(cnode.attrib['phasing'])
-            ind2 = int(cnode.attrib['point'])
+            ind1 = int(cnode.attrib[cls._var0])
+            ind2 = int(cnode.attrib[cls._var1])
             val = float(get_node_value(cnode))
             coefs[ind1, ind2] = val
         return cls(Coefs=coefs)
@@ -571,6 +530,8 @@ class BankCustomType(Serializable, Arrayable):
             node = create_new_node(doc, tag, parent=parent)
         else:
             node = create_new_node(doc, '{}:{}'.format(ns_key, tag), parent=parent)
+        fc_tag = "FilterCoefficients" if ns_key is None else f"{ns_key}:FilterCoefficients"
+        filter_coefs_node = create_new_node(doc, fc_tag, parent=node)
 
         if 'Coefs' in self._child_xml_ns_key:
             ctag = '{}:Coef'.format(self._child_xml_ns_key['Coefs'])
@@ -579,21 +540,93 @@ class BankCustomType(Serializable, Arrayable):
         else:
             ctag = 'Coef'
 
-        node.attrib['numPhasings'] = str(self.numPhasings)
-        node.attrib['numPoints'] = str(self.numPoints)
+        filter_coefs_node.attrib[self._nvar0] = str(self._shape0())
+        filter_coefs_node.attrib[self._nvar1] = str(self._shape1())
         fmt_func = self._get_formatter('Coefs')
         for i, val1 in enumerate(self._coefs):
             for j, val in enumerate(val1):
                 # if val != 0.0:  # should we serialize it sparsely?
-                cnode = create_text_node(doc, ctag, fmt_func(val), parent=node)
-                cnode.attrib['phasing'] = str(i)
-                cnode.attrib['point'] = str(j)
+                cnode = create_text_node(doc, ctag, fmt_func(val), parent=filter_coefs_node)
+                cnode.attrib[self._var0] = str(i)
+                cnode.attrib[self._var1] = str(j)
         return node
 
     def to_dict(self,  check_validity=False, strict=DEFAULT_STRICT, exclude=()):
         out = OrderedDict()
         out['Coefs'] = self.Coefs.tolist()
         return out
+
+
+class KernelCustomType(_CustomType):
+    """
+    A custom filter kernel array.
+    """
+    _var0 = "row"
+    _nvar0 = "numRows"
+    _var1 = "col"
+    _nvar1 = "numCols"
+
+    @property
+    def numRows(self):
+        return self._shape0()
+
+    @property
+    def numCols(self):
+        return self._shape1()
+
+
+class FilterKernelType(Serializable):
+    """
+    The filter kernel parameters. Provides the specifics for **either** a predefined or custom
+    filter kernel.
+    """
+
+    _fields = ('Predefined', 'Custom')
+    _required = ()
+    _choice = ({'required': True, 'collection': ('Predefined', 'Custom')}, )
+    # Descriptor
+    Predefined = SerializableDescriptor(
+        'Predefined', PredefinedFilterType, _required, strict=DEFAULT_STRICT,
+        docstring='')  # type: PredefinedFilterType
+    Custom = SerializableDescriptor(
+        'Custom', KernelCustomType, _required, strict=DEFAULT_STRICT,
+        docstring='The custom filter kernel')  # type: KernelCustomType
+
+    def __init__(self, Predefined=None, Custom=None, **kwargs):
+        """
+
+        Parameters
+        ----------
+        Predefined : None|PredefinedFilterType
+        Custom : None|KernelCustomType
+        kwargs
+        """
+
+        if '_xml_ns' in kwargs:
+            self._xml_ns = kwargs['_xml_ns']
+        if '_xml_ns_key' in kwargs:
+            self._xml_ns_key = kwargs['_xml_ns_key']
+        self.Predefined = Predefined
+        self.Custom = Custom
+        super(FilterKernelType, self).__init__(**kwargs)
+
+
+class BankCustomType(_CustomType):
+    """
+    A custom filter bank array.
+    """
+    _var0 = "phasing"
+    _nvar0 = "numPhasings"
+    _var1 = "point"
+    _nvar1 = "numPoints"
+
+    @property
+    def numPhasings(self):
+        return self._shape0()
+
+    @property
+    def numPoints(self):
+        return self._shape1()
 
 
 class FilterBankType(Serializable):


### PR DESCRIPTION
# Description
This PR addresses #541 by:

- fixing the existing `to_node`/`from_node` logic in `BankCustomType`  (missing "FilterCoefficients" intermediate node, incorrect shape attributes)
- generalizing `CustomType` handling and use in new `KernelCustomType`
- add unittests

## Unittest fails without fixes

<details><summary>example output</summary>

```
pytest tests/io/product/test_sidd.py::test_sidd_filtertypes
=========================================================================== test session starts ============================================================================
platform linux -- Python 3.11.9, pytest-8.3.2, pluggy-1.5.0
rootdir: /home/vscuser/git/glweb/software/third-party/sarpy
collected 6 items                                                                                                                                                          

tests/io/product/test_sidd.py ....FF                                                                                                                                 [100%]

================================================================================= FAILURES =================================================================================
___________________________________________________________________ test_sidd_filtertypes[custom-Kernel] ___________________________________________________________________

tmp_path = PosixPath('/data/tmp/pytest-of-vscuser/pytest-419/test_sidd_filtertypes_custom_K0'), sidd_etree = <lxml.etree._ElementTree object at 0x7f6736e98600>
kernel_or_bank = 'Kernel', filt_type = 'custom'

    @pytest.mark.parametrize("kernel_or_bank", ("Kernel", "Bank"))
    @pytest.mark.parametrize("filt_type", ("predefined_db", "predefined_filt", "custom"))
    def test_sidd_filtertypes(tmp_path, sidd_etree, kernel_or_bank, filt_type):
        if filt_type == "predefined_db":
            filt_details = "<Predefined><DatabaseName>BILINEAR</DatabaseName></Predefined>"
        if filt_type == "predefined_filt":
            filt_details = "<Predefined><FilterFamily>0</FilterFamily><FilterMember>1</FilterMember></Predefined>"
        if filt_type == "custom":
            var0, var1 = {"Kernel": ("row", "col"), "Bank": ("phasing", "point")}[kernel_or_bank]
            filt_details = f'''
            <Custom>
                <FilterCoefficients num{var0.capitalize()}s="1" num{var1.capitalize()}s="2">
                    <Coef {var0}="0" {var1}="0">0.1</Coef>
                    <Coef {var0}="0" {var1}="1">0.2</Coef>
                </FilterCoefficients>
            </Custom>
            '''
        aa_node = sidd_etree.find(".//AntiAlias", namespaces=sidd_etree.getroot().nsmap)
        new_aa = lxml.etree.fromstring(f'''
            <AntiAlias xmlns="{lxml.etree.QName(aa_node).namespace}">
                <FilterName>SARPyFilterTypeTest</FilterName>
                <Filter{kernel_or_bank}>
                    {filt_details}
                </Filter{kernel_or_bank}>
                <Operation>CORRELATION</Operation>
            </AntiAlias>''')
        aa_node[:] = new_aa[:]
    
        sidd_xml_str = lxml.etree.tostring(sidd_etree)
        sidd_consistency.evaluate_xml_versus_schema(sidd_xml_str,
                                                    lxml.etree.QName(sidd_etree.getroot()).namespace)
>       _assert_to_from_xml(tmp_path, sidd_etree)

tests/io/product/test_sidd.py:152: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

tmp_path = PosixPath('/data/tmp/pytest-of-vscuser/pytest-419/test_sidd_filtertypes_custom_K0'), sidd_etree = <lxml.etree._ElementTree object at 0x7f6736e98600>

    def _assert_to_from_xml(tmp_path, sidd_etree):
        """Ensure that XML nodes are preserved when going from XML, through SarPy, then back to XML."""
        original_tree = sidd_etree
        original_read = sarpy_sidd.SIDDType.from_xml_string(lxml.etree.tostring(sidd_etree))
    
        out_file = tmp_path / "read_then_write.xml"
        out_file.write_text(original_read.to_xml_string(check_validity=True))
        reread_tree = lxml.etree.parse(str(out_file))
    
        original_nodes = {original_tree.getelementpath(x) for x in original_tree.iter()}
        new_nodes = {reread_tree.getelementpath(x) for x in reread_tree.iter()}
>       assert original_nodes == new_nodes
E       AssertionError: assert {'.', '{urn:S...sSource', ...} == {'.', '{urn:S...sSource', ...}
E         
E         Extra items in the left set:
E         '{urn:SIDD:2.0.0}Display/{urn:SIDD:2.0.0}NonInteractiveProcessing/{urn:SIDD:2.0.0}RRDS/{urn:SIDD:2.0.0}AntiAlias/{urn:SIDD:2.0.0}FilterKernel/{urn:SIDD:2.0.0}Cust
om/{urn:SIDD:2.0.0}FilterCoefficients/{urn:SIDD:2.0.0}Coef[2]'                                                                                                              E         '{urn:SIDD:2.0.0}Display/{urn:SIDD:2.0.0}NonInteractiveProcessing/{urn:SIDD:2.0.0}RRDS/{urn:SIDD:2.0.0}AntiAlias/{urn:SIDD:2.0.0}FilterKernel/{urn:SIDD:2.0.0}Cust
om/{urn:SIDD:2.0.0}FilterCoefficients/{urn:SIDD:2.0.0}Coef[1]'                                                                                                              E         '{urn:SIDD:2.0.0}Display/{urn:SIDD:2.0.0}NonInteractiveProcessing/{urn:SIDD:2.0.0}RRDS/{urn:SIDD:2.0...
E         
E         ...Full output truncated (2 lines hidden), use '-vv' to show

tests/io/product/test_sidd.py:114: AssertionError
---------------------------------------------------------------------------- Captured log call -----------------------------------------------------------------------------
ERROR    sarpy.io.xml.descriptors:descriptors.py:263 Attribute Custom of class FilterKernelType received <Element '{urn:SIDD:2.0.0}Custom' at 0x7f6736f2d710>,
        but values ARE REQUIRED to be one of ('GENERAL', 'FILTER BANK')
____________________________________________________________________ test_sidd_filtertypes[custom-Bank] ____________________________________________________________________

tmp_path = PosixPath('/data/tmp/pytest-of-vscuser/pytest-419/test_sidd_filtertypes_custom_B0'), sidd_etree = <lxml.etree._ElementTree object at 0x7f6736f9d800>
kernel_or_bank = 'Bank', filt_type = 'custom'

    @pytest.mark.parametrize("kernel_or_bank", ("Kernel", "Bank"))
    @pytest.mark.parametrize("filt_type", ("predefined_db", "predefined_filt", "custom"))
    def test_sidd_filtertypes(tmp_path, sidd_etree, kernel_or_bank, filt_type):
        if filt_type == "predefined_db":
            filt_details = "<Predefined><DatabaseName>BILINEAR</DatabaseName></Predefined>"
        if filt_type == "predefined_filt":
            filt_details = "<Predefined><FilterFamily>0</FilterFamily><FilterMember>1</FilterMember></Predefined>"
        if filt_type == "custom":
            var0, var1 = {"Kernel": ("row", "col"), "Bank": ("phasing", "point")}[kernel_or_bank]
            filt_details = f'''
            <Custom>
                <FilterCoefficients num{var0.capitalize()}s="1" num{var1.capitalize()}s="2">
                    <Coef {var0}="0" {var1}="0">0.1</Coef>
                    <Coef {var0}="0" {var1}="1">0.2</Coef>
                </FilterCoefficients>
            </Custom>
            '''
        aa_node = sidd_etree.find(".//AntiAlias", namespaces=sidd_etree.getroot().nsmap)
        new_aa = lxml.etree.fromstring(f'''
            <AntiAlias xmlns="{lxml.etree.QName(aa_node).namespace}">
                <FilterName>SARPyFilterTypeTest</FilterName>
                <Filter{kernel_or_bank}>
                    {filt_details}
                </Filter{kernel_or_bank}>
                <Operation>CORRELATION</Operation>
            </AntiAlias>''')
        aa_node[:] = new_aa[:]
    
        sidd_xml_str = lxml.etree.tostring(sidd_etree)
        sidd_consistency.evaluate_xml_versus_schema(sidd_xml_str,
                                                    lxml.etree.QName(sidd_etree.getroot()).namespace)
>       _assert_to_from_xml(tmp_path, sidd_etree)

tests/io/product/test_sidd.py:152: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

tmp_path = PosixPath('/data/tmp/pytest-of-vscuser/pytest-419/test_sidd_filtertypes_custom_B0'), sidd_etree = <lxml.etree._ElementTree object at 0x7f6736f9d800>

    def _assert_to_from_xml(tmp_path, sidd_etree):
        """Ensure that XML nodes are preserved when going from XML, through SarPy, then back to XML."""
        original_tree = sidd_etree
        original_read = sarpy_sidd.SIDDType.from_xml_string(lxml.etree.tostring(sidd_etree))
    
        out_file = tmp_path / "read_then_write.xml"
        out_file.write_text(original_read.to_xml_string(check_validity=True))
        reread_tree = lxml.etree.parse(str(out_file))
    
        original_nodes = {original_tree.getelementpath(x) for x in original_tree.iter()}
        new_nodes = {reread_tree.getelementpath(x) for x in reread_tree.iter()}
>       assert original_nodes == new_nodes
E       AssertionError: assert {'.', '{urn:S...sSource', ...} == {'.', '{urn:S...sSource', ...}
E         
E         Extra items in the left set:
E         '{urn:SIDD:2.0.0}Display/{urn:SIDD:2.0.0}NonInteractiveProcessing/{urn:SIDD:2.0.0}RRDS/{urn:SIDD:2.0.0}AntiAlias/{urn:SIDD:2.0.0}FilterBank/{urn:SIDD:2.0.0}Custom
'                                                                                                                                                                           E         '{urn:SIDD:2.0.0}Display/{urn:SIDD:2.0.0}NonInteractiveProcessing/{urn:SIDD:2.0.0}RRDS/{urn:SIDD:2.0.0}AntiAlias/{urn:SIDD:2.0.0}FilterBank/{urn:SIDD:2.0.0}Custom
/{urn:SIDD:2.0.0}FilterCoefficients/{urn:SIDD:2.0.0}Coef[1]'                                                                                                                E         '{urn:SIDD:2.0.0}Display/{urn:SIDD:2.0.0}NonInteractiveProcessing/{urn:SIDD:2.0.0}RRDS/{urn:SIDD:2.0.0}AntiAlias/{urn:SIDD:2.0.0}FilterBank/{urn:SIDD:2.0.0}Custom
/...                                                                                                                                                                        E         
E         ...Full output truncated (3 lines hidden), use '-vv' to show

tests/io/product/test_sidd.py:114: AssertionError
---------------------------------------------------------------------------- Captured log call -----------------------------------------------------------------------------
ERROR    sarpy.io.xml.descriptors:descriptors.py:728 Failed converting <Element '{urn:SIDD:2.0.0}Custom' at 0x7f6736f11bc0> of type <class 'xml.etree.ElementTree.Element'> 
to Serializable type <class 'sarpy.io.product.sidd2_elements.blocks.BankCustomType'>                                                                                                for field Custom of class FilterBankType with exception <class 'KeyError'> - 'numPhasings'.
        Setting value to None, which may be against the standard.
ERROR    validation:base.py:788 FilterBankType: Exactly one of the attributes ('Predefined', 'Custom') should be set, but none are set
WARNING  sarpy.io.xml.base:base.py:1140 FilterBankType is not valid,
        and cannot be SAFELY serialized to XML according to the SICD standard.
========================================================================= short test summary info ==========================================================================
FAILED tests/io/product/test_sidd.py::test_sidd_filtertypes[custom-Kernel] - AssertionError: assert {'.', '{urn:S...sSource', ...} == {'.', '{urn:S...sSource', ...}
FAILED tests/io/product/test_sidd.py::test_sidd_filtertypes[custom-Bank] - AssertionError: assert {'.', '{urn:S...sSource', ...} == {'.', '{urn:S...sSource', ...}
======================================================================= 2 failed, 4 passed in 1.17s ========================================================================

```

</details>

## Tests Pass

<details><summary>all tests pass in this branch</summary>

```
SARPY_TEST_PATH=/data/sarpy_test/ nox
nox > Running session test(version='3.6')
nox > Creating conda env in .nox/test-version-3-6 with python
nox > conda install --yes --prefix /home/vscuser/git/glweb/software/third-party/sarpy/.nox/test-version-3-6 python=3.6
nox > python -m pip install '.[all]'
nox > pytest tests
=========================================================================== test session starts ============================================================================
platform linux -- Python 3.6.13, pytest-7.0.1, pluggy-1.0.0
rootdir: /home/vscuser/git/glweb/software/third-party/sarpy
collected 797 items                                                                                                                                                        

tests/test_class_string.py .                                                                                                                                         [  0%]
tests/consistency/test_consistency.py ........                                                                                                                       [  1%]
tests/consistency/test_cphd_consistency.py ..............................................................                                                            [  8%]
tests/consistency/test_sicd_consistency.py ...                                                                                                                       [  9%]
tests/consistency/test_sidd_consistency.py ....                                                                                                                      [  9%]
tests/geometry/test_geocoords.py ..........                                                                                                                          [ 11%]
tests/geometry/test_geometry_elements.py ..........                                                                                                                  [ 12%]
tests/geometry/test_latlon.py ...                                                                                                                                    [ 12%]
tests/geometry/test_point_projection.py ..............                                                                                                               [ 14%]
tests/io/test_kml.py .                                                                                                                                               [ 14%]
tests/io/DEM/test_dted.py ..                                                                                                                                         [ 14%]
tests/io/DEM/test_geoid.py .                                                                                                                                         [ 14%]
tests/io/DEM/test_geotiff1deg_list.py ....                                                                                                                           [ 15%]
tests/io/DEM/test_geotiff1deg_reader.py ........                                                                                                                     [ 16%]
tests/io/complex/test_other_nitf.py ...                                                                                                                              [ 16%]
tests/io/complex/test_reader.py ..sss.ssss.                                                                                                                          [ 18%]
tests/io/complex/test_remote.py s                                                                                                                                    [ 18%]
tests/io/complex/test_sicd.py .                                                                                                                                      [ 18%]
tests/io/complex/test_utils.py .                                                                                                                                     [ 18%]
tests/io/complex/sicd_elements/test_sicd_elements_antenna.py ...                                                                                                     [ 18%]
tests/io/complex/sicd_elements/test_sicd_elements_base.py ...                                                                                                        [ 19%]
tests/io/complex/sicd_elements/test_sicd_elements_blocks.py .....................                                                                                    [ 21%]
tests/io/complex/sicd_elements/test_sicd_elements_collectioninfo.py ..                                                                                               [ 22%]
tests/io/complex/sicd_elements/test_sicd_elements_errorstatistics.py .                                                                                               [ 22%]
tests/io/complex/sicd_elements/test_sicd_elements_geodata.py ...                                                                                                     [ 22%]
tests/io/complex/sicd_elements/test_sicd_elements_grid.py ..                                                                                                         [ 22%]
tests/io/complex/sicd_elements/test_sicd_elements_imagecreation.py .                                                                                                 [ 23%]
tests/io/complex/sicd_elements/test_sicd_elements_imagedata.py .                                                                                                     [ 23%]
tests/io/complex/sicd_elements/test_sicd_elements_imageformation.py ......                                                                                           [ 23%]
tests/io/complex/sicd_elements/test_sicd_elements_matchinfo.py .                                                                                                     [ 24%]
tests/io/complex/sicd_elements/test_sicd_elements_pfa.py .                                                                                                           [ 24%]
tests/io/complex/sicd_elements/test_sicd_elements_position.py ...                                                                                                    [ 24%]
tests/io/complex/sicd_elements/test_sicd_elements_radarcollection.py ..............                                                                                  [ 26%]
tests/io/complex/sicd_elements/test_sicd_elements_radiometric.py .                                                                                                   [ 26%]
tests/io/complex/sicd_elements/test_sicd_elements_rgazcomp.py .                                                                                                      [ 26%]
tests/io/complex/sicd_elements/test_sicd_elements_rma.py ...                                                                                                         [ 26%]
tests/io/complex/sicd_elements/test_sicd_elements_scpcoa.py ...................                                                                                      [ 29%]
tests/io/complex/sicd_elements/test_sicd_elements_sicd.py ..................................                                                                         [ 33%]
tests/io/complex/sicd_elements/test_sicd_elements_timeline.py ..................                                                                                     [ 35%]
tests/io/complex/sicd_elements/test_sicd_elements_utils.py ...                                                                                                       [ 36%]
tests/io/general/test_base.py ...                                                                                                                                    [ 36%]
tests/io/general/test_data_segment.py ..........                                                                                                                     [ 37%]
tests/io/general/test_format_function.py ........                                                                                                                    [ 38%]
tests/io/general/test_nitf.py ..                                                                                                                                     [ 39%]
tests/io/general/test_nitf_headers.py .                                                                                                                              [ 39%]
tests/io/general/test_nitf_image.py ....                                                                                                                             [ 39%]
tests/io/general/test_tre.py ...                                                                                                                                     [ 40%]
tests/io/phase_history/test_cphd.py .......                                                                                                                          [ 41%]
tests/io/phase_history/test_cphd_versions.py .....                                                                                                                   [ 41%]
tests/io/phase_history/cphd1_elements/test_cphd.py ......                                                                                                            [ 42%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_antenna.py .....                                                                                           [ 43%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_blocks.py ....                                                                                             [ 43%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_channel.py .                                                                                               [ 43%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_data.py .                                                                                                  [ 43%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_dwell.py .                                                                                                 [ 43%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_geoinfo.py ...                                                                                             [ 44%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_global.py ..                                                                                               [ 44%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_pvp.py .                                                                                                   [ 44%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_referencegeometry.py .                                                                                     [ 44%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_supportarray.py ..                                                                                         [ 45%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_txrcv.py .                                                                                                 [ 45%]
tests/io/phase_history/cphd1_elements/test_utils.py .                                                                                                                [ 45%]
tests/io/product/test_reader.py ...s                                                                                                                                 [ 45%]
tests/io/product/test_sidd.py .............                                                                                                                          [ 47%]
tests/io/product/test_sidd_schema.py .........                                                                                                                       [ 48%]
tests/io/product/test_sidd_writing.py ..                                                                                                                             [ 48%]
tests/io/product/sidd1_elements/test_exploitationfeatures.py .........................................................                                               [ 55%]
tests/io/product/sidd2_elements/test_exploitationfeatures.py ....................................................................                                    [ 64%]
tests/io/product/sidd3_elements/test_exploitationfeatures.py ....................................................................................................... [ 77%]
..............................................................................................................................                                       [ 93%]
tests/io/product/sidd3_elements/test_sidd3_elements.py .....                                                                                                         [ 93%]
tests/io/received/test_crsd.py .                                                                                                                                     [ 93%]
tests/processing/sicd/test_spectral_taper.py ........ss...........                                                                                                   [ 96%]
tests/utils/test_sicd_sidelobe_control.py ..                                                                                                                         [ 96%]
tests/visualization/test_cphd_kmz_product_creation.py ..                                                                                                             [ 97%]
tests/visualization/test_crsd_kmz_product_creation.py .                                                                                                              [ 97%]
tests/visualization/test_kmz_product_creation.py .x                                                                                                                  [ 97%]
tests/visualization/test_remap.py ....................                                                                                                               [100%]

============================================================================= warnings summary =============================================================================
tests/geometry/test_point_projection.py::test_image_to_ground_errors
tests/geometry/test_point_projection.py::test_image_to_ground_dem
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/geometry/point_projection.py:1882: RuntimeWarning: divide by zero encountered in double_scalars
    lon_grid_size = min(10, lat_grid_size/abs(numpy.sin(numpy.deg2rad(ref_llh[0]))))

tests/visualization/test_kmz_product_creation.py::test_create_kmz[True]
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/visualization/kmz_utils.py:169: RuntimeWarning: invalid value encountered in double_scalars
    + dir_z**2 * semiaxis_a**2 * semiaxis_b**2

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================= 785 passed, 11 skipped, 1 xfailed, 3 warnings in 45.56s ==========================================================
nox > Session test(version='3.6') was successful.
nox > Running session test(version='3.11')
nox > Creating conda env in .nox/test-version-3-11 with python
nox > conda install --yes --prefix /home/vscuser/git/glweb/software/third-party/sarpy/.nox/test-version-3-11 python=3.11
nox > python -m pip install '.[all]'
nox > pytest tests
=========================================================================== test session starts ============================================================================
platform linux -- Python 3.11.9, pytest-8.3.2, pluggy-1.5.0
rootdir: /home/vscuser/git/glweb/software/third-party/sarpy
collected 797 items                                                                                                                                                        

tests/consistency/test_consistency.py ........                                                                                                                       [  1%]
tests/consistency/test_cphd_consistency.py ..............................................................                                                            [  8%]
tests/consistency/test_sicd_consistency.py ...                                                                                                                       [  9%]
tests/consistency/test_sidd_consistency.py ....                                                                                                                      [  9%]
tests/geometry/test_geocoords.py ..........                                                                                                                          [ 10%]
tests/geometry/test_geometry_elements.py ..........                                                                                                                  [ 12%]
tests/geometry/test_latlon.py ...                                                                                                                                    [ 12%]
tests/geometry/test_point_projection.py ..............                                                                                                               [ 14%]
tests/io/DEM/test_dted.py ..                                                                                                                                         [ 14%]
tests/io/DEM/test_geoid.py .                                                                                                                                         [ 14%]
tests/io/DEM/test_geotiff1deg_list.py ....                                                                                                                           [ 15%]
tests/io/DEM/test_geotiff1deg_reader.py ........                                                                                                                     [ 16%]
tests/io/complex/sicd_elements/test_sicd_elements_antenna.py ...                                                                                                     [ 16%]
tests/io/complex/sicd_elements/test_sicd_elements_base.py ...                                                                                                        [ 16%]
tests/io/complex/sicd_elements/test_sicd_elements_blocks.py .....................                                                                                    [ 19%]
tests/io/complex/sicd_elements/test_sicd_elements_collectioninfo.py ..                                                                                               [ 19%]
tests/io/complex/sicd_elements/test_sicd_elements_errorstatistics.py .                                                                                               [ 19%]
tests/io/complex/sicd_elements/test_sicd_elements_geodata.py ...                                                                                                     [ 20%]
tests/io/complex/sicd_elements/test_sicd_elements_grid.py ..                                                                                                         [ 20%]
tests/io/complex/sicd_elements/test_sicd_elements_imagecreation.py .                                                                                                 [ 20%]
tests/io/complex/sicd_elements/test_sicd_elements_imagedata.py .                                                                                                     [ 20%]
tests/io/complex/sicd_elements/test_sicd_elements_imageformation.py ......                                                                                           [ 21%]
tests/io/complex/sicd_elements/test_sicd_elements_matchinfo.py .                                                                                                     [ 21%]
tests/io/complex/sicd_elements/test_sicd_elements_pfa.py .                                                                                                           [ 21%]
tests/io/complex/sicd_elements/test_sicd_elements_position.py ...                                                                                                    [ 22%]
tests/io/complex/sicd_elements/test_sicd_elements_radarcollection.py ..............                                                                                  [ 23%]
tests/io/complex/sicd_elements/test_sicd_elements_radiometric.py .                                                                                                   [ 24%]
tests/io/complex/sicd_elements/test_sicd_elements_rgazcomp.py .                                                                                                      [ 24%]
tests/io/complex/sicd_elements/test_sicd_elements_rma.py ...                                                                                                         [ 24%]
tests/io/complex/sicd_elements/test_sicd_elements_scpcoa.py ...................                                                                                      [ 26%]
tests/io/complex/sicd_elements/test_sicd_elements_sicd.py ..................................                                                                         [ 31%]
tests/io/complex/sicd_elements/test_sicd_elements_timeline.py ..................                                                                                     [ 33%]
tests/io/complex/sicd_elements/test_sicd_elements_utils.py ...                                                                                                       [ 33%]
tests/io/complex/test_other_nitf.py ...                                                                                                                              [ 34%]
tests/io/complex/test_reader.py ..sss.ssss.                                                                                                                          [ 35%]
tests/io/complex/test_remote.py s                                                                                                                                    [ 35%]
tests/io/complex/test_sicd.py .                                                                                                                                      [ 35%]
tests/io/complex/test_utils.py .                                                                                                                                     [ 36%]
tests/io/general/test_base.py ...                                                                                                                                    [ 36%]
tests/io/general/test_data_segment.py ..........                                                                                                                     [ 37%]
tests/io/general/test_format_function.py ........                                                                                                                    [ 38%]
tests/io/general/test_nitf.py ..                                                                                                                                     [ 38%]
tests/io/general/test_nitf_headers.py .                                                                                                                              [ 39%]
tests/io/general/test_nitf_image.py ....                                                                                                                             [ 39%]
tests/io/general/test_tre.py ...                                                                                                                                     [ 39%]
tests/io/phase_history/cphd1_elements/test_cphd.py ......                                                                                                            [ 40%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_antenna.py .....                                                                                           [ 41%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_blocks.py ....                                                                                             [ 41%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_channel.py .                                                                                               [ 41%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_data.py .                                                                                                  [ 42%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_dwell.py .                                                                                                 [ 42%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_geoinfo.py ...                                                                                             [ 42%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_global.py ..                                                                                               [ 42%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_pvp.py .                                                                                                   [ 42%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_referencegeometry.py .                                                                                     [ 43%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_supportarray.py ..                                                                                         [ 43%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_txrcv.py .                                                                                                 [ 43%]
tests/io/phase_history/cphd1_elements/test_utils.py .                                                                                                                [ 43%]
tests/io/phase_history/test_cphd.py .......                                                                                                                          [ 44%]
tests/io/phase_history/test_cphd_versions.py .....                                                                                                                   [ 45%]
tests/io/product/sidd1_elements/test_exploitationfeatures.py .........................................................                                               [ 52%]
tests/io/product/sidd2_elements/test_exploitationfeatures.py ....................................................................                                    [ 60%]
tests/io/product/sidd3_elements/test_exploitationfeatures.py ....................................................................................................... [ 73%]
..............................................................................................................................                                       [ 89%]
tests/io/product/sidd3_elements/test_sidd3_elements.py .....                                                                                                         [ 90%]
tests/io/product/test_reader.py ...s                                                                                                                                 [ 90%]
tests/io/product/test_sidd.py .............                                                                                                                          [ 92%]
tests/io/product/test_sidd_schema.py .........                                                                                                                       [ 93%]
tests/io/product/test_sidd_writing.py ..                                                                                                                             [ 93%]
tests/io/received/test_crsd.py .                                                                                                                                     [ 93%]
tests/io/test_kml.py .                                                                                                                                               [ 93%]
tests/processing/sicd/test_spectral_taper.py .....................                                                                                                   [ 96%]
tests/test_class_string.py .                                                                                                                                         [ 96%]
tests/utils/test_sicd_sidelobe_control.py ..                                                                                                                         [ 96%]
tests/visualization/test_cphd_kmz_product_creation.py ..                                                                                                             [ 97%]
tests/visualization/test_crsd_kmz_product_creation.py .                                                                                                              [ 97%]
tests/visualization/test_kmz_product_creation.py .x                                                                                                                  [ 97%]
tests/visualization/test_remap.py ....................                                                                                                               [100%]

============================================================================= warnings summary =============================================================================
tests/geometry/test_geometry_elements.py: 77 warnings
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/geometry/geometry_elements.py:131: DeprecationWarning: Arrays of 2-dimensional vectors are deprecated. Use arrays
 of 3-dimensional vectors instead. (deprecated in NumPy 2.0)                                                                                                                    dir_cross = float(numpy.cross(R, S))  # the scalar cross product of the direction vectors

tests/geometry/test_geometry_elements.py: 43 warnings
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/geometry/geometry_elements.py:137: DeprecationWarning: Arrays of 2-dimensional vectors are deprecated. Use arrays
 of 3-dimensional vectors instead. (deprecated in NumPy 2.0)                                                                                                                    end_cross_0 = float(numpy.cross(Q-P, S))

tests/geometry/test_geometry_elements.py: 43 warnings
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/geometry/geometry_elements.py:138: DeprecationWarning: Arrays of 2-dimensional vectors are deprecated. Use arrays
 of 3-dimensional vectors instead. (deprecated in NumPy 2.0)                                                                                                                    end_cross_1 = float(numpy.cross(Q-P, R))

tests/geometry/test_point_projection.py::test_image_to_ground_errors
tests/geometry/test_point_projection.py::test_image_to_ground_dem
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/geometry/point_projection.py:1882: RuntimeWarning: divide by zero encountered in scalar divide
    lon_grid_size = min(10, lat_grid_size/abs(numpy.sin(numpy.deg2rad(ref_llh[0]))))

tests/test_class_string.py::TestClassString::test_class_str
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/annotation/afrl_rde_schema/__init__.py:7: DeprecationWarning: pkg_resources is deprecated as an API. See https://
setuptools.pypa.io/en/latest/pkg_resources.html                                                                                                                                 import pkg_resources

tests/visualization/test_kmz_product_creation.py::test_create_kmz[True]
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/visualization/kmz_utils.py:145: RuntimeWarning: invalid value encountered in scalar divide
    distance = (

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================= 787 passed, 9 skipped, 1 xfailed, 167 warnings in 32.36s =========================================================
nox > Session test(version='3.11') was successful.
nox > Ran multiple sessions:
nox > * test(version='3.6'): success
nox > * test(version='3.11'): success

```

</details>