### PR TITLE
Restore missing antenna beam footprints in some KMZs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ release points are not being annotated in GitHub.
 - NITF attachment level interpretation
 - Enable TREElement.to_dict() to handle floating-point values
 - Consider implicit edges in certain `sarpy/processing/ortho_rectify` bounds calculations
+- Restored missing antenna beam footprints in some KMZs
 
 ## [1.3.59] - 2024-10-03
 ### Added

--- a/sarpy/__about__.py
+++ b/sarpy/__about__.py
@@ -27,7 +27,7 @@ __all__ = ['__version__',
            '__license__', '__copyright__']
 
 from sarpy.__details__ import __classification__, _post_identifier
-_version_number = '1.3.60a7'
+_version_number = '1.3.60a8'
 
 __version__ = _version_number + _post_identifier
 

--- a/sarpy/visualization/kmz_utils.py
+++ b/sarpy/visualization/kmz_utils.py
@@ -7,9 +7,9 @@ __author__ = "Valkyrie Systems Corporation"
 
 import logging
 
-import matplotlib.path
 import matplotlib.pyplot as plt
 import numpy as np
+import shapely.geometry as shg
 
 from sarpy.geometry.geocoords import ecf_to_geodetic
 
@@ -248,34 +248,37 @@ def make_beam_footprints(
 ):
     """Attempt to make beam footprints for the labelled slowtimes"""
 
-    approx_gain_coefs = np.zeros((3, 3))
-    approx_gain_coefs += np.pad(array_gain_poly.Coefs, [(0, 3), (0, 3)])[:3, :3]
-    approx_gain_coefs += np.pad(element_gain_poly.Coefs, [(0, 3), (0, 3)])[:3, :3]
+    def _find_central_contour(max_dc, eb_dcx, eb_dcy):
+        Ns = 201
+        dcs = np.linspace(-max_dc, max_dc, Ns)
+        dcx, dcy = np.meshgrid(dcs, dcs, indexing="ij")
+        gain_pattern = array_gain_poly(dcx, dcy) + element_gain_poly(dcx + eb_dcx, dcy + eb_dcy)
+        contour_sets = plt.contour(dcx, dcy, gain_pattern, levels=[contour_level])
+        plt.close()  # close the figure created by contour
 
