### PR TITLE
Bugfix: SIDD ProductProcessing handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ SarPy follows a continuous release process, so there are fairly frequent release
 Since essentially every (squash merge) commit corresponds to a release, specific 
 release points are not being annotated in GitHub.
 
+## [1.3.60]
+### Fixed
+- SIDD ProductProcessing handling
+
 ## [1.3.59] - 2024-10-03
 ### Added
 - `noxfile.py`

--- a/sarpy/__about__.py
+++ b/sarpy/__about__.py
@@ -27,7 +27,7 @@ __all__ = ['__version__',
            '__license__', '__copyright__']
 
 from sarpy.__details__ import __classification__, _post_identifier
-_version_number = '1.3.60.dev0'
+_version_number = '1.3.60.dev1'
 
 __version__ = _version_number + _post_identifier
 

--- a/sarpy/io/product/sidd2_elements/ProductProcessing.py
+++ b/sarpy/io/product/sidd2_elements/ProductProcessing.py
@@ -129,7 +129,7 @@ class ProcessingModuleType(Serializable):
         return super(ProcessingModuleType, cls).from_node(node, xml_ns, ns_key=ns_key, kwargs=kwargs)
 
     def to_node(self, doc, tag, ns_key=None, parent=None, check_validity=False, strict=DEFAULT_STRICT, exclude=()):
-        exclude = exclude + ('ModuleName', 'name', 'ProcessingModules')
+        exclude = exclude + ('ModuleName', 'name', 'ProcessingModules', 'ModuleParameters')
         node = super(ProcessingModuleType, self).to_node(
             doc, tag, ns_key=ns_key, parent=parent, check_validity=check_validity, strict=strict, exclude=exclude)
         # add the ModuleName and name children
@@ -139,6 +139,9 @@ class ProcessingModuleType(Serializable):
             mn_node = create_text_node(doc, mn_tag, self.ModuleName, parent=node)
             if self.name is not None:
                 mn_node.attrib['name'] = self.name
+        # add ModuleParameters
+        if self.ModuleParameters:
+            self.ModuleParameters.to_node(doc, ns_key=ns_key, parent=node, strict=strict)
         # add the ProcessingModule children
         pm_key = self._child_xml_ns_key.get('ProcessingModules', ns_key)
         for entry in self._ProcessingModules:
@@ -147,7 +150,6 @@ class ProcessingModuleType(Serializable):
 
     def to_dict(self, check_validity=False, strict=DEFAULT_STRICT, exclude=()):
         out = super(ProcessingModuleType, self).to_dict(check_validity=check_validity, strict=strict, exclude=exclude)
-        # slap on the GeoInfo children
         if len(self.ProcessingModules) > 0:
             out['ProcessingModules'] = [
                 entry.to_dict(check_validity=check_validity, strict=strict) for entry in self._ProcessingModules]

--- a/tests/data/example.sidd.xml
+++ b/tests/data/example.sidd.xml
@@ -527,4 +527,27 @@
             <North>-170</North>
         </Product>
     </ExploitationFeatures>
+    <ProductProcessing>
+        <ProcessingModule>
+            <ModuleName name="name_only">only!</ModuleName>
+        </ProcessingModule>
+        <ProcessingModule>
+            <ModuleName name="n1">1</ModuleName>
+            <ModuleParameter name="p1">v1.1</ModuleParameter>
+            <ModuleParameter name="p2">v1.2</ModuleParameter>
+        </ProcessingModule>
+        <ProcessingModule>
+            <ModuleName name="n2">2</ModuleName>
+            <ProcessingModule>
+                <ModuleName name="n2.1">2.1</ModuleName>
+                <ModuleParameter name="p2.1">v2.1.1</ModuleParameter>
+                <ModuleParameter name="p2.2">v2.1.2</ModuleParameter>
+            </ProcessingModule>
+            <ProcessingModule>
+                <ModuleName name="n2.2">2.2</ModuleName>
+                <ModuleParameter name="p1">v2.2.1</ModuleParameter>
+                <ModuleParameter name="p2">v2.2.2</ModuleParameter>
+            </ProcessingModule>
+        </ProcessingModule>
+    </ProductProcessing>
 </SIDD>


