### PR TITLE
Prepare release/1.3.59

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,0 +1,50 @@
+name: Publish to PyPI
+
+on: workflow_dispatch
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.x"
+    - name: Install pypa/build
+      run: >-
+        python3 -m
+        pip install
+        build
+        --user
+    - name: Build a binary wheel and a source tarball
+      run: python3 -m build
+    - name: Store the distribution packages
+      uses: actions/upload-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+
+  publish-to-pypi:
+    name: Publish to PyPI
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs:
+    - build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/sarpy
+
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ SarPy follows a continuous release process, so there are fairly frequent release
 Since essentially every (squash merge) commit corresponds to a release, specific 
 release points are not being annotated in GitHub.
 
-## [1.3.59-rc]
+## [1.3.59] - 2024-10-03
 ### Added
 - `noxfile.py`
 - TOA visualization to `sarpy/visualization/cphd_kmz_product_creation.py`

--- a/sarpy/__about__.py
+++ b/sarpy/__about__.py
@@ -27,7 +27,7 @@ __all__ = ['__version__',
            '__license__', '__copyright__']
 
 from sarpy.__details__ import __classification__, _post_identifier
-_version_number = '1.3.59rc'
+_version_number = '1.3.59'
 
 __version__ = _version_number + _post_identifier
 

--- a/tests/consistency/test_sidd_consistency.py
+++ b/tests/consistency/test_sidd_consistency.py
@@ -106,13 +106,14 @@ def rgb24i_sidd(good_sidd_xml_path):
     sidd_meta.Display.PixelType = "RGB24I"
     sidd_meta.Display.NumBands = 3
 
-    with tempfile.NamedTemporaryFile(delete=True) as sidd_file:
-        with SIDDWriter(sidd_file, sidd_meta=sidd_meta) as writer:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        sidd_file = pathlib.Path(tmpdir) / "tmp.sidd"
+        with SIDDWriter(str(sidd_file), sidd_meta=sidd_meta) as writer:
             rows = sidd_meta.Measurement.PixelFootprint.Row
             cols = sidd_meta.Measurement.PixelFootprint.Col
             image = numpy.random.default_rng().integers(1<<8, size=(rows, cols, 3), dtype=numpy.uint8)
             writer(image, start_indices=(0, 0))
-        yield sidd_file.name
+        yield str(sidd_file)
 
 
 def test_rgb24I_sidd(rgb24i_sidd):


