### PR TITLE
Bugfix: implicit edges in some ortho_rectify bounds calculations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ release points are not being annotated in GitHub.
 - SIDD ProductProcessing handling
 - NITF attachment level interpretation
 - Enable TREElement.to_dict() to handle floating-point values
+- Consider implicit edges in certain `sarpy/processing/ortho_rectify` bounds calculations
 
 ## [1.3.59] - 2024-10-03
 ### Added

--- a/sarpy/__about__.py
+++ b/sarpy/__about__.py
@@ -27,7 +27,7 @@ __all__ = ['__version__',
            '__license__', '__copyright__']
 
 from sarpy.__details__ import __classification__, _post_identifier
-_version_number = '1.3.60a6'
+_version_number = '1.3.60a7'
 
 __version__ = _version_number + _post_identifier
 

--- a/sarpy/processing/ortho_rectify/ortho_methods.py
+++ b/sarpy/processing/ortho_rectify/ortho_methods.py
@@ -26,7 +26,8 @@ logger = logging.getLogger(__name__)
 
 def _linear_fill(pixel_array, fill_interval=1):
     """
-    This is to final in linear features in pixel space at the given interval.
+    This is to fill in linear features in pixel space at the given interval.
+    When the first and last vertices are not identical, an implicit edge connecting them is also filled.
 
     Parameters
     ----------
@@ -68,6 +69,9 @@ def _linear_fill(pixel_array, fill_interval=1):
         start_segment = pixel_array[i, :]
         end_segment = pixel_array[i+1, :]
         segments.append(make_segment(start_segment, end_segment))
+    if not numpy.array_equal(pixel_array[0], pixel_array[-1]):
+        # include line connecting  first and last points if they are not the same
+        segments.append(make_segment(pixel_array[0], pixel_array[-1]))
     return numpy.vstack(segments)
 
 
@@ -417,6 +421,7 @@ class OrthorectificationHelper(object):
         ----------
         coordinates : GeometryObject|numpy.ndarray|list|tuple
             The coordinate system of the input will be assumed to be pixel space.
+            When the first and last vertices are not identical, an implicit edge connecting them is assumed.
 
         Returns
         -------
@@ -425,13 +430,15 @@ class OrthorectificationHelper(object):
         """
 
         if isinstance(coordinates, GeometryObject):
-            pixel_bounds = coordinates.get_bbox()
-            siz = int(len(pixel_bounds)/2)
+            # pixel_bounds.shape is (min/max, coordinate-dimensionality)
+            pixel_bounds = numpy.array(coordinates.get_bbox()).reshape((2, -1))
+            # assume first two coordinate dims are row/col and ignore the rest
+            (minrow, mincol), (maxrow, maxcol) = pixel_bounds[:, :2]
             coordinates = numpy.array(
-                [[pixel_bounds[0], pixel_bounds[1]],
-                 [pixel_bounds[siz], pixel_bounds[1]],
-                 [pixel_bounds[siz], pixel_bounds[siz]],
-                 [pixel_bounds[0], pixel_bounds[siz]]], dtype=numpy.float64)
+                [[minrow, mincol],
+                 [maxrow, mincol],
+                 [maxrow, maxcol],
+                 [minrow, maxcol]], dtype=numpy.float64)
         filled_coordinates = _linear_fill(coordinates, fill_interval=1)
         ortho = self.proj_helper.pixel_to_ortho(filled_coordinates)
         return self.proj_helper.get_pixel_array_bounds(ortho)

