### PR TITLE
Fdt sidd value incorrect 53

### DIFF
--- a/sarpy/io/product/sidd.py
+++ b/sarpy/io/product/sidd.py
@@ -656,7 +656,17 @@ class SIDDWritingDetails(NITFWritingDetails):
             ftitle = 'SIDD: Unknown'
         return ftitle
 
+    # Image Acquisition Datetime
     def _get_fdt(self, index: int) -> Optional[str]:
+        sidd = self.sidd_meta[index]
+        if sidd.ProductCreation.ProcessorInformation.ProcessingDateTime is not None:
+            the_time = sidd.ProductCreation.ProcessorInformation.ProcessingDateTime.astype('datetime64[s]')
+            return re.sub(r'[^0-9]', '', str(the_time))
+        else:
+            return None
+
+    # Current Datetime    
+    def _get_cdt(self, index: int) -> Optional[str]:   
         sidd = self.sidd_meta[index]
         if sidd.ExploitationFeatures.Collections[0].Information.CollectionDateTime is not None:
             the_time = sidd.ExploitationFeatures.Collections[0].Information.CollectionDateTime.astype('datetime64[s]')
@@ -730,7 +740,7 @@ class SIDDWritingDetails(NITFWritingDetails):
             'IC': 'NC',
             'IID2': self._get_iid2(sidd_index),
             'ISORCE': self._get_isorce(sidd_index),
-            'IDATIM': self._get_fdt(sidd_index)
+            'IDATIM': self._get_cdt(sidd_index)
         }
 
         if sidd.Display.PixelType == 'MONO8I':

--- a/sarpy/io/product/sidd.py
+++ b/sarpy/io/product/sidd.py
@@ -656,7 +656,7 @@ class SIDDWritingDetails(NITFWritingDetails):
             ftitle = 'SIDD: Unknown'
         return ftitle
 
-    # Image Acquisition Datetime
+    # File Creation DateTime
     def _get_fdt(self, index: int) -> Optional[str]:
         sidd = self.sidd_meta[index]
         if sidd.ProductCreation.ProcessorInformation.ProcessingDateTime is not None:
@@ -665,8 +665,8 @@ class SIDDWritingDetails(NITFWritingDetails):
         else:
             return None
 
-    # Current Datetime    
-    def _get_cdt(self, index: int) -> Optional[str]:   
+    # Image Acquisition (Collection) Datetime
+    def _get_collection_datetime(self, index: int) -> Optional[str]:   
         sidd = self.sidd_meta[index]
         if sidd.ExploitationFeatures.Collections[0].Information.CollectionDateTime is not None:
             the_time = sidd.ExploitationFeatures.Collections[0].Information.CollectionDateTime.astype('datetime64[s]')
@@ -740,7 +740,7 @@ class SIDDWritingDetails(NITFWritingDetails):
             'IC': 'NC',
             'IID2': self._get_iid2(sidd_index),
             'ISORCE': self._get_isorce(sidd_index),
-            'IDATIM': self._get_cdt(sidd_index)
+            'IDATIM': self._get_collection_datetime(sidd_index)
         }
 
         if sidd.Display.PixelType == 'MONO8I':

