### PR TITLE
Conditionally parse S1 noiseAzimuthVectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ release points are not being annotated in GitHub.
 - Enable TREElement.to_dict() to handle floating-point values
 - Consider implicit edges in certain `sarpy/processing/ortho_rectify` bounds calculations
 - Restored missing antenna beam footprints in some KMZs
+- Handle reading Sentinel-1 SLC files without noiseAzimuthVectors
 
 ## [1.3.59] - 2024-10-03
 ### Added

--- a/sarpy/__about__.py
+++ b/sarpy/__about__.py
@@ -27,7 +27,7 @@ __all__ = ['__version__',
            '__license__', '__copyright__']
 
 from sarpy.__details__ import __classification__, _post_identifier
-_version_number = '1.3.60a8'
+_version_number = '1.3.60a9'
 
 __version__ = _version_number + _post_identifier
 

--- a/sarpy/io/complex/sentinel.py
+++ b/sarpy/io/complex/sentinel.py
@@ -979,15 +979,18 @@ class SentinelDetails(object):
         if root_node.find('./noiseVectorList') is not None:
             # probably prior to March 2018
             range_line, range_pixel, range_noise = extract_vector('noise')
-            azimuth_line, azimuth_pixel, azimuth_noise = None, None, None
         else:
             # noiseRange and noiseAzimuth fields began in March 2018
             range_line, range_pixel, range_noise = extract_vector('noiseRange')
-            azimuth_line, azimuth_pixel, azimuth_noise = extract_vector('noiseAzimuth')
-            azimuth_line = numpy.concatenate(azimuth_line, axis=0)
-
         # NB: range_line is actually a list of 1 element arrays - probably should have been parsed better
         range_line = numpy.concatenate(range_line, axis=0)
+
+        if root_node.find('./noiseAzimuthVectorList/noiseAzimuthVector') is not None:
+            azimuth_line, azimuth_pixel, azimuth_noise = extract_vector('noiseAzimuth')
+            azimuth_line = numpy.concatenate(azimuth_line, axis=0)
+        else:
+            azimuth_line, azimuth_pixel, azimuth_noise = None, None, None
+
         for ind, sic in enumerate(sicds):
             populate_noise(sic, ind)
 

--- a/tests/io/complex/complex_file_types.json
+++ b/tests/io/complex/complex_file_types.json
@@ -13,7 +13,8 @@
     {"path":  "RS2/RS2_C0RS2_OK117768_PK1033407_DK972895_FQ20_20200227_101203_HH_VV_HV_VH_SLC", "path_type":  "relative"},
     {"path":  "RS2/RS2_C0RS2_OK117671_PK1032788_DK972278_SLA17_20200204_144812_HH_SLC", "path_type":  "relative"}],
   "Sentinel-1": [
-    {"path":  "sentinel/S1A_IW_SLC__1SDH_20200201T141253_20200201T141321_031060_03917E_BAA7.SAFE", "path_type":  "relative"}],
+    {"path":  "sentinel/S1A_IW_SLC__1SDH_20200201T141253_20200201T141321_031060_03917E_BAA7.SAFE", "path_type":  "relative"},
+    {"path":  "sentinel/S1B_S3_SLC__1SSV_20210607T070345_20210607T070410_027247_03412B_569D.SAFE", "path_type":  "relative"}],
   "TerraSAR-X": [
     {"path":  "TSX/SO_000009564_0001_1/TSX1_SAR__SSC______HS_S_SRA_20090212T204239_20090212T204240", "path_type":  "relative"},
     {"path":  "TSX/SO_000049726_0013_1/TSX-1.SAR.L1B/TSX1_SAR__SSC______HS_S_SRA_20111128T023746_20111128T023747", "path_type":  "relative"}],


### PR DESCRIPTION
Fix for https://github.com/ngageoint/sarpy/issues/572

The sentinel-1 reader was not handling all the cases where azimuth noise vectors could be omitted.  This changes it to check for their presence before parsing.


The `noiseAzimuthVectorList` node may not be present, 

![image](https://github.com/user-attachments/assets/977b74cd-a1db-407e-b317-8beb9ddeccb5)

and if it is, it may not contain any `noiseAzimuthVector`s

![image](https://github.com/user-attachments/assets/83ff480b-1175-4e62-a16e-8fe502dddcda)

See: [S1-RS-MDA-52-7441 - Sentinel-1 Product Specification 2023 - 3.14.1.pdf](https://sentiwiki.copernicus.eu/__attachments/1673968/S1-RS-MDA-52-7441%20-%20Sentinel-1%20Product%20Specification%202023%20-%203.14.1.pdf?inst-v=2bf88233-59b6-40d4-bf4b-3383d2c2e976)