### PR DESCRIPTION
# Description
[Release preparation PR](https://github.com/ngageoint/sarpy/wiki/Development-Cycle#preparing-for-release) for 1.3.59

- merges master
- updates version number and CHANGELOG
- tweaks tempfile handling in `test_sidd_consistency.py` to resolve windows issue

# Test Results

<details><summary>linux</summary>
<p>

```
SARPY_TEST_PATH=/data/sarpy_test/ nox
nox > Running session test(version='3.6')
nox > Creating conda env in .nox/test-version-3-6 with python
nox > conda install --yes --prefix /home/vscuser/git/glweb/software/third-party/sarpy/.nox/test-version-3-6 python=3.6
nox > python -m pip install '.[all]'
nox > pytest tests
============================================================================================================================================================================== test session starts ==============================================================================================================================================================================
platform linux -- Python 3.6.13, pytest-7.0.1, pluggy-1.0.0
rootdir: /home/vscuser/git/glweb/software/third-party/sarpy
collected 800 items
...
... <truncated due to github character limit>
...
=============================================================================================================================================================================== warnings summary ================================================================================================================================================================================
tests/geometry/test_geometry_elements.py: 77 warnings
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/geometry/geometry_elements.py:131: DeprecationWarning: Arrays of 2-dimensional vectors are deprecated. Use arrays of 3-dimensional vectors instead. (deprecated in NumPy 2.0)
    dir_cross = float(numpy.cross(R, S))  # the scalar cross product of the direction vectors

tests/geometry/test_geometry_elements.py: 43 warnings
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/geometry/geometry_elements.py:137: DeprecationWarning: Arrays of 2-dimensional vectors are deprecated. Use arrays of 3-dimensional vectors instead. (deprecated in NumPy 2.0)
    end_cross_0 = float(numpy.cross(Q-P, S))

tests/geometry/test_geometry_elements.py: 43 warnings
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/geometry/geometry_elements.py:138: DeprecationWarning: Arrays of 2-dimensional vectors are deprecated. Use arrays of 3-dimensional vectors instead. (deprecated in NumPy 2.0)
    end_cross_1 = float(numpy.cross(Q-P, R))

tests/geometry/test_point_projection.py::test_image_to_ground_errors
tests/geometry/test_point_projection.py::test_image_to_ground_dem
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/geometry/point_projection.py:1882: RuntimeWarning: divide by zero encountered in scalar divide
    lon_grid_size = min(10, lat_grid_size/abs(numpy.sin(numpy.deg2rad(ref_llh[0]))))

tests/test_class_string.py::TestClassString::test_class_str
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/annotation/afrl_rde_schema/__init__.py:7: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
    import pkg_resources

tests/visualization/test_kmz_product_creation.py::test_create_kmz[True]
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/visualization/kmz_utils.py:145: RuntimeWarning: invalid value encountered in scalar divide
    distance = (

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================================================================================================================================================== 790 passed, 9 skipped, 1 xfailed, 167 warnings in 54.61s ============================================================================================================================================================
nox > Session test(version='3.11') was successful.
nox > Ran multiple sessions:
nox > * test(version='3.6'): success
nox > * test(version='3.11'): success
```

</p>
</details> 

<details><summary>Windows</summary>
<p>

```
(sarpytest) PS C:\Users\dpressler\git\github\pressler-vsc\sarpy> nox
nox > Running session test(version='3.6')
nox > Creating conda env in .nox\test-version-3-6 with python
nox > conda install --yes --prefix 'C:\Users\dpressler\git\github\pressler-vsc\sarpy\.nox\test-version-3-6' python=3.6
nox > python -m pip install '.[all]'
nox > pytest tests
=================================================================== test session starts ====================================================================
platform win32 -- Python 3.6.13, pytest-7.0.1, pluggy-1.0.0
rootdir: C:\Users\dpressler\git\github\pressler-vsc\sarpy
collected 800 items
...
... <truncated>
...
===================================================================== warnings summary =====================================================================
tests/geometry/test_geometry_elements.py: 77 warnings
  C:\Users\dpressler\git\github\pressler-vsc\sarpy\sarpy\geometry\geometry_elements.py:131: DeprecationWarning: Arrays of 2-dimensional vectors are deprecated. Use arrays of 3-dimensional vectors instead. (deprecated in NumPy 2.0)
    dir_cross = float(numpy.cross(R, S))  # the scalar cross product of the direction vectors

tests/geometry/test_geometry_elements.py: 43 warnings
  C:\Users\dpressler\git\github\pressler-vsc\sarpy\sarpy\geometry\geometry_elements.py:137: DeprecationWarning: Arrays of 2-dimensional vectors are deprecated. Use arrays of 3-dimensional vectors instead. (deprecated in NumPy 2.0)
    end_cross_0 = float(numpy.cross(Q-P, S))

tests/geometry/test_geometry_elements.py: 43 warnings
  C:\Users\dpressler\git\github\pressler-vsc\sarpy\sarpy\geometry\geometry_elements.py:138: DeprecationWarning: Arrays of 2-dimensional vectors are deprecated. Use arrays of 3-dimensional vectors instead. (deprecated in NumPy 2.0)
    end_cross_1 = float(numpy.cross(Q-P, R))

tests/geometry/test_point_projection.py::test_image_to_ground_errors
tests/geometry/test_point_projection.py::test_image_to_ground_dem
  C:\Users\dpressler\git\github\pressler-vsc\sarpy\sarpy\geometry\point_projection.py:1882: RuntimeWarning: divide by zero encountered in scalar divide
    lon_grid_size = min(10, lat_grid_size/abs(numpy.sin(numpy.deg2rad(ref_llh[0]))))

tests/test_class_string.py::TestClassString::test_class_str
  C:\Users\dpressler\git\github\pressler-vsc\sarpy\sarpy\annotation\afrl_rde_schema\__init__.py:7: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
    import pkg_resources

tests/visualization/test_kmz_product_creation.py::test_create_kmz[True]
  C:\Users\dpressler\git\github\pressler-vsc\sarpy\sarpy\visualization\kmz_utils.py:145: RuntimeWarning: invalid value encountered in scalar divide
    distance = (

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================= 790 passed, 9 skipped, 1 xfailed, 167 warnings in 48.26s =================================================
nox > Session test(version='3.11') was successful.
nox > Ran multiple sessions:
nox > * test(version='3.6'): success
nox > * test(version='3.11'): success
```


</p>
</details> 
