### PR TITLE
Handle CMETAA autofocus type field rename

### DIFF
--- a/sarpy/io/complex/other_nitf.py
+++ b/sarpy/io/complex/other_nitf.py
@@ -46,6 +46,17 @@ logger = logging.getLogger(__name__)
 
 _iso_date_format = '{}-{}-{}T{}:{}:{}'
 
+
+def _get_cmetaa_af_type_value(cmetaa) -> str:
+    """Get CMETAA autofocus type value with support for old/new field names."""
+
+    af_type = getattr(cmetaa, 'AF_TYPE1', None)
+    if af_type is None:
+        af_type = getattr(cmetaa, 'AF_TYPE', 'N')
+
+    af_type = str(af_type).strip().upper()
+    return af_type[0] if len(af_type) > 0 else 'N'
+
 # NB: DO NOT implement is_a() here.
 #   This will explicitly happen after other readers
 
@@ -337,7 +348,7 @@ def extract_sicd(
         # all remaining guess work
         the_sicd.ImageFormation.STBeamComp = 'NO'
         the_sicd.ImageFormation.ImageBeamComp = 'SV' if cmetaa.IF_BEAM_COMP[0] == 'Y' else 'NO'
-        the_sicd.ImageFormation.AzAutofocus = 'NO' if cmetaa.AF_TYPE[0] == 'N' else 'SV'
+        the_sicd.ImageFormation.AzAutofocus = 'NO' if _get_cmetaa_af_type_value(cmetaa) == 'N' else 'SV'
         the_sicd.ImageFormation.RgAutofocus = 'NO'
 
     def try_AIMIDA() -> None:

--- a/tests/io/complex/test_other_nitf.py
+++ b/tests/io/complex/test_other_nitf.py
@@ -1,5 +1,6 @@
 import os
 import json
+from types import SimpleNamespace
 
 import pytest
 
@@ -31,3 +32,18 @@ sicd_files = complex_file_types.get("SICD", [])
 def test_read_sicd_with_complex_reader(sicd_file):
     details = other_nitf.ComplexNITFDetails(sicd_file)
     assert other_nitf.ComplexNITFReader(details) is not None
+
+
+def test_get_cmetaa_af_type_value_prefers_af_type1():
+    cmetaa = SimpleNamespace(AF_TYPE1='N    ', AF_TYPE='Y')
+    assert other_nitf._get_cmetaa_af_type_value(cmetaa) == 'N'
+
+
+def test_get_cmetaa_af_type_value_falls_back_to_af_type():
+    cmetaa = SimpleNamespace(AF_TYPE='Y')
+    assert other_nitf._get_cmetaa_af_type_value(cmetaa) == 'Y'
+
+
+def test_get_cmetaa_af_type_value_defaults_when_missing():
+    cmetaa = SimpleNamespace()
+    assert other_nitf._get_cmetaa_af_type_value(cmetaa) == 'N'


### PR DESCRIPTION
Fixes #487

CMETAA now stores autofocus type values as AF_TYPE1, AF_TYPE2, and AF_TYPE3, but other_nitf was still reading AF_TYPE[0]. That can fail on newer CMETAA structures and prevents AzAutofocus from being set correctly.

This adds a small helper that reads AF_TYPE1 first, falls back to AF_TYPE for compatibility, and defaults safely when neither is present.

I also added focused tests for:
- AF_TYPE1 taking precedence
- fallback to AF_TYPE
- default behavior when both are missing

Verified with:
- ./.venv/bin/python -m pytest tests/io/complex/test_other_nitf.py