### PR TITLE
Fix: NITF attachment level interpretation; change integration versioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ release points are not being annotated in GitHub.
 - Typo in SIDD 2.0+ DigitalElevationData/Geoposition/CoordinateSystemType enum (GGS -> GCS)
 - Account for timezones in generated datetimes
 - SIDD ProductProcessing handling
+- NITF attachment level interpretation
 
 ## [1.3.59] - 2024-10-03
 ### Added

--- a/sarpy/__about__.py
+++ b/sarpy/__about__.py
@@ -27,7 +27,7 @@ __all__ = ['__version__',
            '__license__', '__copyright__']
 
 from sarpy.__details__ import __classification__, _post_identifier
-_version_number = '1.3.60.dev3'
+_version_number = '1.3.60a4'
 
 __version__ = _version_number + _post_identifier
 


### PR DESCRIPTION
# Description
While attempting to use SARPy to write a SIDD with a legend:

<details><summary>SIDD 2.0 Vol 2:Table 2-7</summary>

![image](https://github.com/user-attachments/assets/cf6ff4d8-b159-4f95-94f1-bd8f6c732dc0)

</details>

we encountered a failure in the NITF attachment level logic, which can be replicated by running the new test in `master`/`integration/1.3.60`:

<details><summary>example test failure</summary>

```
pytest tests/io/product/test_sidd_writing.py
=========================================================================== test session starts ============================================================================
platform linux -- Python 3.11.9, pytest-8.3.2, pluggy-1.5.0
rootdir: /home/vscuser/git/glweb/software/third-party/sarpy
collected 3 items                                                                                                                                                          

tests/io/product/test_sidd_writing.py .Fs                                                                                                                            [100%]

================================================================================= FAILURES =================================================================================
__________________________________________________________________ TestSIDDWriting.test_nitf_with_legend ___________________________________________________________________

self = <tests.io.product.test_sidd_writing.TestSIDDWriting testMethod=test_nitf_with_legend>

    def test_nitf_with_legend(self):
        """Ensure SARPy can be used to write out a SIDD with a legend"""
        sidd_xml = pathlib.Path(__file__).parents[2]/ 'data/example.sidd.xml'
        sidd_meta = sarpy.io.product.sidd.SIDDType2.from_xml_file(sidd_xml)
        sidd_writing_details = sarpy.io.product.sidd.SIDDWritingDetails([sidd_meta], None)
        assert len(sidd_writing_details.image_managers) == 1
    
        legseg = ImageSubheaderManager(
            ImageSegmentHeader.from_bytes(sidd_writing_details.image_managers[0].subheader.to_bytes(), 0)
        )
        # Modify fields per SIDD 2.0/3.0 Table 2-7
        legseg.subheader.ICAT = "LEG"
        legseg.subheader.IID1 = f"{legseg.subheader.IID1[:-3]}{int(legseg.subheader.IID1[-3:])+1:03}"
        legseg.subheader.IDLVL += 1
        legseg.subheader.IALVL = sidd_writing_details.image_managers[0].subheader.IDLVL
    
>       siddnitf_with_leg = NITFWritingDetails(
            header=sidd_writing_details.header,
            image_managers=sidd_writing_details.image_managers + (legseg,),
            image_segment_collections=tuple((x,) for x in range(2)),
            des_managers=sidd_writing_details.des_managers,
        )

tests/io/product/test_sidd_writing.py:172: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
sarpy/io/general/nitf.py:2959: in __init__
    self.image_segment_coordinates = image_segment_coordinates
sarpy/io/general/nitf.py:3094: in image_segment_coordinates
    coordinate_scheme, clevel = _get_collection_element_coordinate_limits(image_headers, return_clevel=True)
sarpy/io/general/nitf.py:498: in _get_collection_element_coordinate_limits
    the_indices = _correctly_order_image_segment_collection(image_headers)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

image_headers = [<sarpy.io.general.nitf_elements.image.ImageSegmentHeader object at 0x7f99b1914990>]

    def _correctly_order_image_segment_collection(
                image_headers: Sequence[Union[ImageSegmentHeader, ImageSegmentHeader0]]) -> Tuple[int, ...]:
        """
        Determines the proper order, based on IALVL and IDLVL, for a collection of entries
        which will be assembled into a composite image.
    
        Parameters
        ----------
        image_headers : Sequence[ImageSegmentHeader]
    
        Returns
        -------
        Tuple[int, ...]
    
        Raises
        ------
        ValueError
            If incompatible IALVL values collection
        """
    
        ImLvl = namedtuple('ImLvl', ['index', 'IALVL', 'IDLVL'])
        im_levels = sorted([ImLvl(index=n, IALVL=hdr.IALVL, IDLVL=hdr.IDLVL) for n, hdr in enumerate(image_headers)],
                           key=lambda x: x.IDLVL)
        if all(entry.IALVL == 0 for entry in im_levels):
            # all IALVL is 0, and order doesn't matter
            return tuple(range(len(image_headers)))
        if im_levels[0].IALVL == 0  and all(im_levels[n].IALVL == im_levels[n-1].IDLVL for n in range(1, len(im_levels))):
            # From ISO/IEC Joint BIIF Profile JBP-2024.1 - 4.5.4.2 Attachment Level (ALVL) Interpretation
            # The image or graphic segment in the MI collection (multi files) with the minimum display level has an
            # attachment level of zero.
            # The attachment level of an item is equal to the display level of the item to which it is "attached.""
            return tuple(x.index for x in im_levels)
>       raise ValueError(f"Unable to interpret image segment attachment/display levels:\n{im_levels}\n per ISO/IEC JBP")
E       ValueError: Unable to interpret image segment attachment/display levels:
E       [ImLvl(index=0, IALVL=1, IDLVL=2)]
E        per ISO/IEC JBP

sarpy/io/general/nitf.py:470: ValueError
========================================================================= short test summary info ==========================================================================
FAILED tests/io/product/test_sidd_writing.py::TestSIDDWriting::test_nitf_with_legend - ValueError: Unable to interpret image segment attachment/display levels:
================================================================== 1 failed, 1 passed, 1 skipped in 1.64s ==================================================================
                                                                                                                                                                            

```

</details>

The logic introduced in #507 is unnecessarily strict in this use case. This PR proposes removing `_correctly_order_image_segment_collection` and replacing it with logic in `_get_collection_element_coordinate_limits` that is a more general implementation of JBP 2024.1 Clause 4.5.4.2

<details><summary>Clause 4.5.4.2</summary>

![image](https://github.com/user-attachments/assets/896b6de0-d93c-415c-8d18-02a60a23354c)

</details>

## Versioning Convention
This PR also modifies the integration branch versioning convention by incrementing updates in the pre-release segment as opposed to the development segment.

# Tests

<details><summary>tests pass</summary>

```
SARPY_TEST_PATH=/data/sarpy_test/ nox
nox > Running session test(version='3.6')
nox > Creating conda env in .nox/test-version-3-6 with python
nox > conda install --yes --prefix /home/vscuser/git/glweb/software/third-party/sarpy/.nox/test-version-3-6 python=3.6
nox > python -m pip install '.[all]'
nox > pytest tests
=========================================================================== test session starts ============================================================================
platform linux -- Python 3.6.13, pytest-7.0.1, pluggy-1.0.0
rootdir: /home/vscuser/git/glweb/software/third-party/sarpy
collected 802 items                                                                                                                                                        

tests/test_class_string.py .                                                                                                                                         [  0%]
tests/consistency/test_consistency.py ........                                                                                                                       [  1%]
tests/consistency/test_cphd_consistency.py ..............................................................                                                            [  8%]
tests/consistency/test_sicd_consistency.py ...                                                                                                                       [  9%]
tests/consistency/test_sidd_consistency.py .....                                                                                                                     [  9%]
tests/geometry/test_geocoords.py ..........                                                                                                                          [ 11%]
tests/geometry/test_geometry_elements.py ..........                                                                                                                  [ 12%]
tests/geometry/test_latlon.py ...                                                                                                                                    [ 12%]
tests/geometry/test_point_projection.py ..............                                                                                                               [ 14%]
tests/io/test_kml.py .                                                                                                                                               [ 14%]
tests/io/DEM/test_dted.py ..                                                                                                                                         [ 14%]
tests/io/DEM/test_geoid.py .                                                                                                                                         [ 14%]
tests/io/DEM/test_geotiff1deg_list.py ....                                                                                                                           [ 15%]
tests/io/DEM/test_geotiff1deg_reader.py ........                                                                                                                     [ 16%]
tests/io/complex/test_other_nitf.py ...                                                                                                                              [ 16%]
tests/io/complex/test_reader.py ..sss.ssss.                                                                                                                          [ 18%]
tests/io/complex/test_remote.py s                                                                                                                                    [ 18%]
tests/io/complex/test_sicd.py .                                                                                                                                      [ 18%]
tests/io/complex/test_sio.py .                                                                                                                                       [ 18%]
tests/io/complex/test_utils.py .                                                                                                                                     [ 18%]
tests/io/complex/sicd_elements/test_sicd_elements_antenna.py ...                                                                                                     [ 19%]
tests/io/complex/sicd_elements/test_sicd_elements_base.py ...                                                                                                        [ 19%]
tests/io/complex/sicd_elements/test_sicd_elements_blocks.py .....................                                                                                    [ 22%]
tests/io/complex/sicd_elements/test_sicd_elements_collectioninfo.py ..                                                                                               [ 22%]
tests/io/complex/sicd_elements/test_sicd_elements_errorstatistics.py .                                                                                               [ 22%]
tests/io/complex/sicd_elements/test_sicd_elements_geodata.py ...                                                                                                     [ 22%]
tests/io/complex/sicd_elements/test_sicd_elements_grid.py ..                                                                                                         [ 23%]
tests/io/complex/sicd_elements/test_sicd_elements_imagecreation.py .                                                                                                 [ 23%]
tests/io/complex/sicd_elements/test_sicd_elements_imagedata.py .                                                                                                     [ 23%]
tests/io/complex/sicd_elements/test_sicd_elements_imageformation.py ......                                                                                           [ 24%]
tests/io/complex/sicd_elements/test_sicd_elements_matchinfo.py .                                                                                                     [ 24%]
tests/io/complex/sicd_elements/test_sicd_elements_pfa.py .                                                                                                           [ 24%]
tests/io/complex/sicd_elements/test_sicd_elements_position.py ...                                                                                                    [ 24%]
tests/io/complex/sicd_elements/test_sicd_elements_radarcollection.py ..............                                                                                  [ 26%]
tests/io/complex/sicd_elements/test_sicd_elements_radiometric.py .                                                                                                   [ 26%]
tests/io/complex/sicd_elements/test_sicd_elements_rgazcomp.py .                                                                                                      [ 26%]
tests/io/complex/sicd_elements/test_sicd_elements_rma.py ...                                                                                                         [ 27%]
tests/io/complex/sicd_elements/test_sicd_elements_scpcoa.py ...................                                                                                      [ 29%]
tests/io/complex/sicd_elements/test_sicd_elements_sicd.py ...................................                                                                        [ 33%]
tests/io/complex/sicd_elements/test_sicd_elements_timeline.py ..................                                                                                     [ 36%]
tests/io/complex/sicd_elements/test_sicd_elements_utils.py ...                                                                                                       [ 36%]
tests/io/general/test_base.py ...                                                                                                                                    [ 36%]
tests/io/general/test_data_segment.py ..........                                                                                                                     [ 38%]
tests/io/general/test_format_function.py ........                                                                                                                    [ 39%]
tests/io/general/test_nitf.py ..                                                                                                                                     [ 39%]
tests/io/general/test_nitf_headers.py .                                                                                                                              [ 39%]
tests/io/general/test_nitf_image.py ....                                                                                                                             [ 39%]
tests/io/general/test_tre.py ...                                                                                                                                     [ 40%]
tests/io/phase_history/test_cphd.py .......                                                                                                                          [ 41%]
tests/io/phase_history/test_cphd_versions.py .....                                                                                                                   [ 41%]
tests/io/phase_history/cphd1_elements/test_cphd.py ......                                                                                                            [ 42%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_antenna.py .....                                                                                           [ 43%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_blocks.py ....                                                                                             [ 43%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_channel.py .                                                                                               [ 43%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_data.py .                                                                                                  [ 43%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_dwell.py .                                                                                                 [ 44%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_geoinfo.py ...                                                                                             [ 44%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_global.py ..                                                                                               [ 44%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_pvp.py .                                                                                                   [ 44%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_referencegeometry.py .                                                                                     [ 44%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_supportarray.py ..                                                                                         [ 45%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_txrcv.py .                                                                                                 [ 45%]
tests/io/phase_history/cphd1_elements/test_utils.py .                                                                                                                [ 45%]
tests/io/product/test_reader.py ...s                                                                                                                                 [ 45%]
tests/io/product/test_sidd.py ..............                                                                                                                         [ 47%]
tests/io/product/test_sidd_schema.py .........                                                                                                                       [ 48%]
tests/io/product/test_sidd_writing.py ...                                                                                                                            [ 49%]
tests/io/product/sidd1_elements/test_exploitationfeatures.py .........................................................                                               [ 56%]
tests/io/product/sidd2_elements/test_exploitationfeatures.py ....................................................................                                    [ 64%]
tests/io/product/sidd3_elements/test_exploitationfeatures.py ....................................................................................................... [ 77%]
..............................................................................................................................                                       [ 93%]
tests/io/product/sidd3_elements/test_sidd3_elements.py .....                                                                                                         [ 93%]
tests/io/received/test_crsd.py .                                                                                                                                     [ 94%]
tests/processing/sicd/test_spectral_taper.py ........ss...........                                                                                                   [ 96%]
tests/utils/test_sicd_sidelobe_control.py ..                                                                                                                         [ 96%]
tests/visualization/test_cphd_kmz_product_creation.py ..                                                                                                             [ 97%]
tests/visualization/test_crsd_kmz_product_creation.py .                                                                                                              [ 97%]
tests/visualization/test_kmz_product_creation.py .x                                                                                                                  [ 97%]
tests/visualization/test_remap.py ....................                                                                                                               [100%]

============================================================================= warnings summary =============================================================================
tests/geometry/test_point_projection.py::test_image_to_ground_errors
tests/geometry/test_point_projection.py::test_image_to_ground_dem
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/geometry/point_projection.py:1882: RuntimeWarning: divide by zero encountered in double_scalars
    lon_grid_size = min(10, lat_grid_size/abs(numpy.sin(numpy.deg2rad(ref_llh[0]))))

tests/visualization/test_kmz_product_creation.py::test_create_kmz[True]
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/visualization/kmz_utils.py:169: RuntimeWarning: invalid value encountered in double_scalars
    + dir_z**2 * semiaxis_a**2 * semiaxis_b**2

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================= 790 passed, 11 skipped, 1 xfailed, 3 warnings in 44.40s ==========================================================
nox > Session test(version='3.6') was successful.
nox > Running session test(version='3.11')
nox > Creating conda env in .nox/test-version-3-11 with python
nox > conda install --yes --prefix /home/vscuser/git/glweb/software/third-party/sarpy/.nox/test-version-3-11 python=3.11
nox > python -m pip install '.[all]'
nox > pytest tests
=========================================================================== test session starts ============================================================================
platform linux -- Python 3.11.10, pytest-8.3.3, pluggy-1.5.0
rootdir: /home/vscuser/git/glweb/software/third-party/sarpy
collected 802 items                                                                                                                                                        

tests/consistency/test_consistency.py ........                                                                                                                       [  0%]
tests/consistency/test_cphd_consistency.py ..............................................................                                                            [  8%]
tests/consistency/test_sicd_consistency.py ...                                                                                                                       [  9%]
tests/consistency/test_sidd_consistency.py .....                                                                                                                     [  9%]
tests/geometry/test_geocoords.py ..........                                                                                                                          [ 10%]
tests/geometry/test_geometry_elements.py ..........                                                                                                                  [ 12%]
tests/geometry/test_latlon.py ...                                                                                                                                    [ 12%]
tests/geometry/test_point_projection.py ..............                                                                                                               [ 14%]
tests/io/DEM/test_dted.py ..                                                                                                                                         [ 14%]
tests/io/DEM/test_geoid.py .                                                                                                                                         [ 14%]
tests/io/DEM/test_geotiff1deg_list.py ....                                                                                                                           [ 15%]
tests/io/DEM/test_geotiff1deg_reader.py ........                                                                                                                     [ 16%]
tests/io/complex/sicd_elements/test_sicd_elements_antenna.py ...                                                                                                     [ 16%]
tests/io/complex/sicd_elements/test_sicd_elements_base.py ...                                                                                                        [ 16%]
tests/io/complex/sicd_elements/test_sicd_elements_blocks.py .....................                                                                                    [ 19%]
tests/io/complex/sicd_elements/test_sicd_elements_collectioninfo.py ..                                                                                               [ 19%]
tests/io/complex/sicd_elements/test_sicd_elements_errorstatistics.py .                                                                                               [ 19%]
tests/io/complex/sicd_elements/test_sicd_elements_geodata.py ...                                                                                                     [ 20%]
tests/io/complex/sicd_elements/test_sicd_elements_grid.py ..                                                                                                         [ 20%]
tests/io/complex/sicd_elements/test_sicd_elements_imagecreation.py .                                                                                                 [ 20%]
tests/io/complex/sicd_elements/test_sicd_elements_imagedata.py .                                                                                                     [ 20%]
tests/io/complex/sicd_elements/test_sicd_elements_imageformation.py ......                                                                                           [ 21%]
tests/io/complex/sicd_elements/test_sicd_elements_matchinfo.py .                                                                                                     [ 21%]
tests/io/complex/sicd_elements/test_sicd_elements_pfa.py .                                                                                                           [ 21%]
tests/io/complex/sicd_elements/test_sicd_elements_position.py ...                                                                                                    [ 22%]
tests/io/complex/sicd_elements/test_sicd_elements_radarcollection.py ..............                                                                                  [ 23%]
tests/io/complex/sicd_elements/test_sicd_elements_radiometric.py .                                                                                                   [ 24%]
tests/io/complex/sicd_elements/test_sicd_elements_rgazcomp.py .                                                                                                      [ 24%]
tests/io/complex/sicd_elements/test_sicd_elements_rma.py ...                                                                                                         [ 24%]
tests/io/complex/sicd_elements/test_sicd_elements_scpcoa.py ...................                                                                                      [ 26%]
tests/io/complex/sicd_elements/test_sicd_elements_sicd.py ...................................                                                                        [ 31%]
tests/io/complex/sicd_elements/test_sicd_elements_timeline.py ..................                                                                                     [ 33%]
tests/io/complex/sicd_elements/test_sicd_elements_utils.py ...                                                                                                       [ 33%]
tests/io/complex/test_other_nitf.py ...                                                                                                                              [ 34%]
tests/io/complex/test_reader.py ..sss.ssss.                                                                                                                          [ 35%]
tests/io/complex/test_remote.py s                                                                                                                                    [ 35%]
tests/io/complex/test_sicd.py .                                                                                                                                      [ 35%]
tests/io/complex/test_sio.py .                                                                                                                                       [ 36%]
tests/io/complex/test_utils.py .                                                                                                                                     [ 36%]
tests/io/general/test_base.py ...                                                                                                                                    [ 36%]
tests/io/general/test_data_segment.py ..........                                                                                                                     [ 37%]
tests/io/general/test_format_function.py ........                                                                                                                    [ 38%]
tests/io/general/test_nitf.py ..                                                                                                                                     [ 39%]
tests/io/general/test_nitf_headers.py .                                                                                                                              [ 39%]
tests/io/general/test_nitf_image.py ....                                                                                                                             [ 39%]
tests/io/general/test_tre.py ...                                                                                                                                     [ 40%]
tests/io/phase_history/cphd1_elements/test_cphd.py ......                                                                                                            [ 40%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_antenna.py .....                                                                                           [ 41%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_blocks.py ....                                                                                             [ 41%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_channel.py .                                                                                               [ 42%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_data.py .                                                                                                  [ 42%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_dwell.py .                                                                                                 [ 42%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_geoinfo.py ...                                                                                             [ 42%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_global.py ..                                                                                               [ 42%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_pvp.py .                                                                                                   [ 43%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_referencegeometry.py .                                                                                     [ 43%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_supportarray.py ..                                                                                         [ 43%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_txrcv.py .                                                                                                 [ 43%]
tests/io/phase_history/cphd1_elements/test_utils.py .                                                                                                                [ 43%]
tests/io/phase_history/test_cphd.py .......                                                                                                                          [ 44%]
tests/io/phase_history/test_cphd_versions.py .....                                                                                                                   [ 45%]
tests/io/product/sidd1_elements/test_exploitationfeatures.py .........................................................                                               [ 52%]
tests/io/product/sidd2_elements/test_exploitationfeatures.py ....................................................................                                    [ 60%]
tests/io/product/sidd3_elements/test_exploitationfeatures.py ....................................................................................................... [ 73%]
..............................................................................................................................                                       [ 89%]
tests/io/product/sidd3_elements/test_sidd3_elements.py .....                                                                                                         [ 89%]
tests/io/product/test_reader.py ...s                                                                                                                                 [ 90%]
tests/io/product/test_sidd.py ..............                                                                                                                         [ 92%]
tests/io/product/test_sidd_schema.py .........                                                                                                                       [ 93%]
tests/io/product/test_sidd_writing.py ...                                                                                                                            [ 93%]
tests/io/received/test_crsd.py .                                                                                                                                     [ 93%]
tests/io/test_kml.py .                                                                                                                                               [ 93%]
tests/processing/sicd/test_spectral_taper.py .....................                                                                                                   [ 96%]
tests/test_class_string.py .                                                                                                                                         [ 96%]
tests/utils/test_sicd_sidelobe_control.py ..                                                                                                                         [ 96%]
tests/visualization/test_cphd_kmz_product_creation.py ..                                                                                                             [ 97%]
tests/visualization/test_crsd_kmz_product_creation.py .                                                                                                              [ 97%]
tests/visualization/test_kmz_product_creation.py .x                                                                                                                  [ 97%]
tests/visualization/test_remap.py ....................                                                                                                               [100%]

============================================================================= warnings summary =============================================================================
tests/geometry/test_geometry_elements.py: 77 warnings
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/geometry/geometry_elements.py:131: DeprecationWarning: Arrays of 2-dimensional vectors are deprecated. Use arrays
 of 3-dimensional vectors instead. (deprecated in NumPy 2.0)                                                                                                                    dir_cross = float(numpy.cross(R, S))  # the scalar cross product of the direction vectors

tests/geometry/test_geometry_elements.py: 43 warnings
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/geometry/geometry_elements.py:137: DeprecationWarning: Arrays of 2-dimensional vectors are deprecated. Use arrays
 of 3-dimensional vectors instead. (deprecated in NumPy 2.0)                                                                                                                    end_cross_0 = float(numpy.cross(Q-P, S))

tests/geometry/test_geometry_elements.py: 43 warnings
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/geometry/geometry_elements.py:138: DeprecationWarning: Arrays of 2-dimensional vectors are deprecated. Use arrays
 of 3-dimensional vectors instead. (deprecated in NumPy 2.0)                                                                                                                    end_cross_1 = float(numpy.cross(Q-P, R))

tests/geometry/test_point_projection.py::test_image_to_ground_errors
tests/geometry/test_point_projection.py::test_image_to_ground_dem
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/geometry/point_projection.py:1882: RuntimeWarning: divide by zero encountered in scalar divide
    lon_grid_size = min(10, lat_grid_size/abs(numpy.sin(numpy.deg2rad(ref_llh[0]))))

tests/test_class_string.py::TestClassString::test_class_str
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/annotation/afrl_rde_schema/__init__.py:7: DeprecationWarning: pkg_resources is deprecated as an API. See https://
setuptools.pypa.io/en/latest/pkg_resources.html                                                                                                                                 import pkg_resources

tests/visualization/test_kmz_product_creation.py::test_create_kmz[True]
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/visualization/kmz_utils.py:145: RuntimeWarning: invalid value encountered in scalar divide
    distance = (

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================= 792 passed, 9 skipped, 1 xfailed, 167 warnings in 32.95s =========================================================
nox > Session test(version='3.11') was successful.
nox > Ran multiple sessions:
nox > * test(version='3.6'): success
nox > * test(version='3.11'): success

```

</details>