### PR TITLE
Compression issue 578

### DIFF
--- a/sarpy/io/product/sidd2_elements/Compression.py
+++ b/sarpy/io/product/sidd2_elements/Compression.py
@@ -7,6 +7,7 @@ __author__ = "Thomas McCullough"
 
 from typing import Union
 
+import xml.etree.ElementTree
 import numpy
 
 from sarpy.io.xml.base import Serializable
@@ -55,8 +56,22 @@ class J2KSubtype(Serializable):
             self._xml_ns_key = kwargs['_xml_ns_key']
         self.NumWaveletLevels = NumWaveletLevels
         self.NumBands = NumBands
-        self.LayerInfo = LayerInfo
+        self.setLayerInfoType(LayerInfo)
         super(J2KSubtype, self).__init__(**kwargs)
+
+    def setLayerInfoType(self,obj):
+        #print(type(obj))
+        ET = xml.etree.ElementTree
+        if isinstance( obj, ET.Element):
+            numLayers = int(obj.attrib['numLayers'])
+            if (numLayers == 0):
+                return
+            bitrates = numpy.zeros(numLayers)
+          
+            for i in range(numLayers):
+                bitrates[i] = float(obj[i][0].text)
+            self.LayerInfo = bitrates
+        
 
 
 class J2KType(Serializable):

--- a/sarpy/io/product/sidd2_elements/Compression.py
+++ b/sarpy/io/product/sidd2_elements/Compression.py
@@ -60,7 +60,6 @@ class J2KSubtype(Serializable):
         super(J2KSubtype, self).__init__(**kwargs)
 
     def setLayerInfoType(self,obj):
-        #print(type(obj))
         ET = xml.etree.ElementTree
         if isinstance( obj, ET.Element):
             numLayers = int(obj.attrib['numLayers'])
@@ -71,8 +70,6 @@ class J2KSubtype(Serializable):
             for i in range(numLayers):
                 bitrates[i] = float(obj[i][0].text)
             self.LayerInfo = bitrates
-        
-
 
 class J2KType(Serializable):
     """


### PR DESCRIPTION
The schema stores Compression bitrates under LayerInfo as Layers with child Bitrates, while the expectation for the object of LayerInfo is an array of the bitrates.
I've added a parser that would go through the layers and get the bitrates and place them in the array as expected