### PR TITLE
Bugfix: SIDD GeoInfo namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ release points are not being annotated in GitHub.
 - SIDD 2.0+ FilterType handling
 - Erroneous SIDD consistency error re: NITF NBPP when PixelType=RGB24I
 - Properly recompute SCPCOA metadata when updating SCP using a DEM in `sarpy.io.complex.converter.conversion_utility`
+- SIDD GeoInfo namespace handling
 
 ## [1.3.58] - 2023-08-07
 ### Added

--- a/sarpy/io/complex/sicd_elements/GeoData.py
+++ b/sarpy/io/complex/sicd_elements/GeoData.py
@@ -151,9 +151,9 @@ class GeoInfoType(Serializable):
 
         if isinstance(value, ElementTree.Element):
             gi_key = self._child_xml_ns_key.get('GeoInfos', self._xml_ns_key)
-            value = GeoInfoType.from_node(value, self._xml_ns, ns_key=gi_key)
+            value = self.from_node(value, self._xml_ns, ns_key=gi_key)
         elif isinstance(value, dict):
-            value = GeoInfoType.from_dict(value)
+            value = self.from_dict(value)
 
         if isinstance(value, GeoInfoType):
             self._GeoInfos.append(value)

--- a/sarpy/io/complex/sicd_elements/blocks.py
+++ b/sarpy/io/complex/sicd_elements/blocks.py
@@ -237,6 +237,7 @@ class LatLonArrayElementType(LatLonType):
     _fields = ('Lat', 'Lon', 'index')
     _required = _fields
     _set_as_attribute = ('index', )
+    _child_xml_ns_key = {'index': None}
     index = IntegerDescriptor(
         'index', _required, strict=False, docstring="The array index")  # type: int
 

--- a/sarpy/io/product/sidd2_elements/GeoData.py
+++ b/sarpy/io/product/sidd2_elements/GeoData.py
@@ -31,6 +31,7 @@ class GeoDataType(Serializable):
         'ValidData': {'array': True, 'child_tag': 'Vertex'},
         'ImageCorners': {'array': True, 'child_tag': 'ICP'}}
     _numeric_format = {'ImageCorners': FLOAT_FORMAT, 'ValidData': FLOAT_FORMAT}
+    _child_xml_ns_key = {'GeoInfos': 'sicommon'}
     # other class variables
     _EARTH_MODEL_VALUES = ('WGS_84', )
     # descriptors
