### PR TITLE
Fix RgAzComp DeltaKCOAPoly constant validation

### DIFF
--- a/sarpy/io/complex/sicd_elements/validation_checks.py
+++ b/sarpy/io/complex/sicd_elements/validation_checks.py
@@ -91,28 +91,21 @@ def _rgazcomp_check_row_deltakcoa(
 
     cond = True
     row_deltakcoa = Grid.Row.DeltaKCOAPoly.get_array(dtype='float64')
-    if numpy.any(row_deltakcoa != row_deltakcoa[0, 0]):
+    if numpy.any(row_deltakcoa[1:, :] != 0) or numpy.any(row_deltakcoa[:, 1:] != 0):
         RgAzComp.log_validity_error(
             'Grid.Row.DeltaKCOAPoly is defined, '
-            'but all entries are not constant\n\t{}'.format(row_deltakcoa))
+            'but contains non-constant terms\n\t{}'.format(row_deltakcoa))
         cond = False
 
     if RadarCollection.RefFreqIndex is None:
         try:
             fc_proc = ImageFormation.TxFrequencyProc.center_frequency
             k_f_c = fc_proc*2/speed_of_light
-            if row_deltakcoa.shape == (1, 1):
-                if abs(Grid.Row.KCtr - (k_f_c - row_deltakcoa[0, 0])) > 1e-6:
-                    RgAzComp.log_validity_error(
-                        'the Grid.Row.DeltaCOAPoly is scalar, '
-                        'and not in agreement with Grid.Row.KCtr and center frequency')
-                    cond = False
-            else:
-                if abs(Grid.Row.KCtr - k_f_c) > 1e-6:
-                    RgAzComp.log_validity_error(
-                        'the Grid.Row.DeltaCOAPoly is not scalar, '
-                        'and Grid.Row.KCtr not in agreement with center frequency')
-                    cond = False
+            if abs(Grid.Row.KCtr - (k_f_c - row_deltakcoa[0, 0])) > 1e-6:
+                RgAzComp.log_validity_error(
+                    'the Grid.Row.DeltaKCOAPoly constant term is not in agreement '
+                    'with Grid.Row.KCtr and center frequency')
+                cond = False
         except (AttributeError, ValueError, TypeError):
             pass
     return cond
@@ -142,16 +135,15 @@ def _rgazcomp_check_col_deltacoa(
             cond = False
     else:
         col_deltakcoa = Grid.Col.DeltaKCOAPoly.get_array(dtype='float64')
-        if numpy.any(col_deltakcoa != col_deltakcoa[0, 0]):
+        if numpy.any(col_deltakcoa[1:, :] != 0) or numpy.any(col_deltakcoa[:, 1:] != 0):
             RgAzComp.log_validity_error(
                 'the Grid.Col.DeltaKCOAPoly is defined, '
-                'but all entries are not constant\n\t{}'.format(col_deltakcoa))
+                'but contains non-constant terms\n\t{}'.format(col_deltakcoa))
             cond = False
 
-        if col_deltakcoa.shape == (1, 1) and abs(Grid.Col.KCtr + col_deltakcoa[0, 0]) > 1e-6:
+        if abs(Grid.Col.KCtr + col_deltakcoa[0, 0]) > 1e-6:
             RgAzComp.log_validity_error(
-                'the Grid.Col.DeltaCOAPoly is scalar, '
-                'and not in agreement with Grid.Col.KCtr')
+                'the Grid.Col.DeltaKCOAPoly constant term is not in agreement with Grid.Col.KCtr')
             cond = False
     return cond
 

--- a/tests/io/complex/sicd_elements/test_validation_checks.py
+++ b/tests/io/complex/sicd_elements/test_validation_checks.py
@@ -11,10 +11,16 @@
 # 7. Use mocks for the required attributes and methods.
 
 import unittest
+from types import SimpleNamespace
 import numpy as np
+from scipy.constants import speed_of_light
 from unittest.mock import MagicMock
 
-from sarpy.io.complex.sicd_elements.validation_checks import _pfa_check_stdeskew
+from sarpy.io.complex.sicd_elements.validation_checks import (
+    _pfa_check_stdeskew,
+    _rgazcomp_check_col_deltacoa,
+    _rgazcomp_check_row_deltakcoa,
+)
 
 class DummyPoly:
     def __init__(self, arr):
@@ -36,13 +42,21 @@ class DummyPFA:
     def log_validity_warning(self, msg): self._last_warning = msg
 
 class DummyGridRow:
-    def __init__(self, delta_kcoa_poly=None):
+    def __init__(self, delta_kcoa_poly=None, kctr=None):
         self.DeltaKCOAPoly = delta_kcoa_poly