--- a/tests/processing/sidd/test_sidd_nitf_header_creation.py
+++ b/tests/processing/sidd/test_sidd_nitf_header_creation.py
@@ -1,0 +1,80 @@
+import json
+import os
+
+import pytest
+import logging
+import unittest
+from tests import parse_file_entry # fails unless run using pytest
+from datetime  import datetime
+
+from sarpy.io.complex.converter import conversion_utility, open_complex
+from sarpy.processing.ortho_rectify import NearestNeighborMethod
+from sarpy.processing.sidd.sidd_product_creation import \
+    create_detected_image_sidd, create_dynamic_image_sidd
+import sarpy.visualization.remap as remap
+
+from sarpy.utils import create_product
+
+from sarpy.io.general.nitf import NITFDetails
+
+complex_file_types = {}
+this_loc           = os.path.abspath(__file__)
+
+# JSON file that specifies test file locations
+file_reference     = os.path.join(os.path.split(this_loc)[0], \
+                                  'complex_file_types.json')  
+if os.path.isfile(file_reference):
+    with open(file_reference, 'r') as local_file:
+        test_files_list = json.load(local_file)
+        for test_files_type in test_files_list:
+            valid_entries = []
+            for entry in test_files_list[test_files_type]:
+                the_file = parse_file_entry(entry)
+                if the_file is not None:
+                    valid_entries.append(the_file)
+            complex_file_types[test_files_type] = valid_entries
+
+sicd_files = complex_file_types.get('SICD', [])
+
+def get_test_reader(idx):
+    if idx >= len(sicd_files):
+        return None
+    input_file       = sicd_files[idx]
+    reader           = open_complex(input_file)
+    return reader
+
+def test_nitf_fdt_updated_for_detected_image_sidd(tmp_path):
+    local_reader = get_test_reader(0)
+    ortho_helper = NearestNeighborMethod(local_reader, index=0)
+    output_directory = tmp_path
+    output_file = 'output.sidd'
+    test_sidd = create_detected_image_sidd(ortho_helper, output_directory, output_file)
+    sidd_file = os.path.join(*output_directory.parts,output_file)
+    details = NITFDetails(sidd_file)
+    fdt_datetime = datetime.strptime(details.nitf_header.FDT,"%Y%m%d%H%M%S%f")
+    collection_datetime = datetime.strptime(details.img_headers[0].IDATIM,"%Y%m%d%H%M%S%f")
+    time_delta = fdt_datetime - collection_datetime
+    fdt_gt_cdt = time_delta.total_seconds() > 0
+    assert fdt_gt_cdt, 'NITF FileDateTime should be greater than IDATIM: {} > {}?'.format(details.nitf_header.FDT,details.img_headers[0].IDATIM)
+
+def test_nitf_fdt_updated_for_dynamic_image_sidd(tmp_path):
+    local_reader = get_test_reader(0)
+    ortho_helper = NearestNeighborMethod(local_reader, index=0)
+    output_directory = tmp_path
+    output_file = 'output.sidd'
+    test_sidd = create_dynamic_image_sidd(ortho_helper, output_directory, output_file)
+    sidd_file = os.path.join(*output_directory.parts,output_file)
+    details = NITFDetails(sidd_file)
+    fdt_datetime = datetime.strptime(details.nitf_header.FDT,"%Y%m%d%H%M%S%f")
+    collection_datetime = datetime.strptime(details.img_headers[0].IDATIM,"%Y%m%d%H%M%S%f")
+    time_delta = fdt_datetime - collection_datetime
+    fdt_gt_cdt = time_delta.total_seconds() > 0
+    assert fdt_gt_cdt, 'NITF FileDateTime should be greater than IDATIM: {} > {}?'.format(details.nitf_header.FDT,details.img_headers[0].IDATIM)
+
+if __name__ == '__main__':
+    unittest.main()
+
+
+
+
+

--- a/tests/processing/sidd/test_sidd_nitf_header_creation.py
+++ b/tests/processing/sidd/test_sidd_nitf_header_creation.py
@@ -1,3 +1,9 @@
+'''
+This unit test determines if the NITF header value of FDT (FileDateTime) is properly updated when the SIDD product is created.
+The NITF header includes (at least) two datetime values.  IDATIM is the datetime that the image was collected (aka acquired).
+FDT is the datetime that the NITF (SIDD) file was created.  IDATIM and FDT should have different values.
+'''
+
 import json
 import os
 
@@ -20,9 +26,10 @@ from sarpy.io.general.nitf import NITFDetails
 complex_file_types = {}
 this_loc           = os.path.abspath(__file__)
 
-# JSON file that specifies test file locations
+# JSON file that specifies test file locations on the local system
 file_reference     = os.path.join(os.path.split(this_loc)[0], \
                                   'complex_file_types.json')  
+# Find valid files from file_refernce and add them to the valid_entries list
 if os.path.isfile(file_reference):
     with open(file_reference, 'r') as local_file:
         test_files_list = json.load(local_file)