-    Ns = 201
-    db_down = 10  # dB down from peak
-    deltaDC_Xmax = np.abs(
-        (
-            -approx_gain_coefs[1, 0]
-            + np.sqrt(
-                approx_gain_coefs[1, 0] ** 2 - 4 * approx_gain_coefs[2, 0] * db_down
+        # We don't know the validity range of the gain polynomials and may have gone
+        # outside, resulting in multiple contours
+
+        # Only keep contours that form a closed shape
+        try:
+            paths = contour_sets.get_paths()
+        except AttributeError:
+            # matplotlib deprecated collections attribute in 3.8
+            paths = contour_sets.collections[0].get_paths()
+
+        polygons = [
+            polygon
+            for path in paths
+            for polygon in path.to_polygons(closed_only=False)
+            if np.array_equal(polygon[0], polygon[-1]) and len(polygon) > 1  # only consider closed polygons
+        ]
+        if polygons:
+            # Keep contour closest to center
+            return min(
+                polygons, key=lambda vertices: np.linalg.norm(np.mean(vertices, axis=0))
             )
-        )
-        / (2 * approx_gain_coefs[2, 0])
-    )
-    deltaDC_Ymax = np.abs(
-        (
-            -approx_gain_coefs[0, 1]
-            + np.sqrt(
-                approx_gain_coefs[0, 1] ** 2 - 4 * approx_gain_coefs[0, 2] * db_down
-            )
-        )
-        / (2 * approx_gain_coefs[0, 2])
-    )
-    X = np.linspace(-deltaDC_Xmax, deltaDC_Xmax, Ns)
-    Y = np.linspace(-deltaDC_Ymax, deltaDC_Ymax, Ns)
-    XXc, YYc = np.meshgrid(X, Y, indexing="ij")
-    array_gain_pattern = array_gain_poly(XXc, YYc)
+        return None
+
 
     result = {}
     for name, pvp_index in labelled_indices.items():
@@ -287,35 +290,25 @@ def make_beam_footprints(
             time = aiming_metadata["raw"]["times"][pvp_index]
             apc_pos = aiming_metadata["raw"]["positions"][pvp_index]
 
-            element_gain_pattern = element_gain_poly(XXc + eb_dcx, YYc + eb_dcy)
-            gain_pattern = array_gain_pattern + element_gain_pattern
+            contour = _find_central_contour(1, eb_dcx, eb_dcy)
+            for n in range(10):
+                next_contour = _find_central_contour(8**(-n-1), eb_dcx, eb_dcy)
+                if next_contour is None and contour is not None:
+                    break
+                if contour is not None and next_contour is not None:
+                    cpoly = shg.Polygon(contour)
+                    ncpoly = shg.Polygon(next_contour)
+                    if np.isclose(cpoly.intersection(ncpoly).area, ncpoly.area, atol=0, rtol=0.05):
+                        # close enough
+                        contour = next_contour
+                        break
+                contour = next_contour
 
-            contour_sets = plt.contour(XXc, YYc, gain_pattern, levels=[contour_level])
-            plt.close()  # close the figure created by contour
+            if contour is None:
+                raise ValueError("unable to find contour")
 
-            # We don't know the validity range of the gain polynomials and may have gone
-            # outside, resulting in multiple contours
-
-            # Only keep contours that form a closed shape
-            try:
-                paths = contour_sets.get_paths()
-            except AttributeError:
-                # matplotlib deprecated collections attribute in 3.8
-                paths = contour_sets.collections[0].get_paths()
-
-            polygons = [
-                polygon
-                for path in paths
-                for polygon in path.to_polygons(closed_only=False)
-                if np.array_equal(polygon[0], polygon[-1])  # only consider closed polygons
-            ]
-            # Keep contour closest to center
-            contour_vertices = min(
-                polygons, key=lambda vertices: np.linalg.norm(np.mean(vertices, axis=0))
-            )
-
-            delta_dcx = contour_vertices[:, 0]
-            delta_dcy = contour_vertices[:, 1]
+            delta_dcx = contour[:, 0]
+            delta_dcy = contour[:, 1]
 
             contour_pointing = acf_to_ecef(
                 delta_dcx + eb_dcx,


### PR DESCRIPTION
# Description
While generating a KMZ from a CPHD, I found that the beam footprint calculation was raising unexpected warnings for a CPHD with a seemingly reasonable antenna description:

```shell
$ python -m sarpy.utils.create_kmz ~/git/glweb/software/sage/sentinel_kit/dev.cphd /host_shared/sarpy_kmz2 --include-all
/home/vscuser/git/glweb/software/third-party/sarpy/sarpy/visualization/kmz_utils.py:269: RuntimeWarning: invalid value encountered in sqrt
  + np.sqrt(
WARNING:sarpy.visualization.kmz_utils:Exception while calculating start beam footprint of AntennaPattern_IW1_056715_V
WARNING:sarpy.visualization.kmz_utils:min() arg is an empty sequence
Traceback (most recent call last):
  File "/home/vscuser/git/glweb/software/third-party/sarpy/sarpy/visualization/kmz_utils.py", line 313, in make_beam_footprints
    contour_vertices = min(
ValueError: min() arg is an empty sequence
```

<details><summary>example gain poly metadata</summary>

```xml
      <Array>
        <GainPoly order1="6" order2="6">
          <Coef exponent1="0" exponent2="0">0.0</Coef>
          <Coef exponent1="0" exponent2="1">18.9387851561526</Coef>
          <Coef exponent1="0" exponent2="2">87.0245728737165</Coef>
          <Coef exponent1="0" exponent2="3">-3424.024285395014</Coef>
          <Coef exponent1="0" exponent2="4">-243947.7875171209</Coef>
          <Coef exponent1="0" exponent2="5">478503.7456049764</Coef>
          <Coef exponent1="0" exponent2="6">7797282.428695505</Coef>
          <Coef exponent1="1" exponent2="0">71.20914023155471</Coef>
          <Coef exponent1="1" exponent2="1">11.035817638944655</Coef>
          <Coef exponent1="1" exponent2="2">-1114.553017294475</Coef>
          <Coef exponent1="1" exponent2="3">-8682.392050796303</Coef>
          <Coef exponent1="1" exponent2="4">492023.7623725771</Coef>
          <Coef exponent1="1" exponent2="5">1229244.2958455137</Coef>
          <Coef exponent1="1" exponent2="6">-60248992.31014681</Coef>
          <Coef exponent1="2" exponent2="0">-681516.5787838814</Coef>
          <Coef exponent1="2" exponent2="1">-77565.66198212352</Coef>
          <Coef exponent1="2" exponent2="2">6836484.824627486</Coef>
          <Coef exponent1="2" exponent2="3">62172537.364032455</Coef>
          <Coef exponent1="2" exponent2="4">-2804550062.3699083</Coef>
          <Coef exponent1="2" exponent2="5">-8117378795.723192</Coef>
          <Coef exponent1="2" exponent2="6">352289828567.3554</Coef>
          <Coef exponent1="3" exponent2="0">1069753.3735814178</Coef>
          <Coef exponent1="3" exponent2="1">-10272324.105691304</Coef>
          <Coef exponent1="3" exponent2="2">-265077365.23744428</Coef>
          <Coef exponent1="3" exponent2="3">6655833755.818293</Coef>
          <Coef exponent1="3" exponent2="4">206542409423.42834</Coef>
          <Coef exponent1="3" exponent2="5">-577065416725.7755</Coef>
          <Coef exponent1="3" exponent2="6">-25139809427658.652</Coef>
          <Coef exponent1="4" exponent2="0">-7982452906.485406</Coef>
          <Coef exponent1="4" exponent2="1">41341896591.82157</Coef>
          <Coef exponent1="4" exponent2="2">2395773256355.6665</Coef>
          <Coef exponent1="4" exponent2="3">-25564905040957.906</Coef>
          <Coef exponent1="4" exponent2="4">-1550238714476958.8</Coef>
          <Coef exponent1="4" exponent2="5">1593892228922822.0</Coef>
          <Coef exponent1="4" exponent2="6">1.8323000864506944e+17</Coef>
          <Coef exponent1="5" exponent2="0">93340780453.62634</Coef>
          <Coef exponent1="5" exponent2="1">940539963800.2397</Coef>
          <Coef exponent1="5" exponent2="2">22099248020079.184</Coef>
          <Coef exponent1="5" exponent2="3">-361924206224533.75</Coef>
          <Coef exponent1="5" exponent2="4">-1.019108854861121e+16</Coef>
          <Coef exponent1="5" exponent2="5">-4.51874427677008e+16</Coef>
          <Coef exponent1="5" exponent2="6">-5.793607849499854e+17</Coef>
          <Coef exponent1="6" exponent2="0">-608517556385645.6</Coef>
          <Coef exponent1="6" exponent2="1">-2387588627183845.5</Coef>
          <Coef exponent1="6" exponent2="2">-1.388520735056975e+17</Coef>
          <Coef exponent1="6" exponent2="3">6.063906621022573e+17</Coef>
          <Coef exponent1="6" exponent2="4">6.310646465258335e+19</Coef>
          <Coef exponent1="6" exponent2="5">2.5071540020807326e+20</Coef>
          <Coef exponent1="6" exponent2="6">-6.175834493285842e+20</Coef>
        </GainPoly>
        <PhasePoly order1="0" order2="4">
          <Coef exponent1="0" exponent2="0">0.0</Coef>
          <Coef exponent1="0" exponent2="1">-2.954548329039303</Coef>
          <Coef exponent1="0" exponent2="2">3.9007114206119846</Coef>
          <Coef exponent1="0" exponent2="3">228.6644476819556</Coef>
          <Coef exponent1="0" exponent2="4">-489.2607396665932</Coef>
        </PhasePoly>
        <AntGPId>IW1_VH_sampled_array</AntGPId>
      </Array>
      <Element>
        <GainPoly order1="6" order2="0">
          <Coef exponent1="0" exponent2="0">0.0</Coef>
          <Coef exponent1="1" exponent2="0">-2.353098731427088</Coef>
          <Coef exponent1="2" exponent2="0">-3350.969111720006</Coef>
          <Coef exponent1="3" exponent2="0">0.391162606393651</Coef>
          <Coef exponent1="4" exponent2="0">-742.3712683065181</Coef>
          <Coef exponent1="5" exponent2="0">-260.92198369753186</Coef>
          <Coef exponent1="6" exponent2="0">-74960.90611648699</Coef>
        </GainPoly>
        <PhasePoly order1="0" order2="0">
          <Coef exponent1="0" exponent2="0">0.0</Coef>
        </PhasePoly>
        <AntGPId>IW1_VH_sampled_element</AntGPId>
      </Element>
```

</details>

This is because the method used to determine the approximate domain of the patterns ignores higher order terms. This PR proposes replacing the root-finding approximation with an iterative contour approach that is perhaps more robust (albeit slightly slower).

With the change from this branch, the fully-populated KMZ generated with no warnings:

![image](https://github.com/user-attachments/assets/bdf46ac8-47a9-4737-a0b3-4c3d56b9e71c)

![image](https://github.com/user-attachments/assets/be1e46b6-6198-4384-b0ef-1feb0dfcab6d)


# Test Results

<details><summary>tests passed</summary>

```
SARPY_TEST_PATH=/data/sarpy_test/ nox
nox > Running session test(version='3.6')
nox > Creating conda env in .nox/test-version-3-6 with python
nox > conda install --yes --prefix /home/vscuser/git/glweb/software/third-party/sarpy/.nox/test-version-3-6 python=3.6
nox > python -m pip install '.[all]'
nox > pytest tests
============================================================================ test session starts ============================================================================
platform linux -- Python 3.6.13, pytest-7.0.1, pluggy-1.0.0
rootdir: /home/vscuser/git/glweb/software/third-party/sarpy
collected 804 items                                                                                                                                                         

tests/test_class_string.py .                                                                                                                                          [  0%]
tests/consistency/test_consistency.py ........                                                                                                                        [  1%]
tests/consistency/test_cphd_consistency.py ..............................................................                                                             [  8%]
tests/consistency/test_sicd_consistency.py ...                                                                                                                        [  9%]
tests/consistency/test_sidd_consistency.py .....                                                                                                                      [  9%]
tests/geometry/test_geocoords.py ..........                                                                                                                           [ 11%]
tests/geometry/test_geometry_elements.py ..........                                                                                                                   [ 12%]
tests/geometry/test_latlon.py ...                                                                                                                                     [ 12%]
tests/geometry/test_point_projection.py ..............                                                                                                                [ 14%]
tests/io/test_kml.py .                                                                                                                                                [ 14%]
tests/io/DEM/test_dted.py ..                                                                                                                                          [ 14%]
tests/io/DEM/test_geoid.py .                                                                                                                                          [ 14%]
tests/io/DEM/test_geotiff1deg_list.py ....                                                                                                                            [ 15%]
tests/io/DEM/test_geotiff1deg_reader.py ........                                                                                                                      [ 16%]
tests/io/complex/test_other_nitf.py ...                                                                                                                               [ 16%]
tests/io/complex/test_reader.py ..sss.ssss.                                                                                                                           [ 18%]
tests/io/complex/test_remote.py s                                                                                                                                     [ 18%]
tests/io/complex/test_sicd.py .                                                                                                                                       [ 18%]
tests/io/complex/test_sio.py .                                                                                                                                        [ 18%]
tests/io/complex/test_utils.py .                                                                                                                                      [ 18%]
tests/io/complex/sicd_elements/test_sicd_elements_antenna.py ...                                                                                                      [ 19%]
tests/io/complex/sicd_elements/test_sicd_elements_base.py ...                                                                                                         [ 19%]
tests/io/complex/sicd_elements/test_sicd_elements_blocks.py .....................                                                                                     [ 22%]
tests/io/complex/sicd_elements/test_sicd_elements_collectioninfo.py ..                                                                                                [ 22%]
tests/io/complex/sicd_elements/test_sicd_elements_errorstatistics.py .                                                                                                [ 22%]
tests/io/complex/sicd_elements/test_sicd_elements_geodata.py ...                                                                                                      [ 22%]
tests/io/complex/sicd_elements/test_sicd_elements_grid.py ..                                                                                                          [ 23%]
tests/io/complex/sicd_elements/test_sicd_elements_imagecreation.py .                                                                                                  [ 23%]
tests/io/complex/sicd_elements/test_sicd_elements_imagedata.py .                                                                                                      [ 23%]
tests/io/complex/sicd_elements/test_sicd_elements_imageformation.py ......                                                                                            [ 24%]
tests/io/complex/sicd_elements/test_sicd_elements_matchinfo.py .                                                                                                      [ 24%]
tests/io/complex/sicd_elements/test_sicd_elements_pfa.py .                                                                                                            [ 24%]
tests/io/complex/sicd_elements/test_sicd_elements_position.py ...                                                                                                     [ 24%]
tests/io/complex/sicd_elements/test_sicd_elements_radarcollection.py ..............                                                                                   [ 26%]
tests/io/complex/sicd_elements/test_sicd_elements_radiometric.py .                                                                                                    [ 26%]
tests/io/complex/sicd_elements/test_sicd_elements_rgazcomp.py .                                                                                                       [ 26%]
tests/io/complex/sicd_elements/test_sicd_elements_rma.py ...                                                                                                          [ 26%]
tests/io/complex/sicd_elements/test_sicd_elements_scpcoa.py ...................                                                                                       [ 29%]
tests/io/complex/sicd_elements/test_sicd_elements_sicd.py ...................................                                                                         [ 33%]
tests/io/complex/sicd_elements/test_sicd_elements_timeline.py ..................                                                                                      [ 35%]
tests/io/complex/sicd_elements/test_sicd_elements_utils.py ...                                                                                                        [ 36%]
tests/io/general/test_base.py ...                                                                                                                                     [ 36%]
tests/io/general/test_data_segment.py ..........                                                                                                                      [ 37%]
tests/io/general/test_format_function.py ........                                                                                                                     [ 38%]
tests/io/general/test_nitf.py ..                                                                                                                                      [ 39%]
tests/io/general/test_nitf_headers.py .                                                                                                                               [ 39%]
tests/io/general/test_nitf_image.py ....                                                                                                                              [ 39%]
tests/io/general/test_tre.py ...                                                                                                                                      [ 40%]
tests/io/phase_history/test_cphd.py .........                                                                                                                         [ 41%]
tests/io/phase_history/test_cphd_versions.py .....                                                                                                                    [ 41%]
tests/io/phase_history/cphd1_elements/test_cphd.py ......                                                                                                             [ 42%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_antenna.py .....                                                                                            [ 43%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_blocks.py ....                                                                                              [ 43%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_channel.py .                                                                                                [ 43%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_data.py .                                                                                                   [ 44%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_dwell.py .                                                                                                  [ 44%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_geoinfo.py ...                                                                                              [ 44%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_global.py ..                                                                                                [ 44%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_pvp.py .                                                                                                    [ 44%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_referencegeometry.py .                                                                                      [ 45%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_supportarray.py ..                                                                                          [ 45%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_txrcv.py .                                                                                                  [ 45%]
tests/io/phase_history/cphd1_elements/test_utils.py .                                                                                                                 [ 45%]
tests/io/product/test_reader.py ...s                                                                                                                                  [ 46%]
tests/io/product/test_sidd.py ..............                                                                                                                          [ 47%]
tests/io/product/test_sidd_schema.py .........                                                                                                                        [ 48%]
tests/io/product/test_sidd_writing.py ...                                                                                                                             [ 49%]
tests/io/product/sidd1_elements/test_exploitationfeatures.py .........................................................                                                [ 56%]
tests/io/product/sidd2_elements/test_exploitationfeatures.py ....................................................................                                     [ 64%]
tests/io/product/sidd3_elements/test_exploitationfeatures.py ........................................................................................................ [ 77%]
.............................................................................................................................                                         [ 93%]
tests/io/product/sidd3_elements/test_sidd3_elements.py .....                                                                                                          [ 93%]
tests/io/received/test_crsd.py .                                                                                                                                      [ 94%]
tests/processing/sicd/test_spectral_taper.py ........ss...........                                                                                                    [ 96%]
tests/utils/test_sicd_sidelobe_control.py ..                                                                                                                          [ 96%]
tests/visualization/test_cphd_kmz_product_creation.py ..                                                                                                              [ 97%]
tests/visualization/test_crsd_kmz_product_creation.py .                                                                                                               [ 97%]
tests/visualization/test_kmz_product_creation.py .x                                                                                                                   [ 97%]
tests/visualization/test_remap.py ....................                                                                                                                [100%]

============================================================================= warnings summary ==============================================================================
tests/geometry/test_point_projection.py::test_image_to_ground_errors
tests/geometry/test_point_projection.py::test_image_to_ground_dem
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/geometry/point_projection.py:1882: RuntimeWarning: divide by zero encountered in double_scalars
    lon_grid_size = min(10, lat_grid_size/abs(numpy.sin(numpy.deg2rad(ref_llh[0]))))

tests/visualization/test_kmz_product_creation.py::test_create_kmz[True]
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/visualization/kmz_utils.py:169: RuntimeWarning: invalid value encountered in double_scalars
    + dir_z**2 * semiaxis_a**2 * semiaxis_b**2

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================== 792 passed, 11 skipped, 1 xfailed, 3 warnings in 42.67s ==========================================================
nox > Session test(version='3.6') was successful.
nox > Running session test(version='3.11')
nox > Creating conda env in .nox/test-version-3-11 with python
nox > conda install --yes --prefix /home/vscuser/git/glweb/software/third-party/sarpy/.nox/test-version-3-11 python=3.11
nox > python -m pip install '.[all]'
nox > pytest tests
============================================================================ test session starts ============================================================================
platform linux -- Python 3.11.10, pytest-8.3.3, pluggy-1.5.0
rootdir: /home/vscuser/git/glweb/software/third-party/sarpy
collected 804 items                                                                                                                                                         

tests/consistency/test_consistency.py ........                                                                                                                        [  0%]
tests/consistency/test_cphd_consistency.py ..............................................................                                                             [  8%]
tests/consistency/test_sicd_consistency.py ...                                                                                                                        [  9%]
tests/consistency/test_sidd_consistency.py .....                                                                                                                      [  9%]
tests/geometry/test_geocoords.py ..........                                                                                                                           [ 10%]
tests/geometry/test_geometry_elements.py ..........                                                                                                                   [ 12%]
tests/geometry/test_latlon.py ...                                                                                                                                     [ 12%]
tests/geometry/test_point_projection.py ..............                                                                                                                [ 14%]
tests/io/DEM/test_dted.py ..                                                                                                                                          [ 14%]
tests/io/DEM/test_geoid.py .                                                                                                                                          [ 14%]
tests/io/DEM/test_geotiff1deg_list.py ....                                                                                                                            [ 15%]
tests/io/DEM/test_geotiff1deg_reader.py ........                                                                                                                      [ 16%]
tests/io/complex/sicd_elements/test_sicd_elements_antenna.py ...                                                                                                      [ 16%]
tests/io/complex/sicd_elements/test_sicd_elements_base.py ...                                                                                                         [ 16%]
tests/io/complex/sicd_elements/test_sicd_elements_blocks.py .....................                                                                                     [ 19%]
tests/io/complex/sicd_elements/test_sicd_elements_collectioninfo.py ..                                                                                                [ 19%]
tests/io/complex/sicd_elements/test_sicd_elements_errorstatistics.py .                                                                                                [ 19%]
tests/io/complex/sicd_elements/test_sicd_elements_geodata.py ...                                                                                                      [ 20%]
tests/io/complex/sicd_elements/test_sicd_elements_grid.py ..                                                                                                          [ 20%]
tests/io/complex/sicd_elements/test_sicd_elements_imagecreation.py .                                                                                                  [ 20%]
tests/io/complex/sicd_elements/test_sicd_elements_imagedata.py .                                                                                                      [ 20%]
tests/io/complex/sicd_elements/test_sicd_elements_imageformation.py ......                                                                                            [ 21%]
tests/io/complex/sicd_elements/test_sicd_elements_matchinfo.py .                                                                                                      [ 21%]
tests/io/complex/sicd_elements/test_sicd_elements_pfa.py .                                                                                                            [ 21%]
tests/io/complex/sicd_elements/test_sicd_elements_position.py ...                                                                                                     [ 22%]
tests/io/complex/sicd_elements/test_sicd_elements_radarcollection.py ..............                                                                                   [ 23%]
tests/io/complex/sicd_elements/test_sicd_elements_radiometric.py .                                                                                                    [ 24%]
tests/io/complex/sicd_elements/test_sicd_elements_rgazcomp.py .                                                                                                       [ 24%]
tests/io/complex/sicd_elements/test_sicd_elements_rma.py ...                                                                                                          [ 24%]
tests/io/complex/sicd_elements/test_sicd_elements_scpcoa.py ...................                                                                                       [ 26%]
tests/io/complex/sicd_elements/test_sicd_elements_sicd.py ...................................                                                                         [ 31%]
tests/io/complex/sicd_elements/test_sicd_elements_timeline.py ..................                                                                                      [ 33%]
tests/io/complex/sicd_elements/test_sicd_elements_utils.py ...                                                                                                        [ 33%]
tests/io/complex/test_other_nitf.py ...                                                                                                                               [ 34%]
tests/io/complex/test_reader.py ..sss.ssss.                                                                                                                           [ 35%]
tests/io/complex/test_remote.py s                                                                                                                                     [ 35%]
tests/io/complex/test_sicd.py .                                                                                                                                       [ 35%]
tests/io/complex/test_sio.py .                                                                                                                                        [ 35%]
tests/io/complex/test_utils.py .                                                                                                                                      [ 36%]
tests/io/general/test_base.py ...                                                                                                                                     [ 36%]
tests/io/general/test_data_segment.py ..........                                                                                                                      [ 37%]
tests/io/general/test_format_function.py ........                                                                                                                     [ 38%]
tests/io/general/test_nitf.py ..                                                                                                                                      [ 38%]
tests/io/general/test_nitf_headers.py .                                                                                                                               [ 39%]
tests/io/general/test_nitf_image.py ....                                                                                                                              [ 39%]
tests/io/general/test_tre.py ...                                                                                                                                      [ 39%]
tests/io/phase_history/cphd1_elements/test_cphd.py ......                                                                                                             [ 40%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_antenna.py .....                                                                                            [ 41%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_blocks.py ....                                                                                              [ 41%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_channel.py .                                                                                                [ 41%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_data.py .                                                                                                   [ 42%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_dwell.py .                                                                                                  [ 42%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_geoinfo.py ...                                                                                              [ 42%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_global.py ..                                                                                                [ 42%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_pvp.py .                                                                                                    [ 42%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_referencegeometry.py .                                                                                      [ 43%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_supportarray.py ..                                                                                          [ 43%]
tests/io/phase_history/cphd1_elements/test_cphd1_elements_txrcv.py .                                                                                                  [ 43%]
tests/io/phase_history/cphd1_elements/test_utils.py .                                                                                                                 [ 43%]
tests/io/phase_history/test_cphd.py .........                                                                                                                         [ 44%]
tests/io/phase_history/test_cphd_versions.py .....                                                                                                                    [ 45%]
tests/io/product/sidd1_elements/test_exploitationfeatures.py .........................................................                                                [ 52%]
tests/io/product/sidd2_elements/test_exploitationfeatures.py ....................................................................                                     [ 60%]
tests/io/product/sidd3_elements/test_exploitationfeatures.py ........................................................................................................ [ 73%]
.............................................................................................................................                                         [ 89%]
tests/io/product/sidd3_elements/test_sidd3_elements.py .....                                                                                                          [ 89%]
tests/io/product/test_reader.py ...s                                                                                                                                  [ 90%]
tests/io/product/test_sidd.py ..............                                                                                                                          [ 92%]
tests/io/product/test_sidd_schema.py .........                                                                                                                        [ 93%]
tests/io/product/test_sidd_writing.py ...                                                                                                                             [ 93%]
tests/io/received/test_crsd.py .                                                                                                                                      [ 93%]
tests/io/test_kml.py .                                                                                                                                                [ 93%]
tests/processing/sicd/test_spectral_taper.py .....................                                                                                                    [ 96%]
tests/test_class_string.py .                                                                                                                                          [ 96%]
tests/utils/test_sicd_sidelobe_control.py ..                                                                                                                          [ 96%]
tests/visualization/test_cphd_kmz_product_creation.py ..                                                                                                              [ 97%]
tests/visualization/test_crsd_kmz_product_creation.py .                                                                                                               [ 97%]
tests/visualization/test_kmz_product_creation.py .x                                                                                                                   [ 97%]
tests/visualization/test_remap.py ....................                                                                                                                [100%]

============================================================================= warnings summary ==============================================================================
tests/geometry/test_geometry_elements.py: 77 warnings
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/geometry/geometry_elements.py:131: DeprecationWarning: Arrays of 2-dimensional vectors are deprecated. Use arrays 
of 3-dimensional vectors instead. (deprecated in NumPy 2.0)                                                                                                                      dir_cross = float(numpy.cross(R, S))  # the scalar cross product of the direction vectors

tests/geometry/test_geometry_elements.py: 43 warnings
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/geometry/geometry_elements.py:137: DeprecationWarning: Arrays of 2-dimensional vectors are deprecated. Use arrays 
of 3-dimensional vectors instead. (deprecated in NumPy 2.0)                                                                                                                      end_cross_0 = float(numpy.cross(Q-P, S))

tests/geometry/test_geometry_elements.py: 43 warnings
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/geometry/geometry_elements.py:138: DeprecationWarning: Arrays of 2-dimensional vectors are deprecated. Use arrays 
of 3-dimensional vectors instead. (deprecated in NumPy 2.0)                                                                                                                      end_cross_1 = float(numpy.cross(Q-P, R))

tests/geometry/test_point_projection.py::test_image_to_ground_errors
tests/geometry/test_point_projection.py::test_image_to_ground_dem
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/geometry/point_projection.py:1882: RuntimeWarning: divide by zero encountered in scalar divide
    lon_grid_size = min(10, lat_grid_size/abs(numpy.sin(numpy.deg2rad(ref_llh[0]))))

tests/test_class_string.py::TestClassString::test_class_str
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/annotation/afrl_rde_schema/__init__.py:7: DeprecationWarning: pkg_resources is deprecated as an API. See https://s
etuptools.pypa.io/en/latest/pkg_resources.html                                                                                                                                   import pkg_resources

tests/visualization/test_kmz_product_creation.py::test_create_kmz[True]
  /home/vscuser/git/glweb/software/third-party/sarpy/sarpy/visualization/kmz_utils.py:145: RuntimeWarning: invalid value encountered in scalar divide
    distance = (

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================= 794 passed, 9 skipped, 1 xfailed, 167 warnings in 30.99s ==========================================================
nox > Session test(version='3.11') was successful.
nox > Ran multiple sessions:
nox > * test(version='3.6'): success
nox > * test(version='3.11'): success

```

</details>