### PR TITLE
Recompute SCPCOA when converters update SCP using a DEM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ release points are not being annotated in GitHub.
 - SIO reading/writing
 - SIDD 2.0+ FilterType handling
 - Erroneous SIDD consistency error re: NITF NBPP when PixelType=RGB24I
+- Properly recompute SCPCOA metadata when updating SCP using a DEM in `sarpy.io.complex.converter.conversion_utility`
 
 ## [1.3.58] - 2023-08-07
 ### Added

--- a/sarpy/io/complex/converter.py
+++ b/sarpy/io/complex/converter.py
@@ -422,6 +422,9 @@ def conversion_utility(
                 sicd.GeoData.ImageCorners[i].Lat = llh_points[index][0]          # FRFC is index 1, FRLC is index 2,
                 sicd.GeoData.ImageCorners[i].Lon = llh_points[index][1]          # LRFC is index 3, LRLC is index 4
 
+            # Recompute SCPCOA using the updated SCP
+            sicd.SCPCOA.rederive(sicd.Grid, sicd.Position, sicd.GeoData)
+
     # check that frames is valid
     if frames is None:
         frames = tuple(range(len(sicds)))


### PR DESCRIPTION
The SCPCOA fields weren't being updated when the converter used a DEM.  In many cases the changes will be small, but a user encountered a case where the SCP moved enough to cause the consistency checker to complain.