### PR DESCRIPTION
# Description
While trying to write out SIDD XML with a ProductProcessing element, I found that SARPy was not properly forming the XML (ModuleParameter is being put before ModuleName). The bug can be illustrated by running the new tests from master:

```
pytest tests/io/product/test_sidd.py::test_example_sidd
=========================================================================== test session starts ============================================================================
platform linux -- Python 3.11.9, pytest-8.3.2, pluggy-1.5.0
rootdir: /home/vscuser/git/glweb/software/third-party/sarpy
collected 1 item                                                                                                                                                           

tests/io/product/test_sidd.py F                                                                                                                                      [100%]

================================================================================= FAILURES =================================================================================
____________________________________________________________________________ test_example_sidd _____________________________________________________________________________

tmp_path = PosixPath('/data/tmp/pytest-of-vscuser/pytest-593/test_example_sidd0'), sidd_etree = <lxml.etree._ElementTree object at 0x7ff739521000>

    def test_example_sidd(tmp_path, sidd_etree):
>       _assert_to_from_xml(tmp_path, sidd_etree)

tests/io/product/test_sidd.py:128: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

tmp_path = PosixPath('/data/tmp/pytest-of-vscuser/pytest-593/test_example_sidd0'), sidd_etree = <lxml.etree._ElementTree object at 0x7ff739521000>

    def _assert_to_from_xml(tmp_path, sidd_etree):
        """Ensure that XML nodes are preserved when going from XML, through SarPy, then back to XML."""
        original_tree = sidd_etree
        original_xml_str = lxml.etree.tostring(sidd_etree)
        original_read = sarpy_sidd.SIDDType.from_xml_string(original_xml_str)
        assert sidd_consistency.evaluate_xml_versus_schema(original_xml_str,
                                                           lxml.etree.QName(original_tree.getroot()).namespace)
    
        new_xml_str = original_read.to_xml_string(check_validity=True)
        out_file = tmp_path / "read_then_write.xml"
        out_file.write_text(new_xml_str)
        reread_tree = lxml.etree.parse(str(out_file))
>       assert sidd_consistency.evaluate_xml_versus_schema(new_xml_str,
                                                           lxml.etree.QName(reread_tree.getroot()).namespace)
E       assert False
E        +  where False = <function evaluate_xml_versus_schema at 0x7ff7392804a0>('<SIDD xmlns="urn:SIDD:2.0.0" xmlns:sicommon="urn:SICommon:1.0" xmlns:sfa="urn:SFA:1.2.0" 
xmlns:ism="urn:us:gov:ic:ism...uleParameter><ModuleName name="n2.2">2.2</ModuleName></ProcessingModule></ProcessingModule></ProductProcessing></SIDD>', 'urn:SIDD:2.0.0')   E        +    where <function evaluate_xml_versus_schema at 0x7ff7392804a0> = sidd_consistency.evaluate_xml_versus_schema
E        +    and   'urn:SIDD:2.0.0' = <lxml.etree.QName object at 0x7ff739257d80>.namespace
E        +      where <lxml.etree.QName object at 0x7ff739257d80> = <class 'lxml.etree.QName'>(<Element {urn:SIDD:2.0.0}SIDD at 0x7ff739520340>)
E        +        where <class 'lxml.etree.QName'> = <module 'lxml.etree' from '/home/vscuser/miniconda3/envs/sarpy/lib/python3.11/site-packages/lxml/etree.cpython-311-x86_
64-linux-gnu.so'>.QName                                                                                                                                                     E        +          where <module 'lxml.etree' from '/home/vscuser/miniconda3/envs/sarpy/lib/python3.11/site-packages/lxml/etree.cpython-311-x86_64-linux-gnu.so'> = lxml.et
ree                                                                                                                                                                         E        +        and   <Element {urn:SIDD:2.0.0}SIDD at 0x7ff739520340> = getroot()
E        +          where getroot = <lxml.etree._ElementTree object at 0x7ff7397bfe00>.getroot

tests/io/product/test_sidd.py:116: AssertionError
---------------------------------------------------------------------------- Captured log call -----------------------------------------------------------------------------
ERROR    validation:base.py:258 XML validation error on line 1
        b"Element '{urn:SIDD:2.0.0}ModuleParameter': This element is not expected. Expected is ( {urn:SIDD:2.0.0}ModuleName )."
ERROR    validation:base.py:258 XML validation error on line 1
        b"Element '{urn:SIDD:2.0.0}ModuleParameter': This element is not expected. Expected is ( {urn:SIDD:2.0.0}ModuleName )."
ERROR    validation:base.py:258 XML validation error on line 1
        b"Element '{urn:SIDD:2.0.0}ModuleParameter': This element is not expected. Expected is ( {urn:SIDD:2.0.0}ModuleName )."
========================================================================= short test summary info ==========================================================================
FAILED tests/io/product/test_sidd.py::test_example_sidd - assert False
============================================================================ 1 failed in 0.87s =============================================================================                                                                                                                                                                            

```


