### PR TITLE
enable TREElement.to_dict() to handle floating-point values

### DIFF
--- a/sarpy/io/general/nitf_elements/tres/tre_elements.py
+++ b/sarpy/io/general/nitf_elements/tres/tre_elements.py
@@ -174,7 +174,7 @@ class TREElement(object):
         out = OrderedDict()
         for fld in self._field_ordering:
             val = getattr(self, fld)
-            if val is None or isinstance(val, (bytes, str, int)):
+            if val is None or isinstance(val, (bytes, str, int, float)):
                 out[fld] = val
             elif isinstance(val, TREElement):
                 out[fld] = val.to_dict()


### PR DESCRIPTION
fix https://github.com/ngageoint/sarpy/issues/565
