### PR TITLE
Bugfix: account for timezones in generated datetimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ SarPy follows a continuous release process, so there are fairly frequent release
 Since essentially every (squash merge) commit corresponds to a release, specific 
 release points are not being annotated in GitHub.
 
+## [1.3.60]
+### Fixed
+- Account for timezones in generated datetimes
+
 ## [1.3.59] - 2024-10-03
 ### Added
 - `noxfile.py`

--- a/sarpy/__about__.py
+++ b/sarpy/__about__.py
@@ -27,7 +27,7 @@ __all__ = ['__version__',
            '__license__', '__copyright__']
 
 from sarpy.__details__ import __classification__, _post_identifier
-_version_number = '1.3.60.dev0'
+_version_number = '1.3.60.dev1'
 
 __version__ = _version_number + _post_identifier
 

--- a/sarpy/io/complex/sicd.py
+++ b/sarpy/io/complex/sicd.py
@@ -8,7 +8,7 @@ __author__ = "Thomas McCullough"
 
 import re
 import logging
-from datetime import datetime
+import datetime
 from typing import BinaryIO, Union, Optional, Dict, Tuple, Sequence
 
 import numpy
@@ -475,15 +475,17 @@ def validate_sicd_for_writing(sicd_meta: SICDType) -> SICDType:
     sicd_meta = sicd_meta.copy()
 
     profile = '{} {}'.format(__title__, __version__)
+    # use naive datetime because numpy warns about parsing timezone aware
+    now = numpy.datetime64(datetime.datetime.now(tz=datetime.timezone.utc).replace(tzinfo=None))
     if sicd_meta.ImageCreation is None:
         sicd_meta.ImageCreation = ImageCreationType(
             Application=profile,
-            DateTime=numpy.datetime64(datetime.now()),
+            DateTime=now,
             Profile=profile)
     else:
         sicd_meta.ImageCreation.Profile = profile
         if sicd_meta.ImageCreation.DateTime is None:
-            sicd_meta.ImageCreation.DateTime = numpy.datetime64(datetime.now())
+            sicd_meta.ImageCreation.DateTime = now
     return sicd_meta
 
 

--- a/sarpy/io/product/sidd1_elements/ProductCreation.py
+++ b/sarpy/io/product/sidd1_elements/ProductCreation.py
@@ -5,8 +5,8 @@ The ProductCreationType definition for version 1.0.
 __classification__ = "UNCLASSIFIED"
 __author__ = "Thomas McCullough"
 
+import datetime
 from typing import Union
-from datetime import datetime
 
 import numpy
 
@@ -207,7 +207,7 @@ class ProductClassificationType(Serializable):
         clas = extract_classification_from_sicd(sicd)
 
         if create_date is None:
-            create_date = datetime.now().strftime('%Y-%m-%d')
+            create_date = datetime.datetime.now(tz=datetime.timezone.utc).date().isoformat()
 
         return cls(classification=clas, createDate=create_date)
 
@@ -294,9 +294,11 @@ class ProductCreationType(Serializable):
 
         from sarpy.__about__ import __title__, __version__
 