@@ -120,7 +121,6 @@ class GeoDataType(Serializable):
         -------
         None
         """
-
         if isinstance(value, ElementTree.Element):
             gi_key = self._child_xml_ns_key.get('GeoInfos', self._xml_ns_key)
             value = GeoInfoType.from_node(value, self._xml_ns, ns_key=gi_key)
@@ -144,8 +144,9 @@ class GeoDataType(Serializable):
         node = super(GeoDataType, self).to_node(
             doc, tag, ns_key=ns_key, parent=parent, check_validity=check_validity, strict=strict, exclude=exclude)
         # slap on the GeoInfo children
+        gkey = self._child_xml_ns_key.get('GeoInfos', ns_key)
         for entry in self._GeoInfos:
-            entry.to_node(doc, 'GeoInfo', ns_key=ns_key, parent=node, strict=strict)
+            entry.to_node(doc, 'GeoInfo', ns_key=gkey, parent=node, strict=strict)
         return node
 
     def to_dict(self, check_validity=False, strict=DEFAULT_STRICT, exclude=()):

--- a/sarpy/io/product/sidd2_elements/blocks.py
+++ b/sarpy/io/product/sidd2_elements/blocks.py
@@ -309,7 +309,7 @@ class MatchInfoType(MatchInfoTypeBase):
 
 class GeoInfoType(GeoInfoTypeBase):
     _child_xml_ns_key = {
-        'Descriptions': 'sicommon', 'Point': 'sicommon', 'Line': 'sicommon',
+        'name': None, 'Descriptions': 'sicommon', 'Point': 'sicommon', 'Line': 'sicommon',
         'Polygon': 'sicommon'}
 
 

--- a/tests/data/example.sicd.xml
+++ b/tests/data/example.sicd.xml
@@ -347,6 +347,54 @@
             <GeoInfo name="target8">
                 <Desc name="ecef">[6378137.0, 405.5797876726389, -579.2279653395692]</Desc>
             </GeoInfo>
+            <GeoInfo name="root">
+                <Desc name="rootdesc">a description</Desc>
+                <Desc name="rootdesc2">another description</Desc>
+                <GeoInfo name="nested_point">
+                    <Desc name="nested_pointdesc">this is a point</Desc>
+                    <Point>
+                        <Lat>0.0041255109857561032</Lat>
+                        <Lon>-0.0038406233754897695</Lon>
+                    </Point>
+                    <GeoInfo name="nested_nested_point">
+                        <Desc name="nested_nested_pointdesc">this is a point in a point</Desc>
+                        <Point>
+                            <Lat>0.0041255109857561032</Lat>
+                            <Lon>-0.0038406233754897695</Lon>
+                        </Point>
+                    </GeoInfo>
+                </GeoInfo>
+                <GeoInfo name="nested_line">
+                    <Desc name="nested_linedesc">this is a line</Desc>
+                    <Line size="2">
+                        <Endpoint index="1">
+                            <Lat>0.0030092586536039634</Lat>
+                            <Lon>-0.0040353037978433726</Lon>
+                        </Endpoint>
+                        <Endpoint index="2">
+                            <Lat>0.0041255109857561032</Lat>
+                            <Lon>-0.0038406233754897695</Lon>
+                        </Endpoint>
+                    </Line>
+                </GeoInfo>
+                <GeoInfo name="nested_poly">
+                    <Desc name="nested_polydesc">this is a polygon</Desc>
+                    <Polygon size="3">
+                        <Vertex index="1">
+                            <Lat>0.0019022331049687996</Lat>
+                            <Lon>-0.0042291176215286976</Lon>
+                        </Vertex>
+                        <Vertex index="2">
+                            <Lat>0.0030092586536039634</Lat>
+                            <Lon>-0.0040353037978433726</Lon>
+                        </Vertex>
+                        <Vertex index="3">
+                            <Lat>0.0041255109857561032</Lat>
+                            <Lon>-0.0038406233754897695</Lon>
+                        </Vertex>
+                    </Polygon>
+                </GeoInfo>
+            </GeoInfo>
         </GeoInfo>
     </GeoData>
     <Grid>

--- a/tests/data/example.sidd.xml
+++ b/tests/data/example.sidd.xml
@@ -236,6 +236,54 @@
                 <si:Lon>-0.0038406233754897695</si:Lon>
             </Vertex>
         </ValidData>
+        <si:GeoInfo name="root">
+            <si:Desc name="rootdesc">a description</si:Desc>
+            <si:Desc name="rootdesc2">another description</si:Desc>
+            <si:GeoInfo name="nested_point">
+                <si:Desc name="nested_pointdesc">this is a point</si:Desc>
+                <si:Point>
+                    <si:Lat>0.0041255109857561032</si:Lat>
+                    <si:Lon>-0.0038406233754897695</si:Lon>
+                </si:Point>
+                <si:GeoInfo name="nested_nested_point">
+                    <si:Desc name="nested_nested_pointdesc">this is a point in a point</si:Desc>
+                    <si:Point>
+                        <si:Lat>0.0041255109857561032</si:Lat>
+                        <si:Lon>-0.0038406233754897695</si:Lon>
+                    </si:Point>
+                </si:GeoInfo>
+            </si:GeoInfo>
+            <si:GeoInfo name="nested_line">
+                <si:Desc name="nested_linedesc">this is a line</si:Desc>
+                <si:Line size="2">
+                    <si:Endpoint index="1">
+                        <si:Lat>0.0030092586536039634</si:Lat>
+                        <si:Lon>-0.0040353037978433726</si:Lon>
+                    </si:Endpoint>
+                    <si:Endpoint index="2">
+                        <si:Lat>0.0041255109857561032</si:Lat>
+                        <si:Lon>-0.0038406233754897695</si:Lon>
+                    </si:Endpoint>
+                </si:Line>
+            </si:GeoInfo>
+            <si:GeoInfo name="nested_poly">
+                <si:Desc name="nested_polydesc">this is a polygon</si:Desc>
+                <si:Polygon size="3">
+                    <si:Vertex index="1">
+                        <si:Lat>0.0019022331049687996</si:Lat>
+                        <si:Lon>-0.0042291176215286976</si:Lon>
+                    </si:Vertex>
+                    <si:Vertex index="2">
+                        <si:Lat>0.0030092586536039634</si:Lat>
+                        <si:Lon>-0.0040353037978433726</si:Lon>
+                    </si:Vertex>
+                    <si:Vertex index="3">
+                        <si:Lat>0.0041255109857561032</si:Lat>
+                        <si:Lon>-0.0038406233754897695</si:Lon>
+                    </si:Vertex>
+                </si:Polygon>
+            </si:GeoInfo>
+        </si:GeoInfo>
     </GeoData>
     <Measurement>
         <PlaneProjection>

--- a/tests/io/complex/sicd_elements/test_sicd_elements_sicd.py
+++ b/tests/io/complex/sicd_elements/test_sicd_elements_sicd.py
@@ -6,10 +6,12 @@
 import copy
 import re
 
+import lxml.etree
 import numpy as np
 import pytest
 
-from sarpy.io.complex.sicd_elements import RgAzComp
+from sarpy.consistency import sicd_consistency
+from sarpy.io.complex.sicd_elements import RgAzComp, SICD
 
 
 def test_sicd_smoke_tests(sicd, rma_sicd, tol):
@@ -348,3 +350,26 @@ def test_can_project_coordinates_rma(rma_sicd, caplog):
     bad_rma_sicd.RMA.INCA = None
     bad_rma_sicd.can_project_coordinates()
     assert 'but the RMA.INCA parameter is not populated' in caplog.text
+
+
+def test_to_from_xml(tests_path, tmp_path):
+    """Ensure that XML nodes are preserved when going from XML, through SarPy, then back to XML."""
+    sicd_xml = tests_path / 'data/example.sicd.xml'
+    original_tree = lxml.etree.parse(str(sicd_xml))
+    original_read = SICD.SICDType.from_xml_file(sicd_xml)
+    assert sicd_consistency.evaluate_xml_versus_schema(sicd_xml.read_text(),
+                                                       lxml.etree.QName(original_tree.getroot()).namespace)
+
+    out_file = tmp_path / "read_then_write.xml"
+    xmlns_urn = lxml.etree.QName(original_tree.getroot()).namespace
+    out_file.write_text(original_read.to_xml_string(urn=xmlns_urn, check_validity=True))
+    reread_tree = lxml.etree.parse(str(out_file))
+    assert sicd_consistency.evaluate_xml_versus_schema(out_file.read_text(),
+                                                       lxml.etree.QName(reread_tree.getroot()).namespace)
+
+    original_nodes = {original_tree.getelementpath(x) for x in original_tree.iter()}
+    new_nodes = {reread_tree.getelementpath(x) for x in reread_tree.iter()}
+    orig_only = original_nodes - new_nodes
+    new_only = new_nodes - original_nodes
+    assert not orig_only
+    assert not new_only

--- a/tests/io/phase_history/cphd1_elements/test_cphd.py
+++ b/tests/io/phase_history/cphd1_elements/test_cphd.py
@@ -49,7 +49,10 @@ def test_cphdtype_to_from_xml(cphd_xml, tmp_path):
 
     original_nodes = {original_tree.getelementpath(x) for x in original_tree.iter()}
     new_nodes = {reread_tree.getelementpath(x) for x in reread_tree.iter()}
-    assert original_nodes == new_nodes
+    orig_only = original_nodes - new_nodes
+    new_only = new_nodes - original_nodes
+    assert not orig_only
+    assert not new_only
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Description
Someone reported that SARPy currently mishandles xml namespaces for SIDD's GeoInfo elements. This can be illustrated by running the new tests in `integration/1.3.59-rc`:

<details><summary>running new test in integration/1.3.59-rc</summary>

```
pytest tests/io/product/test_sidd.py::test_example_sidd
============================================================================================================================================================================== test session starts ==============================================================================================================================================================================
platform linux -- Python 3.11.9, pytest-8.3.2, pluggy-1.5.0
rootdir: /home/vscuser/git/glweb/software/third-party/sarpy
collected 1 item                                                                                                                                                                                                                                                                                                                                                                

tests/io/product/test_sidd.py F                                                                                                                                                                                                                                                                                                                                           [100%]

=================================================================================================================================================================================== FAILURES ====================================================================================================================================================================================
_______________________________________________________________________________________________________________________________________________________________________________ test_example_sidd _______________________________________________________________________________________________________________________________________________________________________________

tmp_path = PosixPath('/data/tmp/pytest-of-vscuser/pytest-502/test_example_sidd0'), sidd_etree = <lxml.etree._ElementTree object at 0x7fdd4373ff80>

    def test_example_sidd(tmp_path, sidd_etree):
>       _assert_to_from_xml(tmp_path, sidd_etree)

tests/io/product/test_sidd.py:127: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

tmp_path = PosixPath('/data/tmp/pytest-of-vscuser/pytest-502/test_example_sidd0'), sidd_etree = <lxml.etree._ElementTree object at 0x7fdd4373ff80>

    def _assert_to_from_xml(tmp_path, sidd_etree):
        """Ensure that XML nodes are preserved when going from XML, through SarPy, then back to XML."""
        original_tree = sidd_etree
        original_xml_str = lxml.etree.tostring(sidd_etree)
        original_read = sarpy_sidd.SIDDType.from_xml_string(original_xml_str)
        assert sidd_consistency.evaluate_xml_versus_schema(original_xml_str,
                                                           lxml.etree.QName(original_tree.getroot()).namespace)
    
        new_xml_str = original_read.to_xml_string(check_validity=True)
        out_file = tmp_path / "read_then_write.xml"
        out_file.write_text(new_xml_str)
        reread_tree = lxml.etree.parse(str(out_file))
        assert sidd_consistency.evaluate_xml_versus_schema(new_xml_str,
                                                           lxml.etree.QName(reread_tree.getroot()).namespace)
    
        original_nodes = {original_tree.getelementpath(x) for x in original_tree.iter()}
        new_nodes = {reread_tree.getelementpath(x) for x in reread_tree.iter()}
        orig_only = original_nodes - new_nodes
        new_only = new_nodes - original_nodes
>       assert not orig_only
E       AssertionError: assert not {'{urn:SIDD:2.0.0}GeoData/{urn:SICommon:1.0}GeoInfo', '{urn:SIDD:2.0.0}GeoData/{urn:SICommon:1.0}GeoInfo/{urn:SICommon...Desc', '{urn:SIDD:2.0.0}GeoData/{urn:SICommon:1.0}GeoInfo/{urn:SICommon:1.0}GeoInfo[1]/{urn:SICommon:1.0}GeoInfo', ...}

tests/io/product/test_sidd.py:122: AssertionError
============================================================================================================================================================================ short test summary info ============================================================================================================================================================================
FAILED tests/io/product/test_sidd.py::test_example_sidd - AssertionError: assert not {'{urn:SIDD:2.0.0}GeoData/{urn:SICommon:1.0}GeoInfo', '{urn:SIDD:2.0.0}GeoData/{urn:SICommon:1.0}GeoInfo/{urn:SICommon...Desc', '{urn:SIDD:2.0.0}GeoData/{urn:SICommon:1.0}GeoInfo/{urn:SICommon:1.0}GeoInfo[1]/{urn:SICommon:1.0}GeoInfo', ...}
=============================================================================================================================================================================== 1 failed in 0.94s ===============================================================================================================================================================================
                                                                                                                                                                                                                                                                                                                                                                                 

```

</details>

## Notes
- explicitly adds appropriate namespaces for SIDD GeoInfo in SARPy where missing
- `sarpy.io.complex.sicd_elements.GeoData.addGeoInfo` now calls instance method instead of class method so that SIDD subclass does not inadvertently call SICD methods
- a similar unittest was added for SICD for completeness