### PR TITLE
add workflow for publishing to PyPI

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,0 +1,50 @@
+name: Publish to PyPI
+
+on: workflow_dispatch
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.x"
+    - name: Install pypa/build
+      run: >-
+        python3 -m
+        pip install
+        build
+        --user
+    - name: Build a binary wheel and a source tarball
+      run: python3 -m build
+    - name: Store the distribution packages
+      uses: actions/upload-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+
+  publish-to-pypi:
+    name: Publish to PyPI
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs:
+    - build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/sarpy
+
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
# Description
This PR introduces a github workflow for publishing to PyPI. The source was largely taken from the [python packaging user guide](https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/#the-whole-ci-cd-workflow) but with the following modifications:

- remove emoji
- remove `github-release` and ` publish-to-testpypi` steps
- set `<package-name>` to `sarpy`
- change trigger to `workflow_dispatch` (e.g. so that the action is only performed upon manual trigger)
- add `if:` directive to `publish-to-pypi` to reinforce the idea that a tag should be applied prior to publishing

Note: the target is `master` because "[This event](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflow_dispatch) will only trigger a workflow run if the workflow file is on the default branch."

A modified version of this workflow was tested in [`testrepo`](https://github.com/githubtestorg2/testrepo/blob/main/.github/workflows/pypi.yml)