### PR TITLE
Fix TimeCOAPoly constant-check sign handling

### DIFF
--- a/sarpy/io/complex/sicd_elements/validation_checks.py
+++ b/sarpy/io/complex/sicd_elements/validation_checks.py
@@ -422,7 +422,7 @@ def _pfa_check_stdeskew(PFA, Grid) -> bool:
     #       If so, it logs a validity error and sets the return value to False.
     if Grid.TimeCOAPoly is not None:
         timecoa_poly = Grid.TimeCOAPoly.get_array(dtype='float64')
-        if timecoa_poly.shape == (1, 1) or numpy.all(timecoa_poly.flatten()[1:] < 1e-6):
+        if timecoa_poly.shape == (1, 1) or numpy.all(numpy.abs(timecoa_poly.flatten()[1:]) < 1e-6):
             PFA.log_validity_error(
                 'PFA.STDeskew.Applied is True, and the Grid.TimeCOAPoly is essentially constant.')
             cond = False

--- a/tests/io/complex/sicd_elements/test_validation_checks.py
+++ b/tests/io/complex/sicd_elements/test_validation_checks.py
@@ -70,6 +70,14 @@ class TestPfaCheckStdeskew(unittest.TestCase):
         grid = DummyGrid(timecoa_poly=timecoa_poly)
         self.assertFalse(_pfa_check_stdeskew(pfa, grid))
 
+    def test_timecoa_poly_negative_nontrivial_terms(self):
+        stdeskew = DummySTDeskew(applied=True)
+        pfa = DummyPFA(stdeskew=stdeskew)
+        arr = np.array([[1.0, -1e-2], [0.0, 0.0]])
+        timecoa_poly = DummyPoly(arr)
+        grid = DummyGrid(timecoa_poly=timecoa_poly)
+        self.assertTrue(_pfa_check_stdeskew(pfa, grid))
+
     def test_row_deltakcoa_and_stdsphasepoly_agree(self):
         arr = np.array([[1.0, 2.0], [3.0, 4.0]])
         stdeskew = DummySTDeskew(applied=True, stds_phase_poly=DummyPoly(arr))


### PR DESCRIPTION
Fixes #582

The STDeskew validation treated any negative higher-order TimeCOAPoly coefficient as near-zero because it compared raw values to 1e-6. That means a coefficient like -1e-2 could still be flagged as effectively constant.

This updates the check to use absolute values for the non-constant terms, so magnitude is evaluated correctly regardless of sign.

I also added a unit test that covers a non-trivial negative coefficient and verifies that _pfa_check_stdeskew returns True for that case.

Verified with:
- ./.venv/bin/python -m pytest tests/io/complex/sicd_elements/test_validation_checks.py