### PR TITLE
Merge master into integration/1.3.59-rc

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Changes to sarpy for the sole purpose of supporting a Python version beyond
 end-of-life are unlikely to be considered.
 
 Information regarding any discovered bugs would be greatly appreciated, so please
-feel free to create a GitHub issue. If more appropriate, contact wade.c.schwartzkopf@nga.mil.
+feel free to create a GitHub issue. If more appropriate, contact richard.m.naething@nga.mil.
 
 Integration Branches
 --------------------

--- a/sarpy/__about__.py
+++ b/sarpy/__about__.py
@@ -33,7 +33,7 @@ __version__ = _version_number + _post_identifier
 
 __author__ = "National Geospatial-Intelligence Agency"
 __url__ = "https://github.com/ngageoint/sarpy"
-__email__ = "Wade.C.Schwartzkopf@nga.mil"
+__email__ = "richard.m.naething@nga.mil"
 
 
 __title__ = "sarpy"


### PR DESCRIPTION
# Description
Although this content made it into the  `integration/1.3.59-rc` branch; it looks like the commits themselves did not:

![image](https://github.com/user-attachments/assets/40458d66-a9c4-4423-aa73-b7074f656723)

This PR is to get these 3 commits into `integration/1.3.59-rc` (don't squash while merging)