@@ -36,6 +43,7 @@ if os.path.isfile(file_reference):
 
 sicd_files = complex_file_types.get('SICD', [])
 
+# Determine a valid file reader for the complex input image
 def get_test_reader(idx):
     if idx >= len(sicd_files):
         return None
@@ -43,38 +51,94 @@ def get_test_reader(idx):
     reader           = open_complex(input_file)
     return reader
 
+''' Read a single input SICD image, create the detected-image NITF SIDD product, then
+read the NITF header from the newly created SIDD product and test that the FDT value
+is different than the IDATIM value and that the FDT value is close to the current time
+(becuase the NITF SIDD product was just created). 
+'''
 def test_nitf_fdt_updated_for_detected_image_sidd(tmp_path):
     local_reader = get_test_reader(0)
     ortho_helper = NearestNeighborMethod(local_reader, index=0)
     output_directory = tmp_path
     output_file = 'output.sidd'
+    
+    # create SIDD product
     test_sidd = create_detected_image_sidd(ortho_helper, output_directory, output_file)
+
+    # Full path to the created SIDD file
     sidd_file = os.path.join(*output_directory.parts,output_file)
+
+     # Get NITF header data from created SIDD file
     details = NITFDetails(sidd_file)
+
+    # Get datetime values from the NITF header data
     fdt_datetime = datetime.strptime(details.nitf_header.FDT,"%Y%m%d%H%M%S%f")
     collection_datetime = datetime.strptime(details.img_headers[0].IDATIM,"%Y%m%d%H%M%S%f")
+    
+     # Since fdt_datetime and collection_datetime are realtive to Zulu but that information
+    # is not represented in their datetime python objects, we need to determine the
+    # current datetime relative to Zule, but then remove the tiemzone info from the
+    # object in order to compute time deltas later.
     current_time_zulu = datetime.now(timezone.utc).replace(tzinfo=None)
+    
+     # Compute time difference between FDT (presumably current time) and IDATIM (collection time)
     time_delta = fdt_datetime - collection_datetime
+    
+    # boolean representing collection time is before file creation time
     fdt_gt_cdt = time_delta.total_seconds() > 0
+    
+     # Compute time difference between current time the FDT from NITF header
     recent_time_delta = current_time_zulu - fdt_datetime
+    
+    # Boolean representig that the SIDD file was created within the past 2 minutes
     fdt_is_recent = recent_time_delta.total_seconds() < 120
+    
     assert (fdt_gt_cdt and fdt_is_recent), 'NITF FileDateTime should be greater than IDATIM: {} > {}?'.format(details.nitf_header.FDT,details.img_headers[0].IDATIM)
 
+''' Read a single input SICD image, create the dynamic-image NITF SIDD product, then
+read the NITF header from the newly created SIDD product and test that the FDT value
+is different than the IDATIM value and that the FDT value is close to the current time
+(becuase the NITF SIDD product was just created).  It was observed during debug that 
+the FDT and IDATIM values are recomputed for each subaerture of the dynamic-image, but
+that information may not be represented in the NITF header data.
+'''
 def test_nitf_fdt_updated_for_dynamic_image_sidd(tmp_path):
     local_reader = get_test_reader(0)
     ortho_helper = NearestNeighborMethod(local_reader, index=0)
     output_directory = tmp_path
     output_file = 'output.sidd'
+    
+    # create SIDD product
     test_sidd = create_dynamic_image_sidd(ortho_helper, output_directory, output_file)
+    
+    # Full path to the created SIDD file
     sidd_file = os.path.join(*output_directory.parts,output_file)
+    
+    # Get NITF header data from created SIDD file
     details = NITFDetails(sidd_file)
+
+    # Get datetime values from the NITF header data
     fdt_datetime = datetime.strptime(details.nitf_header.FDT,"%Y%m%d%H%M%S%f")
     collection_datetime = datetime.strptime(details.img_headers[0].IDATIM,"%Y%m%d%H%M%S%f")
+    
+    # Since fdt_datetime and collection_datetime are realtive to Zulu but that information
+    # is not represented in their datetime python objects, we need to determine the
+    # current datetime relative to Zule, but then remove the tiemzone info from the
+    # object in order to compute time deltas later.
     current_time_zulu = datetime.now(timezone.utc).replace(tzinfo=None)