--- a/tests/processing/test_ortho_rectify.py
+++ b/tests/processing/test_ortho_rectify.py
@@ -1,0 +1,38 @@
+import pathlib
+
+import numpy as np
+import pytest
+
+import sarpy.geometry.geometry_elements
+import sarpy.io.complex.sicd
+import sarpy.processing.ortho_rectify
+
+
+@pytest.fixture
+def temp_sicd(tmp_path):
+    sicd_xml = pathlib.Path(__file__).parents[1] / "data/example.sicd.xml"
+    sicd_meta = sarpy.io.complex.sicd.SICDType.from_xml_file(str(sicd_xml))
+    sicd_file = tmp_path / "data-example.sicd"
+    with sarpy.io.complex.sicd.SICDWriter(str(sicd_file), sicd_meta):
+        pass  # don't care about pixels
+    yield sicd_file
+
+
+def test_ortho_iterator_bounds(temp_sicd):
+    reader = sarpy.io.complex.sicd.is_a(str(temp_sicd))
+    # contrived test case to exaggerate range/range-rate curvature on "closing" edge
+    reader.sicd_meta.Grid.Col.SS *= 100
+    rowcol_vertices_open = np.array([
+        [1494, 1723],
+        [0, 1723],
+        [0, 0],
+        [1494, 0],
+    ])
+    rowcol_vertices_closed = np.concatenate((rowcol_vertices_open, rowcol_vertices_open[0, np.newaxis]), axis=0)
+    rc_multipoint = sarpy.geometry.geometry_elements.MultiPoint(rowcol_vertices_open)
+    ortho_helper = sarpy.processing.ortho_rectify.OrthorectificationHelper(reader)
+    bounds_open = ortho_helper.get_orthorectification_bounds_from_pixel_object(rowcol_vertices_open)
+    bounds_closed = ortho_helper.get_orthorectification_bounds_from_pixel_object(rowcol_vertices_closed)
+    bounds_geo = ortho_helper.get_orthorectification_bounds_from_pixel_object(rc_multipoint)
+    assert np.allclose(bounds_open, bounds_closed)
+    assert np.allclose(bounds_open, bounds_geo)


### PR DESCRIPTION
# Description
This PR addresses two bugs discovered in some of the bounds calculations `sarpy/processing/ortho_rectify/ortho_methods.py`

1. `_linear_fill` traverses vertices pairwise without connecting the the first and last, but the calling functions only provided the unique vertices (`get_full_ortho_bounds`, `get_valid_ortho_bounds`, `extract_pixel_bounds`) or at best left it semi-ambiguous (`get_orthorectification_bounds_from_pixel_object`)
2. in `get_orthorectification_bounds_from_pixel_object` when constructing coordinates from a `GeometryObject`, the indexing is incorrect resulting in the max column being ignored

Both of these bugs can be demonstrated by running the new test against `integration/1.3.60`:

```
(Pdb) p bounds_open
array([  -2962,    -339, -114961,  115282])
(Pdb) p bounds_closed
array([  -2962,    1638, -114961,  115282])
(Pdb) p bounds_geo
array([  -2962,    1638, -114961,   85013])
```

<details><summary>figures illustrating bugs after projection and fill</summary>

