### PR TITLE
(integration/1.3.60) Enable open_phase_history to take a file-like object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Since essentially every (squash merge) commit corresponds to a release, specific
 release points are not being annotated in GitHub.
 
 ## [1.3.60]
+### Added
+- Support for file objects in `sarpy.io.phase_history.converter.open_phase_history`
 ### Fixed
 - Typo in SIDD 2.0+ DigitalElevationData/Geoposition/CoordinateSystemType enum (GGS -> GCS)
 - Account for timezones in generated datetimes

--- a/sarpy/__about__.py
+++ b/sarpy/__about__.py
@@ -27,7 +27,7 @@ __all__ = ['__version__',
            '__license__', '__copyright__']
 
 from sarpy.__details__ import __classification__, _post_identifier
-_version_number = '1.3.60a4'
+_version_number = '1.3.60a5'
 
 __version__ = _version_number + _post_identifier
 

--- a/sarpy/io/phase_history/converter.py
+++ b/sarpy/io/phase_history/converter.py
@@ -6,10 +6,11 @@ __classification__ = "UNCLASSIFIED"
 __author__ = "Thomas McCullough"
 
 import os
-from typing import Callable
+from typing import BinaryIO, Callable, Union
 
 from sarpy.io.general.base import SarpyIOError, check_for_openers
 from sarpy.io.phase_history.base import CPHDTypeReader
+from sarpy.io.general.utils import is_file_like
 
 
 ###########
@@ -53,13 +54,13 @@ def parse_openers() -> None:
     check_for_openers('sarpy.io.phase_history', register_opener)
 
 
-def open_phase_history(file_name: str) -> CPHDTypeReader:
+def open_phase_history(filename_or_obj:Union[str, BinaryIO]) -> CPHDTypeReader:
     """
     Given a file, try to find and return the appropriate reader object.
 
     Parameters
     ----------
-    file_name : str
+    file_name : str|BinaryIO
 
     Returns
     -------
@@ -70,13 +71,13 @@ def open_phase_history(file_name: str) -> CPHDTypeReader:
     SarpyIOError
     """
 
-    if not os.path.exists(file_name):
-        raise SarpyIOError('File {} does not exist.'.format(file_name))
+    if (not is_file_like(filename_or_obj)) and (not os.path.exists(filename_or_obj)):
+        raise SarpyIOError('File {} does not exist.'.format(filename_or_obj))
     # parse openers, if not already done
     parse_openers()
     # see if we can find a reader though trial and error
     for opener in _openers:
-        reader = opener(file_name)
+        reader = opener(filename_or_obj)
         if reader is not None:
             return reader
 

--- a/sarpy/io/phase_history/converter.py
+++ b/sarpy/io/phase_history/converter.py
@@ -9,8 +9,8 @@ import os
 from typing import BinaryIO, Callable, Union
 
 from sarpy.io.general.base import SarpyIOError, check_for_openers
-from sarpy.io.phase_history.base import CPHDTypeReader
 from sarpy.io.general.utils import is_file_like
+from sarpy.io.phase_history.base import CPHDTypeReader
 
 
 ###########
@@ -54,7 +54,7 @@ def parse_openers() -> None:
     check_for_openers('sarpy.io.phase_history', register_opener)
 
 
-def open_phase_history(filename_or_obj:Union[str, BinaryIO]) -> CPHDTypeReader:
+def open_phase_history(file_name: Union[str, BinaryIO]) -> CPHDTypeReader:
     """
     Given a file, try to find and return the appropriate reader object.
 
@@ -71,13 +71,13 @@ def open_phase_history(filename_or_obj:Union[str, BinaryIO]) -> CPHDTypeReader:
     SarpyIOError
     """
 
-    if (not is_file_like(filename_or_obj)) and (not os.path.exists(filename_or_obj)):
-        raise SarpyIOError('File {} does not exist.'.format(filename_or_obj))
+    if (not is_file_like(file_name)) and (not os.path.exists(file_name)):
+        raise SarpyIOError('File {} does not exist.'.format(file_name))
     # parse openers, if not already done
     parse_openers()
     # see if we can find a reader though trial and error
     for opener in _openers:
-        reader = opener(filename_or_obj)
+        reader = opener(file_name)
         if reader is not None:
             return reader
 


### PR DESCRIPTION
# Description
Credit to @normanb. This PR builds atop #564 with the following changes:

- rebased onto `integration/1.3.60`
- reverts arg name change to maintain backwards compatibility
- adds a unit-test, CHANGELOG entry, and increments version number

# Test Results

<details><summary>Tests pass</summary>
<p>