+        self.KCtr = kctr
 
 class DummyGrid:
-    def __init__(self, timecoa_poly=None, row=None):
+    def __init__(self, timecoa_poly=None, row=None, col=None):
         self.TimeCOAPoly = timecoa_poly
         self.Row = row
+        self.Col = col
+
+class DummyRgAzComp:
+    def __init__(self):
+        self.validity_errors = []
+    def log_validity_error(self, msg):
+        self.validity_errors.append(msg)
 
 class TestPfaCheckStdeskew(unittest.TestCase):
     def test_stdeskew_none(self):
@@ -102,6 +116,52 @@ class TestPfaCheckStdeskew(unittest.TestCase):
         pfa = DummyPFA(stdeskew=stdeskew)
         grid = DummyGrid(row=DummyGridRow(delta_kcoa_poly=DummyPoly([[1.0]])))
         self.assertTrue(_pfa_check_stdeskew(pfa, grid))
+
+class TestRgAzCompDeltaKCOA(unittest.TestCase):
+    def test_row_accepts_padded_constant_polynomial(self):
+        rgazcomp = DummyRgAzComp()
+        delta_kcoa = DummyPoly([[0.25, 0.0], [0.0, 0.0]])
+        grid = DummyGrid(row=DummyGridRow(delta_kcoa_poly=delta_kcoa, kctr=0.75))
+        radar_collection = SimpleNamespace(RefFreqIndex=None)
+        image_formation = SimpleNamespace(
+            TxFrequencyProc=SimpleNamespace(center_frequency=0.5*speed_of_light))
+
+        self.assertTrue(
+            _rgazcomp_check_row_deltakcoa(
+                rgazcomp, grid, radar_collection, image_formation))
+        self.assertEqual(rgazcomp.validity_errors, [])
+
+    def test_row_rejects_nonconstant_polynomial_with_equal_coefficients(self):
+        rgazcomp = DummyRgAzComp()
+        delta_kcoa = DummyPoly([[0.25, 0.25], [0.25, 0.25]])
+        grid = DummyGrid(row=DummyGridRow(delta_kcoa_poly=delta_kcoa, kctr=0.75))
+        radar_collection = SimpleNamespace(RefFreqIndex=1)
+
+        self.assertFalse(
+            _rgazcomp_check_row_deltakcoa(
+                rgazcomp, grid, radar_collection, None))
+
+    def test_col_accepts_padded_constant_polynomial(self):
+        rgazcomp = DummyRgAzComp()
+        delta_kcoa = DummyPoly([[0.25, 0.0], [0.0, 0.0]])
+        grid = DummyGrid(col=DummyGridRow(delta_kcoa_poly=delta_kcoa, kctr=-0.25))
+
+        self.assertTrue(_rgazcomp_check_col_deltacoa(rgazcomp, grid))
+        self.assertEqual(rgazcomp.validity_errors, [])
+
+    def test_col_rejects_nonconstant_polynomial_with_equal_coefficients(self):
+        rgazcomp = DummyRgAzComp()
+        delta_kcoa = DummyPoly([[0.25, 0.25], [0.25, 0.25]])
+        grid = DummyGrid(col=DummyGridRow(delta_kcoa_poly=delta_kcoa, kctr=-0.25))
+
+        self.assertFalse(_rgazcomp_check_col_deltacoa(rgazcomp, grid))
+
+    def test_col_checks_kctr_for_padded_constant_polynomial(self):
+        rgazcomp = DummyRgAzComp()
+        delta_kcoa = DummyPoly([[0.25, 0.0], [0.0, 0.0]])
+        grid = DummyGrid(col=DummyGridRow(delta_kcoa_poly=delta_kcoa, kctr=0.0))
+
+        self.assertFalse(_rgazcomp_check_col_deltacoa(rgazcomp, grid))
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
RgAzComp validation currently determines whether `DeltaKCOAPoly` is constant by comparing every coefficient with `[0, 0]`. For a 2D polynomial, constant means all higher-order coefficients are zero, so this can reject padded constant polynomials and accept nonconstant polynomials whose coefficients happen to equal the constant coefficient.

This updates the row and column checks to inspect only higher-order terms and applies the `KCtr` consistency check using the constant coefficient regardless of the declared polynomial shape.

Regression coverage includes:
- padded constant row and column polynomials
- nonconstant polynomials with repeated equal coefficients
- column `KCtr` validation for padded constant polynomials

Verified with:
- `PYTHONPATH=. python -m pytest -q tests/io/complex/sicd_elements/test_validation_checks.py`
- `PYTHONPATH=. python -m compileall -q sarpy/io/complex/sicd_elements/validation_checks.py tests/io/complex/sicd_elements/test_validation_checks.py`
- `git diff --check`