# Test Plan
<details><summary>tests now pass</summary>

```
SARPY_TEST_PATH=/data/sarpy_test/ nox
nox > Running session test(version='3.6')
nox > Creating conda env in .nox/test-version-3-6 with python
nox > conda install --yes --prefix /home/vscuser/git/glweb/software/third-party/sarpy/.nox/test-version-3-6 python=3.6
nox > python -m pip install '.[all]'
nox > pytest tests
=========================================================================== test session starts ============================================================================
platform linux -- Python 3.6.13, pytest-7.0.1, pluggy-1.0.0
rootdir: /home/vscuser/git/glweb/software/third-party/sarpy
collected 801 items                                                                                                                                                        

tests/test_class_string.py .                                                                                                                                         [  0%]
tests/consistency/test_consistency.py ........                                                                                                                       [  1%]
tests/consistency/test_cphd_consistency.py ..............................................................                                                            [  8%]
tests/consistency/test_sicd_consistency.py ...                                                                                                                       [  9%]
tests/consistency/test_sidd_consistency.py .....                                                                                                                     [  9%]
tests/geometry/test_geocoords.py ..........                                                                                                                          [ 11%]
tests/geometry/test_geometry_elements.py ..........                                                                                                                  [ 12%]
tests/geometry/test_latlon.py ...                                                                                                                                    [ 12%]
tests/geometry/test_point_projection.py ..............                                                                                                               [ 14%]
tests/io/test_kml.py .                                                                                                                                               [ 14%]
tests/io/DEM/test_dted.py ..                                                                                                                                         [ 14%]
tests/io/DEM/test_geoid.py .                                                                                                                                         [ 14%]
tests/io/DEM/test_geotiff1deg_list.py ....                                                                                                                           [ 15%]
tests/io/DEM/test_geotiff1deg_reader.py ........                                                                                                                     [ 16%]
tests/io/complex/test_other_nitf.py ...                                                                                                                              [ 16%]
tests/io/complex/test_reader.py ..sss.ssss.                                                                                                                          [ 18%]
tests/io/complex/test_remote.py s                                                                                                                                    [ 18%]
tests/io/complex/test_sicd.py .                                                                                                                                      [ 18%]
tests/io/complex/test_sio.py .                                                                                                                                       [ 18%]
tests/io/complex/test_utils.py .                                                                                                                                     [ 18%]
tests/io/complex/sicd_elements/test_sicd_elements_antenna.py ...                                                                                                     [ 19%]
tests/io/complex/sicd_elements/test_sicd_elements_base.py ...                                                                                                        [ 19%]
tests/io/complex/sicd_elements/test_sicd_elements_blocks.py .....................                                                                                    [ 22%]
tests/io/complex/sicd_elements/test_sicd_elements_collectioninfo.py ..                                                                                               [ 22%]
tests/io/complex/sicd_elements/test_sicd_elements_errorstatistics.py .                                                                                               [ 22%]
tests/io/complex/sicd_elements/test_sicd_elements_geodata.py ...                                                                                                     [ 22%]
tests/io/complex/sicd_elements/test_sicd_elements_grid.py ..                                                                                                         [ 23%]
tests/io/complex/sicd_elements/test_sicd_elements_imagecreation.py .                                                                                                 [ 23%]
tests/io/complex/sicd_elements/test_sicd_elements_imagedata.py .                                                                                                     [ 23%]
tests/io/complex/sicd_elements/test_sicd_elements_imageformation.py ......                                                                                           [ 24%]
tests/io/complex/sicd_elements/test_sicd_elements_matchinfo.py .                                                                                                     [ 24%]
tests/io/complex/sicd_elements/test_sicd_elements_pfa.py .                                                                                                           [ 24%]
tests/io/complex/sicd_elements/test_sicd_elements_position.py ...                                                                                                    [ 24%]
tests/io/complex/sicd_elements/test_sicd_elements_radarcollection.py ..............                                                                                  [ 26%]
tests/io/complex/sicd_elements/test_sicd_elements_radiometric.py .                                                                                                   [ 26%]
tests/io/complex/sicd_elements/test_sicd_elements_rgazcomp.py .                                                                                                      [ 26%]
tests/io/complex/sicd_elements/test_sicd_elements_rma.py ...                                                                                                         [ 27%]
tests/io/complex/sicd_elements/test_sicd_elements_scpcoa.py ...................                                                                                      [ 29%]
tests/io/complex/sicd_elements/test_sicd_elements_sicd.py ...................................                                                                        [ 33%]
tests/io/complex/sicd_elements/test_sicd_elements_timeline.py ..................                                                                                     [ 36%]
tests/io/complex/sicd_elements/test_sicd_elements_utils.py ...                                                                                                       [ 36%]
tests/io/general/test_base.py ...                                                                                                                                    [ 36%]
tests/io/general/test_data_segment.py ..........                                                                                                                     [ 38%]
tests/io/general/test_format_function.py ........                                                                                                                    [ 39%]
tests/io/general/test_nitf.py ..                                                                                                                                     [ 39%]
tests/io/general/test_nitf_headers.py .                                                                                                                              [ 39%]
tests/io/general/test_nitf_image.py ....                                                                                                                             [ 39%]
tests/io/general/test_tre.py ...                                                                                                                                     [ 40%]
tests/io/phase_history/test_cphd.py .......                                                                                                                          [ 41%]
tests/io/phase_history/test_cphd_versions.py .....                                                                                                                   [ 41%]
tests/io/phase_history/cphd1_elements/test_cphd.py ......                                                                                                            [ 42%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_antenna.py .....                                                                                           [ 43%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_blocks.py ....                                                                                             [ 43%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_channel.py .                                                                                               [ 43%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_data.py .                                                                                                  [ 43%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_dwell.py .                                                                                                 [ 44%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_geoinfo.py ...                                                                                             [ 44%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_global.py ..                                                                                               [ 44%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_pvp.py .                                                                                                   [ 44%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_referencegeometry.py .                                                                                     [ 44%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_supportarray.py ..                                                                                         [ 45%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_txrcv.py .                                                                                                 [ 45%]
tests/io/phase_history/cphd1_elements/test_utils.py .                                                                                                                [ 45%]
tests/io/product/test_reader.py ...s                                                                                                                                 [ 45%]
tests/io/product/test_sidd.py ..............                                                                                                                         [ 47%]
tests/io/product/test_sidd_schema.py .........                                                                                                                       [ 48%]
tests/io/product/test_sidd_writing.py ..                                                                                                                             [ 49%]
tests/io/product/sidd1_elements/test_exploitationfeatures.py .........................................................                                               [ 56%]
tests/io/product/sidd2_elements/test_exploitationfeatures.py ....................................................................                                    [ 64%]
tests/io/product/sidd3_elements/test_exploitationfeatures.py ....................................................................................................... [ 77%]
..............................................................................................................................                                       [ 93%]
tests/io/product/sidd3_elements/test_sidd3_elements.py .....                                                                                                         [ 93%]
tests/io/received/test_crsd.py .                                                                                                                                     [ 94%]
tests/processing/sicd/test_spectral_taper.py ........ss...........                                                                                                   [ 96%]
tests/utils/test_sicd_sidelobe_control.py ..                                                                                                                         [ 96%]
tests/visualization/test_cphd_kmz_product_creation.py ..                                                                                                             [ 97%]
tests/visualization/test_crsd_kmz_product_creation.py .                                                                                                              [ 97%]
tests/visualization/test_kmz_product_creation.py .x                                                                                                                  [ 97%]
tests/visualization/test_remap.py ....................                                                                                                               [100%]

============================================================================= warnings summary =============================================================================
tests/geometry/test_point_projection.py::test_image_to_ground_errors
tests/geometry/test_point_projection.py::test_image_to_ground_dem
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/geometry/point_projection.py:1882: RuntimeWarning: divide by zero encountered in double_scalars
    lon_grid_size = min(10, lat_grid_size/abs(numpy.sin(numpy.deg2rad(ref_llh[0]))))

tests/visualization/test_kmz_product_creation.py::test_create_kmz[True]
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/visualization/kmz_utils.py:169: RuntimeWarning: invalid value encountered in double_scalars
    + dir_z**2 * semiaxis_a**2 * semiaxis_b**2

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================= 789 passed, 11 skipped, 1 xfailed, 3 warnings in 43.69s ==========================================================
nox > Session test(version='3.6') was successful.
nox > Running session test(version='3.11')
nox > Creating conda env in .nox/test-version-3-11 with python
nox > conda install --yes --prefix /home/vscuser/git/glweb/software/third-party/sarpy/.nox/test-version-3-11 python=3.11
nox > python -m pip install '.[all]'
nox > pytest tests
=========================================================================== test session starts ============================================================================
platform linux -- Python 3.11.10, pytest-8.3.3, pluggy-1.5.0
rootdir: /home/vscuser/git/glweb/software/third-party/sarpy
collected 801 items                                                                                                                                                        

tests/consistency/test_consistency.py ........                                                                                                                       [  0%]
tests/consistency/test_cphd_consistency.py ..............................................................                                                            [  8%]
tests/consistency/test_sicd_consistency.py ...                                                                                                                       [  9%]
tests/consistency/test_sidd_consistency.py .....                                                                                                                     [  9%]
tests/geometry/test_geocoords.py ..........                                                                                                                          [ 10%]
tests/geometry/test_geometry_elements.py ..........                                                                                                                  [ 12%]
tests/geometry/test_latlon.py ...                                                                                                                                    [ 12%]
tests/geometry/test_point_projection.py ..............                                                                                                               [ 14%]
tests/io/DEM/test_dted.py ..                                                                                                                                         [ 14%]
tests/io/DEM/test_geoid.py .                                                                                                                                         [ 14%]
tests/io/DEM/test_geotiff1deg_list.py ....                                                                                                                           [ 15%]
tests/io/DEM/test_geotiff1deg_reader.py ........                                                                                                                     [ 16%]
tests/io/complex/sicd_elements/test_sicd_elements_antenna.py ...                                                                                                     [ 16%]
tests/io/complex/sicd_elements/test_sicd_elements_base.py ...                                                                                                        [ 16%]
tests/io/complex/sicd_elements/test_sicd_elements_blocks.py .....................                                                                                    [ 19%]
tests/io/complex/sicd_elements/test_sicd_elements_collectioninfo.py ..                                                                                               [ 19%]
tests/io/complex/sicd_elements/test_sicd_elements_errorstatistics.py .                                                                                               [ 19%]
tests/io/complex/sicd_elements/test_sicd_elements_geodata.py ...                                                                                                     [ 20%]
tests/io/complex/sicd_elements/test_sicd_elements_grid.py ..                                                                                                         [ 20%]
tests/io/complex/sicd_elements/test_sicd_elements_imagecreation.py .                                                                                                 [ 20%]
tests/io/complex/sicd_elements/test_sicd_elements_imagedata.py .                                                                                                     [ 20%]
tests/io/complex/sicd_elements/test_sicd_elements_imageformation.py ......                                                                                           [ 21%]
tests/io/complex/sicd_elements/test_sicd_elements_matchinfo.py .                                                                                                     [ 21%]
tests/io/complex/sicd_elements/test_sicd_elements_pfa.py .                                                                                                           [ 21%]
tests/io/complex/sicd_elements/test_sicd_elements_position.py ...                                                                                                    [ 22%]
tests/io/complex/sicd_elements/test_sicd_elements_radarcollection.py ..............                                                                                  [ 23%]
tests/io/complex/sicd_elements/test_sicd_elements_radiometric.py .                                                                                                   [ 24%]
tests/io/complex/sicd_elements/test_sicd_elements_rgazcomp.py .                                                                                                      [ 24%]
tests/io/complex/sicd_elements/test_sicd_elements_rma.py ...                                                                                                         [ 24%]
tests/io/complex/sicd_elements/test_sicd_elements_scpcoa.py ...................                                                                                      [ 26%]
tests/io/complex/sicd_elements/test_sicd_elements_sicd.py ...................................                                                                        [ 31%]
tests/io/complex/sicd_elements/test_sicd_elements_timeline.py ..................                                                                                     [ 33%]
tests/io/complex/sicd_elements/test_sicd_elements_utils.py ...                                                                                                       [ 33%]
tests/io/complex/test_other_nitf.py ...                                                                                                                              [ 34%]
tests/io/complex/test_reader.py ..sss.ssss.                                                                                                                          [ 35%]
tests/io/complex/test_remote.py s                                                                                                                                    [ 35%]
tests/io/complex/test_sicd.py .                                                                                                                                      [ 35%]
tests/io/complex/test_sio.py .                                                                                                                                       [ 36%]
tests/io/complex/test_utils.py .                                                                                                                                     [ 36%]
tests/io/general/test_base.py ...                                                                                                                                    [ 36%]
tests/io/general/test_data_segment.py ..........                                                                                                                     [ 37%]
tests/io/general/test_format_function.py ........                                                                                                                    [ 38%]
tests/io/general/test_nitf.py ..                                                                                                                                     [ 39%]
tests/io/general/test_nitf_headers.py .                                                                                                                              [ 39%]
tests/io/general/test_nitf_image.py ....                                                                                                                             [ 39%]
tests/io/general/test_tre.py ...                                                                                                                                     [ 40%]
tests/io/phase_history/cphd1_elements/test_cphd.py ......                                                                                                            [ 40%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_antenna.py .....                                                                                           [ 41%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_blocks.py ....                                                                                             [ 41%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_channel.py .                                                                                               [ 42%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_data.py .                                                                                                  [ 42%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_dwell.py .                                                                                                 [ 42%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_geoinfo.py ...                                                                                             [ 42%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_global.py ..                                                                                               [ 42%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_pvp.py .                                                                                                   [ 43%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_referencegeometry.py .                                                                                     [ 43%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_supportarray.py ..                                                                                         [ 43%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_txrcv.py .                                                                                                 [ 43%]
tests/io/phase_history/cphd1_elements/test_utils.py .                                                                                                                [ 43%]
tests/io/phase_history/test_cphd.py .......                                                                                                                          [ 44%]
tests/io/phase_history/test_cphd_versions.py .....                                                                                                                   [ 45%]
tests/io/product/sidd1_elements/test_exploitationfeatures.py .........................................................                                               [ 52%]
tests/io/product/sidd2_elements/test_exploitationfeatures.py ....................................................................                                    [ 60%]
tests/io/product/sidd3_elements/test_exploitationfeatures.py ....................................................................................................... [ 73%]
..............................................................................................................................                                       [ 89%]
tests/io/product/sidd3_elements/test_sidd3_elements.py .....                                                                                                         [ 90%]
tests/io/product/test_reader.py ...s                                                                                                                                 [ 90%]
tests/io/product/test_sidd.py ..............                                                                                                                         [ 92%]
tests/io/product/test_sidd_schema.py .........                                                                                                                       [ 93%]
tests/io/product/test_sidd_writing.py ..                                                                                                                             [ 93%]
tests/io/received/test_crsd.py .                                                                                                                                     [ 93%]
tests/io/test_kml.py .                                                                                                                                               [ 93%]
tests/processing/sicd/test_spectral_taper.py .....................                                                                                                   [ 96%]
tests/test_class_string.py .                                                                                                                                         [ 96%]
tests/utils/test_sicd_sidelobe_control.py ..                                                                                                                         [ 96%]
tests/visualization/test_cphd_kmz_product_creation.py ..                                                                                                             [ 97%]
tests/visualization/test_crsd_kmz_product_creation.py .                                                                                                              [ 97%]
tests/visualization/test_kmz_product_creation.py .x                                                                                                                  [ 97%]
tests/visualization/test_remap.py ....................                                                                                                               [100%]

============================================================================= warnings summary =============================================================================
tests/geometry/test_geometry_elements.py: 77 warnings
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/geometry/geometry_elements.py:131: DeprecationWarning: Arrays of 2-dimensional vectors are deprecated. Use arrays
 of 3-dimensional vectors instead. (deprecated in NumPy 2.0)                                                                                                                    dir_cross = float(numpy.cross(R, S))  # the scalar cross product of the direction vectors

tests/geometry/test_geometry_elements.py: 43 warnings
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/geometry/geometry_elements.py:137: DeprecationWarning: Arrays of 2-dimensional vectors are deprecated. Use arrays
 of 3-dimensional vectors instead. (deprecated in NumPy 2.0)                                                                                                                    end_cross_0 = float(numpy.cross(Q-P, S))

tests/geometry/test_geometry_elements.py: 43 warnings
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/geometry/geometry_elements.py:138: DeprecationWarning: Arrays of 2-dimensional vectors are deprecated. Use arrays
 of 3-dimensional vectors instead. (deprecated in NumPy 2.0)                                                                                                                    end_cross_1 = float(numpy.cross(Q-P, R))

tests/geometry/test_point_projection.py::test_image_to_ground_errors
tests/geometry/test_point_projection.py::test_image_to_ground_dem
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/geometry/point_projection.py:1882: RuntimeWarning: divide by zero encountered in scalar divide
    lon_grid_size = min(10, lat_grid_size/abs(numpy.sin(numpy.deg2rad(ref_llh[0]))))

tests/test_class_string.py::TestClassString::test_class_str
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/annotation/afrl_rde_schema/__init__.py:7: DeprecationWarning: pkg_resources is deprecated as an API. See https://
setuptools.pypa.io/en/latest/pkg_resources.html                                                                                                                                 import pkg_resources

tests/visualization/test_kmz_product_creation.py::test_create_kmz[True]
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/visualization/kmz_utils.py:145: RuntimeWarning: invalid value encountered in scalar divide
    distance = (

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================= 791 passed, 9 skipped, 1 xfailed, 167 warnings in 31.04s =========================================================
nox > Session test(version='3.11') was successful.
nox > Ran multiple sessions:
nox > * test(version='3.6'): success
nox > * test(version='3.11'): success

```

</details>