```
SARPY_TEST_PATH=/data/sarpy_test/ nox
nox > Running session test(version='3.6')
nox > Creating conda env in .nox/test-version-3-6 with python
nox > conda install --yes --prefix /home/vscuser/git/glweb/software/third-party/sarpy/.nox/test-version-3-6 python=3.6
nox > python -m pip install '.[all]'
nox > pytest tests
=========================================================================== test session starts ============================================================================
platform linux -- Python 3.6.13, pytest-7.0.1, pluggy-1.0.0
rootdir: /home/vscuser/git/glweb/software/third-party/sarpy
collected 804 items                                                                                                                                                        

tests/test_class_string.py .                                                                                                                                         [  0%]
tests/consistency/test_consistency.py ........                                                                                                                       [  1%]
tests/consistency/test_cphd_consistency.py ..............................................................                                                            [  8%]
tests/consistency/test_sicd_consistency.py ...                                                                                                                       [  9%]
tests/consistency/test_sidd_consistency.py .....                                                                                                                     [  9%]
tests/geometry/test_geocoords.py ..........                                                                                                                          [ 11%]
tests/geometry/test_geometry_elements.py ..........                                                                                                                  [ 12%]
tests/geometry/test_latlon.py ...                                                                                                                                    [ 12%]
tests/geometry/test_point_projection.py ..............                                                                                                               [ 14%]
tests/io/test_kml.py .                                                                                                                                               [ 14%]
tests/io/DEM/test_dted.py ..                                                                                                                                         [ 14%]
tests/io/DEM/test_geoid.py .                                                                                                                                         [ 14%]
tests/io/DEM/test_geotiff1deg_list.py ....                                                                                                                           [ 15%]
tests/io/DEM/test_geotiff1deg_reader.py ........                                                                                                                     [ 16%]
tests/io/complex/test_other_nitf.py ...                                                                                                                              [ 16%]
tests/io/complex/test_reader.py ..sss.ssss.                                                                                                                          [ 18%]
tests/io/complex/test_remote.py s                                                                                                                                    [ 18%]
tests/io/complex/test_sicd.py .                                                                                                                                      [ 18%]
tests/io/complex/test_sio.py .                                                                                                                                       [ 18%]
tests/io/complex/test_utils.py .                                                                                                                                     [ 18%]
tests/io/complex/sicd_elements/test_sicd_elements_antenna.py ...                                                                                                     [ 19%]
tests/io/complex/sicd_elements/test_sicd_elements_base.py ...                                                                                                        [ 19%]
tests/io/complex/sicd_elements/test_sicd_elements_blocks.py .....................                                                                                    [ 22%]
tests/io/complex/sicd_elements/test_sicd_elements_collectioninfo.py ..                                                                                               [ 22%]
tests/io/complex/sicd_elements/test_sicd_elements_errorstatistics.py .                                                                                               [ 22%]
tests/io/complex/sicd_elements/test_sicd_elements_geodata.py ...                                                                                                     [ 22%]
tests/io/complex/sicd_elements/test_sicd_elements_grid.py ..                                                                                                         [ 23%]
tests/io/complex/sicd_elements/test_sicd_elements_imagecreation.py .                                                                                                 [ 23%]
tests/io/complex/sicd_elements/test_sicd_elements_imagedata.py .                                                                                                     [ 23%]
tests/io/complex/sicd_elements/test_sicd_elements_imageformation.py ......                                                                                           [ 24%]
tests/io/complex/sicd_elements/test_sicd_elements_matchinfo.py .                                                                                                     [ 24%]
tests/io/complex/sicd_elements/test_sicd_elements_pfa.py .                                                                                                           [ 24%]
tests/io/complex/sicd_elements/test_sicd_elements_position.py ...                                                                                                    [ 24%]
tests/io/complex/sicd_elements/test_sicd_elements_radarcollection.py ..............                                                                                  [ 26%]
tests/io/complex/sicd_elements/test_sicd_elements_radiometric.py .                                                                                                   [ 26%]
tests/io/complex/sicd_elements/test_sicd_elements_rgazcomp.py .                                                                                                      [ 26%]
tests/io/complex/sicd_elements/test_sicd_elements_rma.py ...                                                                                                         [ 26%]
tests/io/complex/sicd_elements/test_sicd_elements_scpcoa.py ...................                                                                                      [ 29%]
tests/io/complex/sicd_elements/test_sicd_elements_sicd.py ...................................                                                                        [ 33%]
tests/io/complex/sicd_elements/test_sicd_elements_timeline.py ..................                                                                                     [ 35%]
tests/io/complex/sicd_elements/test_sicd_elements_utils.py ...                                                                                                       [ 36%]
tests/io/general/test_base.py ...                                                                                                                                    [ 36%]
tests/io/general/test_data_segment.py ..........                                                                                                                     [ 37%]
tests/io/general/test_format_function.py ........                                                                                                                    [ 38%]
tests/io/general/test_nitf.py ..                                                                                                                                     [ 39%]
tests/io/general/test_nitf_headers.py .                                                                                                                              [ 39%]
tests/io/general/test_nitf_image.py ....                                                                                                                             [ 39%]
tests/io/general/test_tre.py ...                                                                                                                                     [ 40%]
tests/io/phase_history/test_cphd.py .........                                                                                                                        [ 41%]
tests/io/phase_history/test_cphd_versions.py .....                                                                                                                   [ 41%]
tests/io/phase_history/cphd1_elements/test_cphd.py ......                                                                                                            [ 42%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_antenna.py .....                                                                                           [ 43%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_blocks.py ....                                                                                             [ 43%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_channel.py .                                                                                               [ 43%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_data.py .                                                                                                  [ 44%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_dwell.py .                                                                                                 [ 44%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_geoinfo.py ...                                                                                             [ 44%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_global.py ..                                                                                               [ 44%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_pvp.py .                                                                                                   [ 44%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_referencegeometry.py .                                                                                     [ 45%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_supportarray.py ..                                                                                         [ 45%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_txrcv.py .                                                                                                 [ 45%]
tests/io/phase_history/cphd1_elements/test_utils.py .                                                                                                                [ 45%]
tests/io/product/test_reader.py ...s                                                                                                                                 [ 46%]
tests/io/product/test_sidd.py ..............                                                                                                                         [ 47%]
tests/io/product/test_sidd_schema.py .........                                                                                                                       [ 48%]
tests/io/product/test_sidd_writing.py ...                                                                                                                            [ 49%]
tests/io/product/sidd1_elements/test_exploitationfeatures.py .........................................................                                               [ 56%]
tests/io/product/sidd2_elements/test_exploitationfeatures.py ....................................................................                                    [ 64%]
tests/io/product/sidd3_elements/test_exploitationfeatures.py ....................................................................................................... [ 77%]
..............................................................................................................................                                       [ 93%]
tests/io/product/sidd3_elements/test_sidd3_elements.py .....                                                                                                         [ 93%]
tests/io/received/test_crsd.py .                                                                                                                                     [ 94%]
tests/processing/sicd/test_spectral_taper.py ........ss...........                                                                                                   [ 96%]
tests/utils/test_sicd_sidelobe_control.py ..                                                                                                                         [ 96%]
tests/visualization/test_cphd_kmz_product_creation.py ..                                                                                                             [ 97%]
tests/visualization/test_crsd_kmz_product_creation.py .                                                                                                              [ 97%]
tests/visualization/test_kmz_product_creation.py .x                                                                                                                  [ 97%]
tests/visualization/test_remap.py ....................                                                                                                               [100%]

============================================================================= warnings summary =============================================================================
tests/geometry/test_point_projection.py::test_image_to_ground_errors
tests/geometry/test_point_projection.py::test_image_to_ground_dem
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/geometry/point_projection.py:1882: RuntimeWarning: divide by zero encountered in double_scalars
    lon_grid_size = min(10, lat_grid_size/abs(numpy.sin(numpy.deg2rad(ref_llh[0]))))

tests/visualization/test_kmz_product_creation.py::test_create_kmz[True]
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/visualization/kmz_utils.py:169: RuntimeWarning: invalid value encountered in double_scalars
    + dir_z**2 * semiaxis_a**2 * semiaxis_b**2

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================= 792 passed, 11 skipped, 1 xfailed, 3 warnings in 46.81s ==========================================================
nox > Session test(version='3.6') was successful.
nox > Running session test(version='3.11')
nox > Creating conda env in .nox/test-version-3-11 with python
nox > conda install --yes --prefix /home/vscuser/git/glweb/software/third-party/sarpy/.nox/test-version-3-11 python=3.11
nox > python -m pip install '.[all]'
nox > pytest tests
=========================================================================== test session starts ============================================================================
platform linux -- Python 3.11.10, pytest-8.3.3, pluggy-1.5.0
rootdir: /home/vscuser/git/glweb/software/third-party/sarpy
collected 804 items                                                                                                                                                        

tests/consistency/test_consistency.py ........                                                                                                                       [  0%]
tests/consistency/test_cphd_consistency.py ..............................................................                                                            [  8%]
tests/consistency/test_sicd_consistency.py ...                                                                                                                       [  9%]
tests/consistency/test_sidd_consistency.py .....                                                                                                                     [  9%]
tests/geometry/test_geocoords.py ..........                                                                                                                          [ 10%]
tests/geometry/test_geometry_elements.py ..........                                                                                                                  [ 12%]
tests/geometry/test_latlon.py ...                                                                                                                                    [ 12%]
tests/geometry/test_point_projection.py ..............                                                                                                               [ 14%]
tests/io/DEM/test_dted.py ..                                                                                                                                         [ 14%]
tests/io/DEM/test_geoid.py .                                                                                                                                         [ 14%]
tests/io/DEM/test_geotiff1deg_list.py ....                                                                                                                           [ 15%]
tests/io/DEM/test_geotiff1deg_reader.py ........                                                                                                                     [ 16%]
tests/io/complex/sicd_elements/test_sicd_elements_antenna.py ...                                                                                                     [ 16%]
tests/io/complex/sicd_elements/test_sicd_elements_base.py ...                                                                                                        [ 16%]
tests/io/complex/sicd_elements/test_sicd_elements_blocks.py .....................                                                                                    [ 19%]
tests/io/complex/sicd_elements/test_sicd_elements_collectioninfo.py ..                                                                                               [ 19%]
tests/io/complex/sicd_elements/test_sicd_elements_errorstatistics.py .                                                                                               [ 19%]
tests/io/complex/sicd_elements/test_sicd_elements_geodata.py ...                                                                                                     [ 20%]
tests/io/complex/sicd_elements/test_sicd_elements_grid.py ..                                                                                                         [ 20%]
tests/io/complex/sicd_elements/test_sicd_elements_imagecreation.py .                                                                                                 [ 20%]
tests/io/complex/sicd_elements/test_sicd_elements_imagedata.py .                                                                                                     [ 20%]
tests/io/complex/sicd_elements/test_sicd_elements_imageformation.py ......                                                                                           [ 21%]
tests/io/complex/sicd_elements/test_sicd_elements_matchinfo.py .                                                                                                     [ 21%]
tests/io/complex/sicd_elements/test_sicd_elements_pfa.py .                                                                                                           [ 21%]
tests/io/complex/sicd_elements/test_sicd_elements_position.py ...                                                                                                    [ 22%]
tests/io/complex/sicd_elements/test_sicd_elements_radarcollection.py ..............                                                                                  [ 23%]
tests/io/complex/sicd_elements/test_sicd_elements_radiometric.py .                                                                                                   [ 24%]
tests/io/complex/sicd_elements/test_sicd_elements_rgazcomp.py .                                                                                                      [ 24%]
tests/io/complex/sicd_elements/test_sicd_elements_rma.py ...                                                                                                         [ 24%]
tests/io/complex/sicd_elements/test_sicd_elements_scpcoa.py ...................                                                                                      [ 26%]
tests/io/complex/sicd_elements/test_sicd_elements_sicd.py ...................................                                                                        [ 31%]
tests/io/complex/sicd_elements/test_sicd_elements_timeline.py ..................                                                                                     [ 33%]
tests/io/complex/sicd_elements/test_sicd_elements_utils.py ...                                                                                                       [ 33%]
tests/io/complex/test_other_nitf.py ...                                                                                                                              [ 34%]
tests/io/complex/test_reader.py ..sss.ssss.                                                                                                                          [ 35%]
tests/io/complex/test_remote.py s                                                                                                                                    [ 35%]
tests/io/complex/test_sicd.py .                                                                                                                                      [ 35%]
tests/io/complex/test_sio.py .                                                                                                                                       [ 35%]
tests/io/complex/test_utils.py .                                                                                                                                     [ 36%]
tests/io/general/test_base.py ...                                                                                                                                    [ 36%]
tests/io/general/test_data_segment.py ..........                                                                                                                     [ 37%]
tests/io/general/test_format_function.py ........                                                                                                                    [ 38%]
tests/io/general/test_nitf.py ..                                                                                                                                     [ 38%]
tests/io/general/test_nitf_headers.py .                                                                                                                              [ 39%]
tests/io/general/test_nitf_image.py ....                                                                                                                             [ 39%]
tests/io/general/test_tre.py ...                                                                                                                                     [ 39%]
tests/io/phase_history/cphd1_elements/test_cphd.py ......                                                                                                            [ 40%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_antenna.py .....                                                                                           [ 41%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_blocks.py ....                                                                                             [ 41%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_channel.py .                                                                                               [ 41%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_data.py .                                                                                                  [ 42%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_dwell.py .                                                                                                 [ 42%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_geoinfo.py ...                                                                                             [ 42%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_global.py ..                                                                                               [ 42%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_pvp.py .                                                                                                   [ 42%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_referencegeometry.py .                                                                                     [ 43%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_supportarray.py ..                                                                                         [ 43%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_txrcv.py .                                                                                                 [ 43%]
tests/io/phase_history/cphd1_elements/test_utils.py .                                                                                                                [ 43%]
tests/io/phase_history/test_cphd.py .........                                                                                                                        [ 44%]
tests/io/phase_history/test_cphd_versions.py .....                                                                                                                   [ 45%]
tests/io/product/sidd1_elements/test_exploitationfeatures.py .........................................................                                               [ 52%]
tests/io/product/sidd2_elements/test_exploitationfeatures.py ....................................................................                                    [ 60%]
tests/io/product/sidd3_elements/test_exploitationfeatures.py ....................................................................................................... [ 73%]
..............................................................................................................................                                       [ 89%]
tests/io/product/sidd3_elements/test_sidd3_elements.py .....                                                                                                         [ 89%]
tests/io/product/test_reader.py ...s                                                                                                                                 [ 90%]
tests/io/product/test_sidd.py ..............                                                                                                                         [ 92%]
tests/io/product/test_sidd_schema.py .........                                                                                                                       [ 93%]
tests/io/product/test_sidd_writing.py ...                                                                                                                            [ 93%]
tests/io/received/test_crsd.py .                                                                                                                                     [ 93%]
tests/io/test_kml.py .                                                                                                                                               [ 93%]
tests/processing/sicd/test_spectral_taper.py .....................                                                                                                   [ 96%]
tests/test_class_string.py .                                                                                                                                         [ 96%]
tests/utils/test_sicd_sidelobe_control.py ..                                                                                                                         [ 96%]
tests/visualization/test_cphd_kmz_product_creation.py ..                                                                                                             [ 97%]
tests/visualization/test_crsd_kmz_product_creation.py .                                                                                                              [ 97%]
tests/visualization/test_kmz_product_creation.py .x                                                                                                                  [ 97%]
tests/visualization/test_remap.py ....................                                                                                                               [100%]

============================================================================= warnings summary =============================================================================
tests/geometry/test_geometry_elements.py: 77 warnings
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/geometry/geometry_elements.py:131: DeprecationWarning: Arrays of 2-dimensional vectors are deprecated. Use arrays
 of 3-dimensional vectors instead. (deprecated in NumPy 2.0)                                                                                                                    dir_cross = float(numpy.cross(R, S))  # the scalar cross product of the direction vectors

tests/geometry/test_geometry_elements.py: 43 warnings
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/geometry/geometry_elements.py:137: DeprecationWarning: Arrays of 2-dimensional vectors are deprecated. Use arrays
 of 3-dimensional vectors instead. (deprecated in NumPy 2.0)                                                                                                                    end_cross_0 = float(numpy.cross(Q-P, S))

tests/geometry/test_geometry_elements.py: 43 warnings
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/geometry/geometry_elements.py:138: DeprecationWarning: Arrays of 2-dimensional vectors are deprecated. Use arrays
 of 3-dimensional vectors instead. (deprecated in NumPy 2.0)                                                                                                                    end_cross_1 = float(numpy.cross(Q-P, R))

tests/geometry/test_point_projection.py::test_image_to_ground_errors
tests/geometry/test_point_projection.py::test_image_to_ground_dem
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/geometry/point_projection.py:1882: RuntimeWarning: divide by zero encountered in scalar divide
    lon_grid_size = min(10, lat_grid_size/abs(numpy.sin(numpy.deg2rad(ref_llh[0]))))

tests/test_class_string.py::TestClassString::test_class_str
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/annotation/afrl_rde_schema/__init__.py:7: DeprecationWarning: pkg_resources is deprecated as an API. See https://
setuptools.pypa.io/en/latest/pkg_resources.html                                                                                                                                 import pkg_resources

tests/visualization/test_kmz_product_creation.py::test_create_kmz[True]
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/visualization/kmz_utils.py:145: RuntimeWarning: invalid value encountered in scalar divide
    distance = (

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================= 794 passed, 9 skipped, 1 xfailed, 167 warnings in 40.00s =========================================================
nox > Session test(version='3.11') was successful.
nox > Ran multiple sessions:
nox > * test(version='3.6'): success
nox > * test(version='3.11'): success

```

</p>
</details> 