+    
+    # Compute time difference between FDT (presumably current time) and IDATIM (collection time)
     time_delta = fdt_datetime - collection_datetime
+
+    # boolean representing collection time is before file creation time
     fdt_gt_cdt = time_delta.total_seconds() > 0
+
+    # Compute time difference between current time the FDT from NITF header
     recent_time_delta = current_time_zulu - fdt_datetime
+
+    # Boolean representig that the SIDD file was created within the past 2 minutes
     fdt_is_recent = recent_time_delta.total_seconds() < 120
+    
     assert (fdt_gt_cdt and fdt_is_recent), 'NITF FileDateTime should be greater than IDATIM: {} > {}?'.format(details.nitf_header.FDT,details.img_headers[0].IDATIM)
 
 if __name__ == '__main__':

--- a/tests/processing/sidd/test_sidd_nitf_header_creation.py
+++ b/tests/processing/sidd/test_sidd_nitf_header_creation.py
@@ -5,7 +5,7 @@ import pytest
 import logging
 import unittest
 from tests import parse_file_entry # fails unless run using pytest
-from datetime  import datetime
+from datetime  import datetime, timezone
 
 from sarpy.io.complex.converter import conversion_utility, open_complex
 from sarpy.processing.ortho_rectify import NearestNeighborMethod
@@ -53,9 +53,12 @@ def test_nitf_fdt_updated_for_detected_image_sidd(tmp_path):
     details = NITFDetails(sidd_file)
     fdt_datetime = datetime.strptime(details.nitf_header.FDT,"%Y%m%d%H%M%S%f")
     collection_datetime = datetime.strptime(details.img_headers[0].IDATIM,"%Y%m%d%H%M%S%f")
+    current_time_zulu = datetime.now(timezone.utc).replace(tzinfo=None)
     time_delta = fdt_datetime - collection_datetime
     fdt_gt_cdt = time_delta.total_seconds() > 0
-    assert fdt_gt_cdt, 'NITF FileDateTime should be greater than IDATIM: {} > {}?'.format(details.nitf_header.FDT,details.img_headers[0].IDATIM)
+    recent_time_delta = current_time_zulu - fdt_datetime
+    fdt_is_recent = recent_time_delta.total_seconds() < 120
+    assert (fdt_gt_cdt and fdt_is_recent), 'NITF FileDateTime should be greater than IDATIM: {} > {}?'.format(details.nitf_header.FDT,details.img_headers[0].IDATIM)
 
 def test_nitf_fdt_updated_for_dynamic_image_sidd(tmp_path):
     local_reader = get_test_reader(0)
@@ -67,9 +70,12 @@ def test_nitf_fdt_updated_for_dynamic_image_sidd(tmp_path):
     details = NITFDetails(sidd_file)
     fdt_datetime = datetime.strptime(details.nitf_header.FDT,"%Y%m%d%H%M%S%f")
     collection_datetime = datetime.strptime(details.img_headers[0].IDATIM,"%Y%m%d%H%M%S%f")
+    current_time_zulu = datetime.now(timezone.utc).replace(tzinfo=None)
     time_delta = fdt_datetime - collection_datetime
     fdt_gt_cdt = time_delta.total_seconds() > 0
-    assert fdt_gt_cdt, 'NITF FileDateTime should be greater than IDATIM: {} > {}?'.format(details.nitf_header.FDT,details.img_headers[0].IDATIM)
+    recent_time_delta = current_time_zulu - fdt_datetime
+    fdt_is_recent = recent_time_delta.total_seconds() < 120
+    assert (fdt_gt_cdt and fdt_is_recent), 'NITF FileDateTime should be greater than IDATIM: {} > {}?'.format(details.nitf_header.FDT,details.img_headers[0].IDATIM)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Updated about 10 lines of code in sidd.py to correct the FDT (FileDateTime) value in the NITF header.

The unit test created for this fix could possibly be rolled into another unit test, but the test must check whether the FDT value was updated during SIDD product creation and not merely check that the value is populated. 