+        # use naive datetime because numpy warns about parsing timezone aware
+        now = numpy.datetime64(datetime.datetime.now(tz=datetime.timezone.utc).replace(tzinfo=None))
         proc_info = ProcessorInformationType(
             Application='{} {}'.format(__title__, __version__),
-            ProcessingDateTime=numpy.datetime64(datetime.now()),
+            ProcessingDateTime=now,
             Site='Unknown')
         classification = ProductClassificationType.from_sicd(sicd)
         return cls(ProcessorInformation=proc_info,

--- a/sarpy/io/product/sidd2_elements/DownstreamReprocessing.py
+++ b/sarpy/io/product/sidd2_elements/DownstreamReprocessing.py
@@ -5,8 +5,8 @@ The DownstreamReprocessingType definition.
 __classification__ = "UNCLASSIFIED"
 __author__ = "Thomas McCullough"
 
+import datetime
 from typing import Union, List
-from datetime import datetime
 
 import numpy
 
@@ -116,8 +116,10 @@ class ProcessingEventType(Serializable):
             self._xml_ns = kwargs['_xml_ns']
         if '_xml_ns_key' in kwargs:
             self._xml_ns_key = kwargs['_xml_ns_key']
+        # use naive datetime because numpy warns about parsing timezone aware
+        now = numpy.datetime64(datetime.datetime.now(tz=datetime.timezone.utc).replace(tzinfo=None))
         self.ApplicationName = ApplicationName
-        self.AppliedDateTime = numpy.datetime64(datetime.now()) if AppliedDateTime is None else AppliedDateTime
+        self.AppliedDateTime = now if AppliedDateTime is None else AppliedDateTime
         self.InterpolationMethod = InterpolationMethod
         self.Descriptors = Descriptors
         super(ProcessingEventType, self).__init__(**kwargs)

--- a/sarpy/io/product/sidd2_elements/ProductCreation.py
+++ b/sarpy/io/product/sidd2_elements/ProductCreation.py
@@ -5,9 +5,9 @@ The ProductCreationType definition.
 __classification__ = "UNCLASSIFIED"
 __author__ = "Thomas McCullough"
 
+import datetime
 import logging
 from typing import Union
-from datetime import datetime
 
 import numpy
 
@@ -296,7 +296,7 @@ class ProductClassificationType(Serializable):
         clas = extract_classification_from_sicd(sicd)
 
         if create_date is None:
-            create_date = datetime.now().strftime('%Y-%m-%d')
+            create_date = datetime.datetime.now(tz=datetime.timezone.utc).date().isoformat()
 
         return cls(classification=clas, createDate=create_date)
 
@@ -383,9 +383,11 @@ class ProductCreationType(Serializable):
 
         from sarpy.__about__ import __title__, __version__
 
+        # use naive datetime because numpy warns about parsing timezone aware
+        now = numpy.datetime64(datetime.datetime.now(tz=datetime.timezone.utc).replace(tzinfo=None))
         proc_info = ProcessorInformationType(
             Application='{} {}'.format(__title__, __version__),
-            ProcessingDateTime=numpy.datetime64(datetime.now()),
+            ProcessingDateTime=now,
             Site='Unknown')
         classification = ProductClassificationType.from_sicd(sicd)
         return cls(ProcessorInformation=proc_info,


### PR DESCRIPTION
# Description
I noticed that some of the SARPy-generated datetimes were incorrect and traced the problem to a mishandling of timezones. This PR fixes the occurrences of `numpy.datetime64(datetime.now())`

The changes can be illustrated using the following script (run in UTC-7):

<details><summary>tmp_badtz.py</summary>

```python
import datetime

import sarpy.io.complex.sicd
import sarpy.io.complex.sicd_elements.SICD as sarpy_sicd
import sarpy.io.product.sidd1_elements.ProductCreation as sarpy_sidd_pc1
import sarpy.io.product.sidd2_elements.ProductCreation as sarpy_sidd_pc2
import sarpy.io.product.sidd2_elements.DownstreamReprocessing as sarpy_sidd_drp2

sicd_meta = sarpy_sicd.SICDType.from_xml_file("tests/data/example.sicd.xml")
sicd_meta.ImageCreation = None
sicd_meta = sarpy.io.complex.sicd.validate_sicd_for_writing(sicd_meta)

def _print_xml(node):
    print(node.to_xml_string())
    print()
    print()

print(datetime.datetime.now(datetime.timezone.utc))
print()

print("sicd.validate_sicd_for_writing")
_print_xml(sicd_meta.ImageCreation)


print("sidd1_elements.ProductCreation")
_print_xml(sarpy_sidd_pc1.ProductCreationType.from_sicd(sicd_meta, "pr-demo"))


print("sidd2_elements.ProductCreation")
_print_xml(sarpy_sidd_pc2.ProductCreationType.from_sicd(sicd_meta, "pr-demo"))

print("sidd2_elements.DownstreamReprocessing")
_print_xml(sarpy_sidd_drp2.ProcessingEventType("pr-demo"))

```

</details>

<details><summary>in master</summary>

```
2024-10-08 15:06:25.048510+00:00

sicd.validate_sicd_for_writing
<ImageCreationType><Application>sarpy 1.3.59</Application><DateTime>2024-10-08T08:06:25.048186Z</DateTime><Profile>sarpy 1.3.59</Profile></ImageCreationType>


sidd1_elements.ProductCreation
<ProductCreationType><ProcessorInformation><Application>sarpy 1.3.59</Application><ProcessingDateTime>2024-10-08T08:06:25.048802Z</ProcessingDateTime><Site>Unknown</Site></ProcessorInformation><Classification ism:DESVersion="4" ism:resourceElement="true" ism:createDate="2024-10-08" ism:classification="U" ism:ownerProducer="USA" /><ProductName>pr-demo</ProductName><Pr
oductClass>pr-demo</ProductClass></ProductCreationType>                                                                                                                                                                                                                                                                                                                          

sidd2_elements.ProductCreation
<ProductCreationType><ProcessorInformation><Application>sarpy 1.3.59</Application><ProcessingDateTime>2024-10-08T08:06:25.049140Z</ProcessingDateTime><Site>Unknown</Site></ProcessorInformation><Classification ism:DESVersion="13" ism:resourceElement="true" ism:createDate="2024-10-08" ism:compliesWith="USGov" ism:ISMCATCESVersion="201903" ism:classification="U" ism:own
erProducer="USA" /><ProductName>pr-demo</ProductName><ProductClass>pr-demo</ProductClass></ProductCreationType>                                                                                                                                                                                                                                                                  

sidd2_elements.DownstreamReprocessing
<ProcessingEventType><ApplicationName>pr-demo</ApplicationName><AppliedDateTime>2024-10-08T08:06:25.049420Z</AppliedDateTime></ProcessingEventType>
```

</details>

<details><summary>in this branch</summary>

```
2024-10-08 15:05:37.134481+00:00

sicd.validate_sicd_for_writing
<ImageCreationType><Application>sarpy 1.3.60.dev1</Application><DateTime>2024-10-08T15:05:37.134157Z</DateTime><Profile>sarpy 1.3.60.dev1</Profile></ImageCreationType>


sidd1_elements.ProductCreation
<ProductCreationType><ProcessorInformation><Application>sarpy 1.3.60.dev1</Application><ProcessingDateTime>2024-10-08T15:05:37.134694Z</ProcessingDateTime><Site>Unknown</Site></ProcessorInformation><Classification ism:DESVersion="4" ism:resourceElement="true" ism:createDate="2024-10-08" ism:classification="U" ism:ownerProducer="USA" /><ProductName>pr-demo</ProductNam
e><ProductClass>pr-demo</ProductClass></ProductCreationType>                                                                                                                                                                                                                                                                                                                     

sidd2_elements.ProductCreation
<ProductCreationType><ProcessorInformation><Application>sarpy 1.3.60.dev1</Application><ProcessingDateTime>2024-10-08T15:05:37.134924Z</ProcessingDateTime><Site>Unknown</Site></ProcessorInformation><Classification ism:DESVersion="13" ism:resourceElement="true" ism:createDate="2024-10-08" ism:compliesWith="USGov" ism:ISMCATCESVersion="201903" ism:classification="U" is
m:ownerProducer="USA" /><ProductName>pr-demo</ProductName><ProductClass>pr-demo</ProductClass></ProductCreationType>                                                                                                                                                                                                                                                             

sidd2_elements.DownstreamReprocessing
<ProcessingEventType><ApplicationName>pr-demo</ApplicationName><AppliedDateTime>2024-10-08T15:05:37.135108Z</AppliedDateTime></ProcessingEventType>
```

</details>

# Test results

<details><summary>tests pass</summary>

```
SARPY_TEST_PATH=/data/sarpy_test/ nox
nox > Running session test(version='3.6')
nox > Creating conda env in .nox/test-version-3-6 with python
nox > conda install --yes --prefix /home/vscuser/git/glweb/software/third-party/sarpy/.nox/test-version-3-6 python=3.6
nox > python -m pip install '.[all]'
nox > pytest tests
=========================================================================== test session starts ============================================================================
platform linux -- Python 3.6.13, pytest-7.0.1, pluggy-1.0.0
rootdir: /home/vscuser/git/glweb/software/third-party/sarpy
collected 800 items                                                                                                                                                        

tests/test_class_string.py .                                                                                                                                         [  0%]
tests/consistency/test_consistency.py ........                                                                                                                       [  1%]
tests/consistency/test_cphd_consistency.py ..............................................................                                                            [  8%]
tests/consistency/test_sicd_consistency.py ...                                                                                                                       [  9%]
tests/consistency/test_sidd_consistency.py .....                                                                                                                     [  9%]
tests/geometry/test_geocoords.py ..........                                                                                                                          [ 11%]
tests/geometry/test_geometry_elements.py ..........                                                                                                                  [ 12%]
tests/geometry/test_latlon.py ...                                                                                                                                    [ 12%]
tests/geometry/test_point_projection.py ..............                                                                                                               [ 14%]
tests/io/test_kml.py .                                                                                                                                               [ 14%]
tests/io/DEM/test_dted.py ..                                                                                                                                         [ 14%]
tests/io/DEM/test_geoid.py .                                                                                                                                         [ 15%]
tests/io/DEM/test_geotiff1deg_list.py ....                                                                                                                           [ 15%]
tests/io/DEM/test_geotiff1deg_reader.py ........                                                                                                                     [ 16%]
tests/io/complex/test_other_nitf.py ...                                                                                                                              [ 16%]
tests/io/complex/test_reader.py ..sss.ssss.                                                                                                                          [ 18%]
tests/io/complex/test_remote.py s                                                                                                                                    [ 18%]
tests/io/complex/test_sicd.py .                                                                                                                                      [ 18%]
tests/io/complex/test_sio.py .                                                                                                                                       [ 18%]
tests/io/complex/test_utils.py .                                                                                                                                     [ 18%]
tests/io/complex/sicd_elements/test_sicd_elements_antenna.py ...                                                                                                     [ 19%]
tests/io/complex/sicd_elements/test_sicd_elements_base.py ...                                                                                                        [ 19%]
tests/io/complex/sicd_elements/test_sicd_elements_blocks.py .....................                                                                                    [ 22%]
tests/io/complex/sicd_elements/test_sicd_elements_collectioninfo.py ..                                                                                               [ 22%]
tests/io/complex/sicd_elements/test_sicd_elements_errorstatistics.py .                                                                                               [ 22%]
tests/io/complex/sicd_elements/test_sicd_elements_geodata.py ...                                                                                                     [ 22%]
tests/io/complex/sicd_elements/test_sicd_elements_grid.py ..                                                                                                         [ 23%]
tests/io/complex/sicd_elements/test_sicd_elements_imagecreation.py .                                                                                                 [ 23%]
tests/io/complex/sicd_elements/test_sicd_elements_imagedata.py .                                                                                                     [ 23%]
tests/io/complex/sicd_elements/test_sicd_elements_imageformation.py ......                                                                                           [ 24%]
tests/io/complex/sicd_elements/test_sicd_elements_matchinfo.py .                                                                                                     [ 24%]
tests/io/complex/sicd_elements/test_sicd_elements_pfa.py .                                                                                                           [ 24%]
tests/io/complex/sicd_elements/test_sicd_elements_position.py ...                                                                                                    [ 24%]
tests/io/complex/sicd_elements/test_sicd_elements_radarcollection.py ..............                                                                                  [ 26%]
tests/io/complex/sicd_elements/test_sicd_elements_radiometric.py .                                                                                                   [ 26%]
tests/io/complex/sicd_elements/test_sicd_elements_rgazcomp.py .                                                                                                      [ 26%]
tests/io/complex/sicd_elements/test_sicd_elements_rma.py ...                                                                                                         [ 27%]
tests/io/complex/sicd_elements/test_sicd_elements_scpcoa.py ...................                                                                                      [ 29%]
tests/io/complex/sicd_elements/test_sicd_elements_sicd.py ...................................                                                                        [ 33%]
tests/io/complex/sicd_elements/test_sicd_elements_timeline.py ..................                                                                                     [ 36%]
tests/io/complex/sicd_elements/test_sicd_elements_utils.py ...                                                                                                       [ 36%]
tests/io/general/test_base.py ...                                                                                                                                    [ 36%]
tests/io/general/test_data_segment.py ..........                                                                                                                     [ 38%]
tests/io/general/test_format_function.py ........                                                                                                                    [ 39%]
tests/io/general/test_nitf.py ..                                                                                                                                     [ 39%]
tests/io/general/test_nitf_headers.py .                                                                                                                              [ 39%]
tests/io/general/test_nitf_image.py ....                                                                                                                             [ 40%]
tests/io/general/test_tre.py ...                                                                                                                                     [ 40%]
tests/io/phase_history/test_cphd.py .......                                                                                                                          [ 41%]
tests/io/phase_history/test_cphd_versions.py .....                                                                                                                   [ 41%]
tests/io/phase_history/cphd1_elements/test_cphd.py ......                                                                                                            [ 42%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_antenna.py .....                                                                                           [ 43%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_blocks.py ....                                                                                             [ 43%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_channel.py .                                                                                               [ 43%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_data.py .                                                                                                  [ 44%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_dwell.py .                                                                                                 [ 44%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_geoinfo.py ...                                                                                             [ 44%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_global.py ..                                                                                               [ 44%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_pvp.py .                                                                                                   [ 44%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_referencegeometry.py .                                                                                     [ 45%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_supportarray.py ..                                                                                         [ 45%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_txrcv.py .                                                                                                 [ 45%]
tests/io/phase_history/cphd1_elements/test_utils.py .                                                                                                                [ 45%]
tests/io/product/test_reader.py ...s                                                                                                                                 [ 46%]
tests/io/product/test_sidd.py .............                                                                                                                          [ 47%]
tests/io/product/test_sidd_schema.py .........                                                                                                                       [ 48%]
tests/io/product/test_sidd_writing.py ..                                                                                                                             [ 49%]
tests/io/product/sidd1_elements/test_exploitationfeatures.py .........................................................                                               [ 56%]
tests/io/product/sidd2_elements/test_exploitationfeatures.py ....................................................................                                    [ 64%]
tests/io/product/sidd3_elements/test_exploitationfeatures.py ....................................................................................................... [ 77%]
..............................................................................................................................                                       [ 93%]
tests/io/product/sidd3_elements/test_sidd3_elements.py .....                                                                                                         [ 93%]
tests/io/received/test_crsd.py .                                                                                                                                     [ 94%]
tests/processing/sicd/test_spectral_taper.py ........ss...........                                                                                                   [ 96%]
tests/utils/test_sicd_sidelobe_control.py ..                                                                                                                         [ 96%]
tests/visualization/test_cphd_kmz_product_creation.py ..                                                                                                             [ 97%]
tests/visualization/test_crsd_kmz_product_creation.py .                                                                                                              [ 97%]
tests/visualization/test_kmz_product_creation.py .x                                                                                                                  [ 97%]
tests/visualization/test_remap.py ....................                                                                                                               [100%]

============================================================================= warnings summary =============================================================================
tests/geometry/test_point_projection.py::test_image_to_ground_errors
tests/geometry/test_point_projection.py::test_image_to_ground_dem
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/geometry/point_projection.py:1882: RuntimeWarning: divide by zero encountered in double_scalars
    lon_grid_size = min(10, lat_grid_size/abs(numpy.sin(numpy.deg2rad(ref_llh[0]))))

tests/visualization/test_kmz_product_creation.py::test_create_kmz[True]
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/visualization/kmz_utils.py:169: RuntimeWarning: invalid value encountered in double_scalars
    + dir_z**2 * semiaxis_a**2 * semiaxis_b**2

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
==================================================== 788 passed, 11 skipped, 1 xfailed, 3 warnings in 86.07s (0:01:26) =====================================================
nox > Session test(version='3.6') was successful.
nox > Running session test(version='3.11')
nox > Creating conda env in .nox/test-version-3-11 with python
nox > conda install --yes --prefix /home/vscuser/git/glweb/software/third-party/sarpy/.nox/test-version-3-11 python=3.11
nox > python -m pip install '.[all]'
nox > pytest tests
=========================================================================== test session starts ============================================================================
platform linux -- Python 3.11.10, pytest-8.3.3, pluggy-1.5.0
rootdir: /home/vscuser/git/glweb/software/third-party/sarpy
collected 800 items                                                                                                                                                        

tests/consistency/test_consistency.py ........                                                                                                                       [  1%]
tests/consistency/test_cphd_consistency.py ..............................................................                                                            [  8%]
tests/consistency/test_sicd_consistency.py ...                                                                                                                       [  9%]
tests/consistency/test_sidd_consistency.py .....                                                                                                                     [  9%]
tests/geometry/test_geocoords.py ..........                                                                                                                          [ 11%]
tests/geometry/test_geometry_elements.py ..........                                                                                                                  [ 12%]
tests/geometry/test_latlon.py ...                                                                                                                                    [ 12%]
tests/geometry/test_point_projection.py ..............                                                                                                               [ 14%]
tests/io/DEM/test_dted.py ..                                                                                                                                         [ 14%]
tests/io/DEM/test_geoid.py .                                                                                                                                         [ 14%]
tests/io/DEM/test_geotiff1deg_list.py ....                                                                                                                           [ 15%]
tests/io/DEM/test_geotiff1deg_reader.py ........                                                                                                                     [ 16%]
tests/io/complex/sicd_elements/test_sicd_elements_antenna.py ...                                                                                                     [ 16%]
tests/io/complex/sicd_elements/test_sicd_elements_base.py ...                                                                                                        [ 17%]
tests/io/complex/sicd_elements/test_sicd_elements_blocks.py .....................                                                                                    [ 19%]
tests/io/complex/sicd_elements/test_sicd_elements_collectioninfo.py ..                                                                                               [ 19%]
tests/io/complex/sicd_elements/test_sicd_elements_errorstatistics.py .                                                                                               [ 20%]
tests/io/complex/sicd_elements/test_sicd_elements_geodata.py ...                                                                                                     [ 20%]
tests/io/complex/sicd_elements/test_sicd_elements_grid.py ..                                                                                                         [ 20%]
tests/io/complex/sicd_elements/test_sicd_elements_imagecreation.py .                                                                                                 [ 20%]
tests/io/complex/sicd_elements/test_sicd_elements_imagedata.py .                                                                                                     [ 20%]
tests/io/complex/sicd_elements/test_sicd_elements_imageformation.py ......                                                                                           [ 21%]
tests/io/complex/sicd_elements/test_sicd_elements_matchinfo.py .                                                                                                     [ 21%]
tests/io/complex/sicd_elements/test_sicd_elements_pfa.py .                                                                                                           [ 21%]
tests/io/complex/sicd_elements/test_sicd_elements_position.py ...                                                                                                    [ 22%]
tests/io/complex/sicd_elements/test_sicd_elements_radarcollection.py ..............                                                                                  [ 24%]
tests/io/complex/sicd_elements/test_sicd_elements_radiometric.py .                                                                                                   [ 24%]
tests/io/complex/sicd_elements/test_sicd_elements_rgazcomp.py .                                                                                                      [ 24%]
tests/io/complex/sicd_elements/test_sicd_elements_rma.py ...                                                                                                         [ 24%]
tests/io/complex/sicd_elements/test_sicd_elements_scpcoa.py ...................                                                                                      [ 27%]
tests/io/complex/sicd_elements/test_sicd_elements_sicd.py ...................................                                                                        [ 31%]
tests/io/complex/sicd_elements/test_sicd_elements_timeline.py ..................                                                                                     [ 33%]
tests/io/complex/sicd_elements/test_sicd_elements_utils.py ...                                                                                                       [ 34%]
tests/io/complex/test_other_nitf.py ...                                                                                                                              [ 34%]
tests/io/complex/test_reader.py ..sss.ssss.                                                                                                                          [ 35%]
tests/io/complex/test_remote.py s                                                                                                                                    [ 35%]
tests/io/complex/test_sicd.py .                                                                                                                                      [ 36%]
tests/io/complex/test_sio.py .                                                                                                                                       [ 36%]
tests/io/complex/test_utils.py .                                                                                                                                     [ 36%]
tests/io/general/test_base.py ...                                                                                                                                    [ 36%]
tests/io/general/test_data_segment.py ..........                                                                                                                     [ 37%]
tests/io/general/test_format_function.py ........                                                                                                                    [ 38%]
tests/io/general/test_nitf.py ..                                                                                                                                     [ 39%]
tests/io/general/test_nitf_headers.py .                                                                                                                              [ 39%]
tests/io/general/test_nitf_image.py ....                                                                                                                             [ 39%]
tests/io/general/test_tre.py ...                                                                                                                                     [ 40%]
tests/io/phase_history/cphd1_elements/test_cphd.py ......                                                                                                            [ 40%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_antenna.py .....                                                                                           [ 41%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_blocks.py ....                                                                                             [ 42%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_channel.py .                                                                                               [ 42%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_data.py .                                                                                                  [ 42%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_dwell.py .                                                                                                 [ 42%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_geoinfo.py ...                                                                                             [ 42%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_global.py ..                                                                                               [ 43%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_pvp.py .                                                                                                   [ 43%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_referencegeometry.py .                                                                                     [ 43%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_supportarray.py ..                                                                                         [ 43%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_txrcv.py .                                                                                                 [ 43%]
tests/io/phase_history/cphd1_elements/test_utils.py .                                                                                                                [ 43%]
tests/io/phase_history/test_cphd.py .......                                                                                                                          [ 44%]
tests/io/phase_history/test_cphd_versions.py .....                                                                                                                   [ 45%]
tests/io/product/sidd1_elements/test_exploitationfeatures.py .........................................................                                               [ 52%]
tests/io/product/sidd2_elements/test_exploitationfeatures.py ....................................................................                                    [ 60%]
tests/io/product/sidd3_elements/test_exploitationfeatures.py ....................................................................................................... [ 73%]
..............................................................................................................................                                       [ 89%]
tests/io/product/sidd3_elements/test_sidd3_elements.py .....                                                                                                         [ 90%]
tests/io/product/test_reader.py ...s                                                                                                                                 [ 90%]
tests/io/product/test_sidd.py .............                                                                                                                          [ 92%]
tests/io/product/test_sidd_schema.py .........                                                                                                                       [ 93%]
tests/io/product/test_sidd_writing.py ..                                                                                                                             [ 93%]
tests/io/received/test_crsd.py .                                                                                                                                     [ 93%]
tests/io/test_kml.py .                                                                                                                                               [ 93%]
tests/processing/sicd/test_spectral_taper.py .....................                                                                                                   [ 96%]
tests/test_class_string.py .                                                                                                                                         [ 96%]
tests/utils/test_sicd_sidelobe_control.py ..                                                                                                                         [ 96%]
tests/visualization/test_cphd_kmz_product_creation.py ..                                                                                                             [ 97%]
tests/visualization/test_crsd_kmz_product_creation.py .                                                                                                              [ 97%]
tests/visualization/test_kmz_product_creation.py .x                                                                                                                  [ 97%]
tests/visualization/test_remap.py ....................                                                                                                               [100%]

============================================================================= warnings summary =============================================================================
tests/geometry/test_geometry_elements.py: 77 warnings
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/geometry/geometry_elements.py:131: DeprecationWarning: Arrays of 2-dimensional vectors are deprecated. Use arrays
 of 3-dimensional vectors instead. (deprecated in NumPy 2.0)                                                                                                                    dir_cross = float(numpy.cross(R, S))  # the scalar cross product of the direction vectors

tests/geometry/test_geometry_elements.py: 43 warnings
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/geometry/geometry_elements.py:137: DeprecationWarning: Arrays of 2-dimensional vectors are deprecated. Use arrays
 of 3-dimensional vectors instead. (deprecated in NumPy 2.0)                                                                                                                    end_cross_0 = float(numpy.cross(Q-P, S))

tests/geometry/test_geometry_elements.py: 43 warnings
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/geometry/geometry_elements.py:138: DeprecationWarning: Arrays of 2-dimensional vectors are deprecated. Use arrays
 of 3-dimensional vectors instead. (deprecated in NumPy 2.0)                                                                                                                    end_cross_1 = float(numpy.cross(Q-P, R))

tests/geometry/test_point_projection.py::test_image_to_ground_errors
tests/geometry/test_point_projection.py::test_image_to_ground_dem
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/geometry/point_projection.py:1882: RuntimeWarning: divide by zero encountered in scalar divide
    lon_grid_size = min(10, lat_grid_size/abs(numpy.sin(numpy.deg2rad(ref_llh[0]))))

tests/test_class_string.py::TestClassString::test_class_str
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/annotation/afrl_rde_schema/__init__.py:7: DeprecationWarning: pkg_resources is deprecated as an API. See https://
setuptools.pypa.io/en/latest/pkg_resources.html                                                                                                                                 import pkg_resources

tests/visualization/test_kmz_product_creation.py::test_create_kmz[True]
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/visualization/kmz_utils.py:145: RuntimeWarning: invalid value encountered in scalar divide
    distance = (

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================= 790 passed, 9 skipped, 1 xfailed, 167 warnings in 39.30s =========================================================
nox > Session test(version='3.11') was successful.
nox > Ran multiple sessions:
nox > * test(version='3.6'): success
nox > * test(version='3.11'): success

```

</details>