### PR TITLE
Cache glob results in GeoTIFF1DegList

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ release points are not being annotated in GitHub.
 - Erroneous SIDD consistency error re: NITF NBPP when PixelType=RGB24I
 - Properly recompute SCPCOA metadata when updating SCP using a DEM in `sarpy.io.complex.converter.conversion_utility`
 - SIDD GeoInfo namespace handling
+- Cache glob results in `GeoTIFF1DegList` to alleviate excessive filesystem load
 
 ## [1.3.58] - 2023-08-07
 ### Added


### PR DESCRIPTION
This stops sarpy from calling glob a bunch of times when accessing a DEM.  When the dem pattern has wildcards, this can result in   excessive filesystem load. 