### PR TITLE
Optimize file write

### DIFF
--- a/sarpy/io/complex/sicd.py
+++ b/sarpy/io/complex/sicd.py
@@ -865,7 +865,8 @@ class SICDWriter(NITFWriter):
             sicd_meta: Optional[SICDType] = None,
             sicd_writing_details: Optional[SICDWritingDetails] = None,
             check_older_version: bool = False,
-            check_existence: bool = True):
+            check_existence: bool = True,
+            in_memory: bool = None):
         """
 
         Parameters
@@ -878,6 +879,8 @@ class SICDWriter(NITFWriter):
             NGA applications like SOCET or RemoteView
         check_existence : bool
             Should we check if the given file already exists?
+        in_memory : bool
+            If True force in-memory writing, if False force file writing.
         """
 
         if sicd_meta is None and sicd_writing_details is None:
@@ -885,7 +888,7 @@ class SICDWriter(NITFWriter):
         if sicd_writing_details is None:
             sicd_writing_details = SICDWritingDetails(sicd_meta, check_older_version=check_older_version)
         NITFWriter.__init__(
-            self, file_object, sicd_writing_details, check_existence=check_existence)
+            self, file_object, sicd_writing_details, check_existence=check_existence, in_memory=in_memory)
 
     @property
     def nitf_writing_details(self) -> SICDWritingDetails:

--- a/sarpy/io/general/data_segment.py
+++ b/sarpy/io/general/data_segment.py
@@ -2053,7 +2053,7 @@ class NumpyArraySegment(DataSegment):
             logger.error(
                 'There has been a call to `get_raw_bytes` from {},\n\t'
                 'but all pixels are not fully written'.format(self.__class__))
-        return self.underlying_array.tobytes()
+        return self.underlying_array.view('B').reshape(-1)
 
     def flush(self) -> None:
         self._validate_closed()

--- a/sarpy/io/general/nitf.py
+++ b/sarpy/io/general/nitf.py
@@ -2535,6 +2535,8 @@ def _flatten_bytes(value: Union[bytes, Sequence]) -> bytes:
         return value
     elif isinstance(value, Sequence):
         return b''.join(_flatten_bytes(entry) for entry in value)
+    elif isinstance(value, numpy.ndarray) and value.dtype == numpy.uint8:
+        return value.reshape(-1)
     else:
         raise TypeError('input must be a bytes object, or a sequence with bytes objects as leaves')
 
@@ -3516,7 +3518,8 @@ class NITFWriter(BaseWriter):
             self,
             file_object: Union[str, BinaryIO],
             writing_details: NITFWritingDetails,
-            check_existence: bool = True):
+            check_existence: bool = True,
+            in_memory: bool = None):
         """
 
         Parameters
@@ -3525,6 +3528,8 @@ class NITFWriter(BaseWriter):
         writing_details : NITFWritingDetails
         check_existence : bool
             Should we check if the given file already exists?
+        in_memory : bool
+            If True force in-memory writing, if False force file writing.
 
         Raises
         ------
@@ -3547,9 +3552,11 @@ class NITFWriter(BaseWriter):
             raise ValueError('file_object requires a file path or BinaryIO object')
 
         self._file_object = file_object
-        if is_real_file(file_object):
+        if in_memory is not None:
+            self._in_memory = in_memory
+        elif is_real_file(file_object):
             self._file_name = file_object.name
-            self._in_memory = False
+            self._in_memory = True
         else:
             self._file_name = None
             self._in_memory = True

--- a/sarpy/io/general/nitf.py
+++ b/sarpy/io/general/nitf.py
@@ -3552,14 +3552,16 @@ class NITFWriter(BaseWriter):
             raise ValueError('file_object requires a file path or BinaryIO object')
 
         self._file_object = file_object
-        if in_memory is not None:
-            self._in_memory = in_memory
-        elif is_real_file(file_object):
+
+        if is_real_file(file_object):
             self._file_name = file_object.name
-            self._in_memory = True
+            self._in_memory = False
         else:
             self._file_name = None
             self._in_memory = True
+
+        if in_memory is not None:
+            self._in_memory = in_memory
 
         self.nitf_writing_details = writing_details
 

--- a/sarpy/io/product/sidd.py
+++ b/sarpy/io/product/sidd.py
@@ -893,7 +893,8 @@ class SIDDWriter(NITFWriter):
                                 Sequence[SIDDType2], Sequence[SIDDType1]]] = None,
             sicd_meta: Optional[Union[SICDType, Sequence[SICDType]]] = None,
             sidd_writing_details: Optional[SIDDWritingDetails] = None,
-            check_existence: bool = True):
+            check_existence: bool = True,
+            in_memory: bool = False):
         """
 
         Parameters
@@ -904,6 +905,8 @@ class SIDDWriter(NITFWriter):
         sidd_writing_details : None|SIDDWritingDetails
         check_existence : bool
             Should we check if the given file already exists?
+        in_memory : bool
+            If True force in-memory writing, if False force file writing.
         """
 
         if sidd_meta is None and sidd_writing_details is None:
@@ -911,7 +914,7 @@ class SIDDWriter(NITFWriter):
         if sidd_writing_details is None:
             sidd_writing_details = SIDDWritingDetails(sidd_meta, sicd_meta=sicd_meta)
         NITFWriter.__init__(
-            self, file_object, sidd_writing_details, check_existence=check_existence)
+            self, file_object, sidd_writing_details, check_existence=check_existence, in_memory=in_memory)
 
     @property
     def nitf_writing_details(self) -> SIDDWritingDetails:

--- a/sarpy/io/product/sidd.py
+++ b/sarpy/io/product/sidd.py
@@ -894,7 +894,7 @@ class SIDDWriter(NITFWriter):
             sicd_meta: Optional[Union[SICDType, Sequence[SICDType]]] = None,
             sidd_writing_details: Optional[SIDDWritingDetails] = None,
             check_existence: bool = True,
-            in_memory: bool = False):
+            in_memory: bool = None):
         """
 
         Parameters


### PR DESCRIPTION
When performing a SICD write, Sarpy stores the data in an array, then creates a bytes object from that array. That takes time, and increases the memory footprint. This modifies the logic to create a view into the stored array instead of a copy. It also allows memory mapping to be explicitly turned on and off. This prevents sarpy from attempting to use memory mapping on systems that don't support it.