| bounds_open | bounds_closed | bounds_geo |
| ------ | ------ | ------ |
| ![image](https://github.com/user-attachments/assets/c9b1ad38-50b4-4bf1-b4d3-37da35f5fc74) | ![image](https://github.com/user-attachments/assets/8b38fad8-ab38-41f2-a7d9-f4bbe95f2b03) | ![image](https://github.com/user-attachments/assets/669cca3d-49b3-4d81-a7c1-8ceb44fa3909) |


</details>

# Test Results

<details><summary>tests pass</summary>

```
SARPY_TEST_PATH=/data/sarpy_test/ nox
nox > Running session test(version='3.6')
nox > Creating conda env in .nox/test-version-3-6 with python
nox > conda install --yes --prefix /home/vscuser/git/glweb/software/third-party/sarpy/.nox/test-version-3-6 python=3.6
nox > python -m pip install '.[all]'
nox > pytest tests
=========================================================================== test session starts ============================================================================
platform linux -- Python 3.6.13, pytest-7.0.1, pluggy-1.0.0
rootdir: /home/vscuser/git/glweb/software/third-party/sarpy
collected 805 items                                                                                                                                                        

tests/test_class_string.py .                                                                                                                                         [  0%]
tests/consistency/test_consistency.py ........                                                                                                                       [  1%]
tests/consistency/test_cphd_consistency.py ..............................................................                                                            [  8%]
tests/consistency/test_sicd_consistency.py ...                                                                                                                       [  9%]
tests/consistency/test_sidd_consistency.py .....                                                                                                                     [  9%]
tests/geometry/test_geocoords.py ..........                                                                                                                          [ 11%]
tests/geometry/test_geometry_elements.py ..........                                                                                                                  [ 12%]
tests/geometry/test_latlon.py ...                                                                                                                                    [ 12%]
tests/geometry/test_point_projection.py ..............                                                                                                               [ 14%]
tests/io/test_kml.py .                                                                                                                                               [ 14%]
tests/io/DEM/test_dted.py ..                                                                                                                                         [ 14%]
tests/io/DEM/test_geoid.py .                                                                                                                                         [ 14%]
tests/io/DEM/test_geotiff1deg_list.py ....                                                                                                                           [ 15%]
tests/io/DEM/test_geotiff1deg_reader.py ........                                                                                                                     [ 16%]
tests/io/complex/test_other_nitf.py ...                                                                                                                              [ 16%]
tests/io/complex/test_reader.py ..sss.ssss.                                                                                                                          [ 18%]
tests/io/complex/test_remote.py s                                                                                                                                    [ 18%]
tests/io/complex/test_sicd.py .                                                                                                                                      [ 18%]
tests/io/complex/test_sio.py .                                                                                                                                       [ 18%]
tests/io/complex/test_utils.py .                                                                                                                                     [ 18%]
tests/io/complex/sicd_elements/test_sicd_elements_antenna.py ...                                                                                                     [ 19%]
tests/io/complex/sicd_elements/test_sicd_elements_base.py ...                                                                                                        [ 19%]
tests/io/complex/sicd_elements/test_sicd_elements_blocks.py .....................                                                                                    [ 21%]
tests/io/complex/sicd_elements/test_sicd_elements_collectioninfo.py ..                                                                                               [ 22%]
tests/io/complex/sicd_elements/test_sicd_elements_errorstatistics.py .                                                                                               [ 22%]
tests/io/complex/sicd_elements/test_sicd_elements_geodata.py ...                                                                                                     [ 22%]
tests/io/complex/sicd_elements/test_sicd_elements_grid.py ..                                                                                                         [ 22%]
tests/io/complex/sicd_elements/test_sicd_elements_imagecreation.py .                                                                                                 [ 23%]
tests/io/complex/sicd_elements/test_sicd_elements_imagedata.py .                                                                                                     [ 23%]
tests/io/complex/sicd_elements/test_sicd_elements_imageformation.py ......                                                                                           [ 23%]
tests/io/complex/sicd_elements/test_sicd_elements_matchinfo.py .                                                                                                     [ 24%]
tests/io/complex/sicd_elements/test_sicd_elements_pfa.py .                                                                                                           [ 24%]
tests/io/complex/sicd_elements/test_sicd_elements_position.py ...                                                                                                    [ 24%]
tests/io/complex/sicd_elements/test_sicd_elements_radarcollection.py ..............                                                                                  [ 26%]
tests/io/complex/sicd_elements/test_sicd_elements_radiometric.py .                                                                                                   [ 26%]
tests/io/complex/sicd_elements/test_sicd_elements_rgazcomp.py .                                                                                                      [ 26%]
tests/io/complex/sicd_elements/test_sicd_elements_rma.py ...                                                                                                         [ 26%]
tests/io/complex/sicd_elements/test_sicd_elements_scpcoa.py ...................                                                                                      [ 29%]
tests/io/complex/sicd_elements/test_sicd_elements_sicd.py ...................................                                                                        [ 33%]
tests/io/complex/sicd_elements/test_sicd_elements_timeline.py ..................                                                                                     [ 35%]
tests/io/complex/sicd_elements/test_sicd_elements_utils.py ...                                                                                                       [ 36%]
tests/io/general/test_base.py ...                                                                                                                                    [ 36%]
tests/io/general/test_data_segment.py ..........                                                                                                                     [ 37%]
tests/io/general/test_format_function.py ........                                                                                                                    [ 38%]
tests/io/general/test_nitf.py ..                                                                                                                                     [ 39%]
tests/io/general/test_nitf_headers.py .                                                                                                                              [ 39%]
tests/io/general/test_nitf_image.py ....                                                                                                                             [ 39%]
tests/io/general/test_tre.py ...                                                                                                                                     [ 40%]
tests/io/phase_history/test_cphd.py .........                                                                                                                        [ 41%]
tests/io/phase_history/test_cphd_versions.py .....                                                                                                                   [ 41%]
tests/io/phase_history/cphd1_elements/test_cphd.py ......                                                                                                            [ 42%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_antenna.py .....                                                                                           [ 43%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_blocks.py ....                                                                                             [ 43%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_channel.py .                                                                                               [ 43%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_data.py .                                                                                                  [ 43%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_dwell.py .                                                                                                 [ 44%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_geoinfo.py ...                                                                                             [ 44%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_global.py ..                                                                                               [ 44%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_pvp.py .                                                                                                   [ 44%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_referencegeometry.py .                                                                                     [ 44%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_supportarray.py ..                                                                                         [ 45%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_txrcv.py .                                                                                                 [ 45%]
tests/io/phase_history/cphd1_elements/test_utils.py .                                                                                                                [ 45%]
tests/io/product/test_reader.py ...s                                                                                                                                 [ 45%]
tests/io/product/test_sidd.py ..............                                                                                                                         [ 47%]
tests/io/product/test_sidd_schema.py .........                                                                                                                       [ 48%]
tests/io/product/test_sidd_writing.py ...                                                                                                                            [ 49%]
tests/io/product/sidd1_elements/test_exploitationfeatures.py .........................................................                                               [ 56%]
tests/io/product/sidd2_elements/test_exploitationfeatures.py ....................................................................                                    [ 64%]
tests/io/product/sidd3_elements/test_exploitationfeatures.py ....................................................................................................... [ 77%]
..............................................................................................................................                                       [ 93%]
tests/io/product/sidd3_elements/test_sidd3_elements.py .....                                                                                                         [ 93%]
tests/io/received/test_crsd.py .                                                                                                                                     [ 93%]
tests/processing/test_ortho_rectify.py .                                                                                                                             [ 94%]
tests/processing/sicd/test_spectral_taper.py ........ss...........                                                                                                   [ 96%]
tests/utils/test_sicd_sidelobe_control.py ..                                                                                                                         [ 96%]
tests/visualization/test_cphd_kmz_product_creation.py ..                                                                                                             [ 97%]
tests/visualization/test_crsd_kmz_product_creation.py .                                                                                                              [ 97%]
tests/visualization/test_kmz_product_creation.py .x                                                                                                                  [ 97%]
tests/visualization/test_remap.py ....................                                                                                                               [100%]

============================================================================= warnings summary =============================================================================
tests/geometry/test_point_projection.py::test_image_to_ground_errors
tests/geometry/test_point_projection.py::test_image_to_ground_dem
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/geometry/point_projection.py:1882: RuntimeWarning: divide by zero encountered in double_scalars
    lon_grid_size = min(10, lat_grid_size/abs(numpy.sin(numpy.deg2rad(ref_llh[0]))))

tests/visualization/test_kmz_product_creation.py::test_create_kmz[True]
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/visualization/kmz_utils.py:169: RuntimeWarning: invalid value encountered in double_scalars
    + dir_z**2 * semiaxis_a**2 * semiaxis_b**2

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
==================================================== 793 passed, 11 skipped, 1 xfailed, 3 warnings in 110.12s (0:01:50) ====================================================
nox > Session test(version='3.6') was successful.
nox > Running session test(version='3.11')
nox > Creating conda env in .nox/test-version-3-11 with python
nox > conda install --yes --prefix /home/vscuser/git/glweb/software/third-party/sarpy/.nox/test-version-3-11 python=3.11
nox > python -m pip install '.[all]'
nox > pytest tests
=========================================================================== test session starts ============================================================================
platform linux -- Python 3.11.10, pytest-8.3.3, pluggy-1.5.0
rootdir: /home/vscuser/git/glweb/software/third-party/sarpy
collected 805 items                                                                                                                                                        

tests/consistency/test_consistency.py ........                                                                                                                       [  0%]
tests/consistency/test_cphd_consistency.py ..............................................................                                                            [  8%]
tests/consistency/test_sicd_consistency.py ...                                                                                                                       [  9%]
tests/consistency/test_sidd_consistency.py .....                                                                                                                     [  9%]
tests/geometry/test_geocoords.py ..........                                                                                                                          [ 10%]
tests/geometry/test_geometry_elements.py ..........                                                                                                                  [ 12%]
tests/geometry/test_latlon.py ...                                                                                                                                    [ 12%]
tests/geometry/test_point_projection.py ..............                                                                                                               [ 14%]
tests/io/DEM/test_dted.py ..                                                                                                                                         [ 14%]
tests/io/DEM/test_geoid.py .                                                                                                                                         [ 14%]
tests/io/DEM/test_geotiff1deg_list.py ....                                                                                                                           [ 15%]
tests/io/DEM/test_geotiff1deg_reader.py ........                                                                                                                     [ 16%]
tests/io/complex/sicd_elements/test_sicd_elements_antenna.py ...                                                                                                     [ 16%]
tests/io/complex/sicd_elements/test_sicd_elements_base.py ...                                                                                                        [ 16%]
tests/io/complex/sicd_elements/test_sicd_elements_blocks.py .....................                                                                                    [ 19%]
tests/io/complex/sicd_elements/test_sicd_elements_collectioninfo.py ..                                                                                               [ 19%]
tests/io/complex/sicd_elements/test_sicd_elements_errorstatistics.py .                                                                                               [ 19%]
tests/io/complex/sicd_elements/test_sicd_elements_geodata.py ...                                                                                                     [ 20%]
tests/io/complex/sicd_elements/test_sicd_elements_grid.py ..                                                                                                         [ 20%]
tests/io/complex/sicd_elements/test_sicd_elements_imagecreation.py .                                                                                                 [ 20%]
tests/io/complex/sicd_elements/test_sicd_elements_imagedata.py .                                                                                                     [ 20%]
tests/io/complex/sicd_elements/test_sicd_elements_imageformation.py ......                                                                                           [ 21%]
tests/io/complex/sicd_elements/test_sicd_elements_matchinfo.py .                                                                                                     [ 21%]
tests/io/complex/sicd_elements/test_sicd_elements_pfa.py .                                                                                                           [ 21%]
tests/io/complex/sicd_elements/test_sicd_elements_position.py ...                                                                                                    [ 22%]
tests/io/complex/sicd_elements/test_sicd_elements_radarcollection.py ..............                                                                                  [ 23%]
tests/io/complex/sicd_elements/test_sicd_elements_radiometric.py .                                                                                                   [ 23%]
tests/io/complex/sicd_elements/test_sicd_elements_rgazcomp.py .                                                                                                      [ 24%]
tests/io/complex/sicd_elements/test_sicd_elements_rma.py ...                                                                                                         [ 24%]
tests/io/complex/sicd_elements/test_sicd_elements_scpcoa.py ...................                                                                                      [ 26%]
tests/io/complex/sicd_elements/test_sicd_elements_sicd.py ...................................                                                                        [ 31%]
tests/io/complex/sicd_elements/test_sicd_elements_timeline.py ..................                                                                                     [ 33%]
tests/io/complex/sicd_elements/test_sicd_elements_utils.py ...                                                                                                       [ 33%]
tests/io/complex/test_other_nitf.py ...                                                                                                                              [ 34%]
tests/io/complex/test_reader.py ..sss.ssss.                                                                                                                          [ 35%]
tests/io/complex/test_remote.py s                                                                                                                                    [ 35%]
tests/io/complex/test_sicd.py .                                                                                                                                      [ 35%]
tests/io/complex/test_sio.py .                                                                                                                                       [ 35%]
tests/io/complex/test_utils.py .                                                                                                                                     [ 36%]
tests/io/general/test_base.py ...                                                                                                                                    [ 36%]
tests/io/general/test_data_segment.py ..........                                                                                                                     [ 37%]
tests/io/general/test_format_function.py ........                                                                                                                    [ 38%]
tests/io/general/test_nitf.py ..                                                                                                                                     [ 38%]
tests/io/general/test_nitf_headers.py .                                                                                                                              [ 39%]
tests/io/general/test_nitf_image.py ....                                                                                                                             [ 39%]
tests/io/general/test_tre.py ...                                                                                                                                     [ 39%]
tests/io/phase_history/cphd1_elements/test_cphd.py ......                                                                                                            [ 40%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_antenna.py .....                                                                                           [ 41%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_blocks.py ....                                                                                             [ 41%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_channel.py .                                                                                               [ 41%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_data.py .                                                                                                  [ 41%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_dwell.py .                                                                                                 [ 42%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_geoinfo.py ...                                                                                             [ 42%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_global.py ..                                                                                               [ 42%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_pvp.py .                                                                                                   [ 42%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_referencegeometry.py .                                                                                     [ 42%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_supportarray.py ..                                                                                         [ 43%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_txrcv.py .                                                                                                 [ 43%]
tests/io/phase_history/cphd1_elements/test_utils.py .                                                                                                                [ 43%]
tests/io/phase_history/test_cphd.py .........                                                                                                                        [ 44%]
tests/io/phase_history/test_cphd_versions.py .....                                                                                                                   [ 45%]
tests/io/product/sidd1_elements/test_exploitationfeatures.py .........................................................                                               [ 52%]
tests/io/product/sidd2_elements/test_exploitationfeatures.py ....................................................................                                    [ 60%]
tests/io/product/sidd3_elements/test_exploitationfeatures.py ....................................................................................................... [ 73%]
..............................................................................................................................                                       [ 89%]
tests/io/product/sidd3_elements/test_sidd3_elements.py .....                                                                                                         [ 89%]
tests/io/product/test_reader.py ...s                                                                                                                                 [ 90%]
tests/io/product/test_sidd.py ..............                                                                                                                         [ 92%]
tests/io/product/test_sidd_schema.py .........                                                                                                                       [ 93%]
tests/io/product/test_sidd_writing.py ...                                                                                                                            [ 93%]
tests/io/received/test_crsd.py .                                                                                                                                     [ 93%]
tests/io/test_kml.py .                                                                                                                                               [ 93%]
tests/processing/sicd/test_spectral_taper.py .....................                                                                                                   [ 96%]
tests/processing/test_ortho_rectify.py .                                                                                                                             [ 96%]
tests/test_class_string.py .                                                                                                                                         [ 96%]
tests/utils/test_sicd_sidelobe_control.py ..                                                                                                                         [ 96%]
tests/visualization/test_cphd_kmz_product_creation.py ..                                                                                                             [ 97%]
tests/visualization/test_crsd_kmz_product_creation.py .                                                                                                              [ 97%]
tests/visualization/test_kmz_product_creation.py .x                                                                                                                  [ 97%]
tests/visualization/test_remap.py ....................                                                                                                               [100%]

============================================================================= warnings summary =============================================================================
tests/geometry/test_geometry_elements.py: 77 warnings
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/geometry/geometry_elements.py:131: DeprecationWarning: Arrays of 2-dimensional vectors are deprecated. Use arrays
 of 3-dimensional vectors instead. (deprecated in NumPy 2.0)                                                                                                                    dir_cross = float(numpy.cross(R, S))  # the scalar cross product of the direction vectors

tests/geometry/test_geometry_elements.py: 43 warnings
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/geometry/geometry_elements.py:137: DeprecationWarning: Arrays of 2-dimensional vectors are deprecated. Use arrays
 of 3-dimensional vectors instead. (deprecated in NumPy 2.0)                                                                                                                    end_cross_0 = float(numpy.cross(Q-P, S))

tests/geometry/test_geometry_elements.py: 43 warnings
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/geometry/geometry_elements.py:138: DeprecationWarning: Arrays of 2-dimensional vectors are deprecated. Use arrays
 of 3-dimensional vectors instead. (deprecated in NumPy 2.0)                                                                                                                    end_cross_1 = float(numpy.cross(Q-P, R))

tests/geometry/test_point_projection.py::test_image_to_ground_errors
tests/geometry/test_point_projection.py::test_image_to_ground_dem
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/geometry/point_projection.py:1882: RuntimeWarning: divide by zero encountered in scalar divide
    lon_grid_size = min(10, lat_grid_size/abs(numpy.sin(numpy.deg2rad(ref_llh[0]))))

tests/test_class_string.py::TestClassString::test_class_str
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/annotation/afrl_rde_schema/__init__.py:7: DeprecationWarning: pkg_resources is deprecated as an API. See https://
setuptools.pypa.io/en/latest/pkg_resources.html                                                                                                                                 import pkg_resources

tests/visualization/test_kmz_product_creation.py::test_create_kmz[True]
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/visualization/kmz_utils.py:145: RuntimeWarning: invalid value encountered in scalar divide
    distance = (

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================= 795 passed, 9 skipped, 1 xfailed, 167 warnings in 30.81s =========================================================
nox > Session test(version='3.11') was successful.
nox > Ran multiple sessions:
nox > * test(version='3.6'): success
nox > * test(version='3.11'): success

```

</details>